### PR TITLE
Make `env apply`/`dev env apply` work without internet again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### 0.1.7 - 2023-05-31
+### 0.1.7 - 2023-06-01
 
 - `cache ls-img` can now search for locally-downloaded Docker container images matching a provided repository and tag.
 - `cache ls-img` now shows the first tag of each Docker container image together with the image repository name, if the tag exists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### 0.1.7 - 2023-05-31
+
+- `cache ls-img` can now search for locally-downloaded Docker container images matching a provided repository and tag.
+- `cache ls-img` now shows the first tag of each Docker container image together with the image repository name, if the tag exists
+
+### Fixed
+
+- Previously, `env apply` and `dev env apply` would always explicitly attempt to pull the image needed for each Docker Stack service, leading them to fail with an error if the computer had no internet connection. Now, they will only explicitly attempt to pull the image if it is not found among the locally-downloaded Docker container images.
+
 ## 0.1.6 - 2023-05-31
 
 ### Added

--- a/cmd/forklift/cache.go
+++ b/cmd/forklift/cache.go
@@ -195,7 +195,7 @@ func cacheLsImgAction(c *cli.Context) error {
 		return errors.Wrap(err, "couldn't make Docker API client")
 	}
 
-	imgs, err := client.ListImages(context.Background())
+	imgs, err := client.ListImages(context.Background(), c.Args().First())
 	if err != nil {
 		return errors.Wrapf(err, "couldn't list local Docker images")
 	}
@@ -203,7 +203,11 @@ func cacheLsImgAction(c *cli.Context) error {
 		return imgs[i].Repository < imgs[j].Repository
 	})
 	for _, img := range imgs {
-		fmt.Printf("%s: %s\n", img.ID, img.Repository)
+		fmt.Printf("%s: %s", img.ID, img.Repository)
+		if img.Tag != "" {
+			fmt.Printf(":%s", img.Tag)
+		}
+		fmt.Println()
 	}
 	return nil
 }

--- a/cmd/forklift/main.go
+++ b/cmd/forklift/main.go
@@ -20,7 +20,7 @@ var app = &cli.App{
 	Name: "forklift",
 	// TODO: see if there's a way to get the version from a build tag, so that we don't have to update
 	// this manually
-	Version: "v0.1.6",
+	Version: "v0.1.7",
 	Usage:   "Manages Pallet repositories and package deployments",
 	Commands: []*cli.Command{
 		envCmd,

--- a/internal/clients/docker/stacks-deploy.go
+++ b/internal/clients/docker/stacks-deploy.go
@@ -160,7 +160,15 @@ func (c *Client) pullServiceImages(
 	}
 
 	for _, image := range orderedImages {
-		if _, err := c.PullImage(ctx, image, outStream); err != nil {
+		images, err := c.ListImages(ctx, image)
+		if err != nil {
+			return errors.Wrapf(err, "couldn't check if %s was already locally downloaded", image)
+		}
+		if len(images) > 0 {
+			continue
+		}
+
+		if _, err = c.PullImage(ctx, image, outStream); err != nil {
 			return errors.Wrapf(err, "couldn't download %s", image)
 		}
 	}


### PR DESCRIPTION
Commit https://github.com/PlanktoScope/forklift/pull/24/commits/974d5367285d9dd730ab994d027edcece60f5dce in #24 introduced a regression within that PR which broke the ability of `env apply` and `dev env apply` to work without internet after all images had been pre-downloaded, because that commit made those commands explicitly attempt to pull each image from the internet again before making the Docker Stack service using that image. This PR fixes that regression by making `env apply`/`dev env apply` only attempt to pull the image from the internet if the image is not already found on the local disk.

Additionally, this PR enables searching the downloaded images for an image from a particular repository (and optionally tag) in `cache ls-img` by adding an image name, e.g. `cache ls-img alpine` or `cache ls-img alpine:3.17.3`. Finally, this PR shows the tags of images (if available) in the output of the `cache ls-img` command.