### PR TITLE
Enable overriding cached repos with repos from filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `env check` and `dev env check` now checks resource constraints againt all provided resources and resource requirements among all package deployments in the environment, and reports any identified resource constraint violations.
 - `dev env` now allows specifying one or more directories containing Pallet repositories to replace any corresponding cached repositories, using the `--repo` flag (which can be specified repeatedly).
+- `env plan` and `dev env plan` now show the changes which will be made by `env apply` and `dev env apply`, respectively.
 
 ### 0.1.7 - 2023-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - `env check` and `dev env check` now checks resource constraints againt all provided resources and resource requirements among all package deployments in the environment, and reports any identified resource constraint violations.
+- `dev env` now allows specifying one or more directories containing Pallet repositories to replace any corresponding cached repositories, using the `--repo` flag (which can be specified repeatedly).
 
 ### 0.1.7 - 2023-06-01
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ You can also run commands like `forklift dev env cache-repo` and `sudo -E forkli
 
 Finally, you can run the `forklift dev env check` command to check the environment for any problems, such as resource constraint violations.
 
+You can also override cached repos with repos from your filesystem by specifying one or more directories containing one or more repos; then the repos in those directories will be used instead of the respective repos from the cache, regardless of repo version. For example:
+
+```
+cd /home/pi/
+/home/pi/forklift dev --cwd /home/pi/dev/pallets-env env --repo /home/pi/forklift/dev/pallets check
+```
+
 ## Similar projects
 
 The following projects solve related problems with containers, though they make different trade-offs compared to Forklift and Pallets:

--- a/cmd/forklift/cache.go
+++ b/cmd/forklift/cache.go
@@ -37,7 +37,7 @@ func cacheLsRepoAction(c *cli.Context) error {
 	return nil
 }
 
-// info-repo
+// show-repo
 
 func cacheShowRepoAction(c *cli.Context) error {
 	wpath := c.String("workspace")
@@ -94,7 +94,7 @@ func cacheLsPkgAction(c *cli.Context) error {
 	return nil
 }
 
-// info-pkg
+// show-pkg
 
 func cacheShowPkgAction(c *cli.Context) error {
 	wpath := c.String("workspace")
@@ -182,7 +182,12 @@ func printDeplSpec(indent int, spec forklift.PkgDeplSpec) {
 	indent++
 
 	// TODO: actually display the definition file?
-	indentedPrintf(indent, "Definition file: %s\n", spec.DefinitionFile)
+	indentedPrintf(indent, "Definition file: ")
+	if len(spec.DefinitionFile) == 0 {
+		fmt.Println("(none)")
+		return
+	}
+	fmt.Println(spec.DefinitionFile)
 }
 
 func printFeatureSpecs(indent int, features map[string]forklift.PkgFeatureSpec) {

--- a/cmd/forklift/dev-env.go
+++ b/cmd/forklift/dev-env.go
@@ -131,6 +131,28 @@ func devEnvCheckAction(c *cli.Context) error {
 	return nil
 }
 
+// plan
+
+func devEnvPlanAction(c *cli.Context) error {
+	envPath, err := dev.FindParentEnv(c.String("cwd"))
+	if err != nil {
+		return errors.Wrap(err, "The current working directory is not part of a Forklift environment.")
+	}
+	replacementRepos, err := loadReplacementRepos(c.StringSlice("repo"))
+	if err != nil {
+		return err
+	}
+	wpath := c.String("workspace")
+	if !workspace.Exists(workspace.CachePath(wpath)) && len(replacementRepos) == 0 {
+		return errMissingCache
+	}
+
+	if err := planEnv(0, envPath, workspace.CachePath(wpath), replacementRepos); err != nil {
+		return err
+	}
+	return nil
+}
+
 // apply
 
 func devEnvApplyAction(c *cli.Context) error {
@@ -147,7 +169,6 @@ func devEnvApplyAction(c *cli.Context) error {
 		return errMissingCache
 	}
 
-	// TODO: support overriding cached repos with any specified replacement repos from fs paths
 	if err := applyEnv(0, envPath, workspace.CachePath(wpath), replacementRepos); err != nil {
 		return err
 	}

--- a/cmd/forklift/dev-env.go
+++ b/cmd/forklift/dev-env.go
@@ -125,7 +125,6 @@ func devEnvCheckAction(c *cli.Context) error {
 		return errMissingCache
 	}
 
-	// TODO: support overriding cached repos with any specified replacement repos from fs paths
 	if err := checkEnv(0, envPath, workspace.CachePath(wpath), replacementRepos); err != nil {
 		return err
 	}
@@ -185,7 +184,6 @@ func devEnvShowRepoAction(c *cli.Context) error {
 	}
 
 	repoPath := c.Args().First()
-	// TODO: support overriding cached repos with any specified replacement repos from fs paths
 	return printRepoInfo(0, envPath, workspace.CachePath(wpath), replacementRepos, repoPath)
 }
 
@@ -205,7 +203,6 @@ func devEnvLsPkgAction(c *cli.Context) error {
 		return errMissingCache
 	}
 
-	// TODO: support overriding cached repos with any specified replacement repos from fs paths
 	return printEnvPkgs(0, envPath, workspace.CachePath(wpath), replacementRepos)
 }
 
@@ -226,7 +223,6 @@ func devEnvShowPkgAction(c *cli.Context) error {
 	}
 
 	pkgPath := c.Args().First()
-	// TODO: support overriding cached repos with any specified replacement repos from fs paths
 	return printPkgInfo(0, envPath, workspace.CachePath(wpath), replacementRepos, pkgPath)
 }
 
@@ -246,7 +242,6 @@ func devEnvLsDeplAction(c *cli.Context) error {
 		return errMissingCache
 	}
 
-	// TODO: support overriding cached repos with any specified replacement repos from fs paths
 	return printEnvDepls(0, envPath, workspace.CachePath(wpath), replacementRepos)
 }
 
@@ -267,7 +262,6 @@ func devEnvShowDeplAction(c *cli.Context) error {
 	}
 
 	deplName := c.Args().First()
-	// TODO: support overriding cached repos with any specified replacement repos from fs paths
 	return printDeplInfo(0, envPath, workspace.CachePath(wpath), replacementRepos, deplName)
 }
 

--- a/cmd/forklift/dev-env.go
+++ b/cmd/forklift/dev-env.go
@@ -100,7 +100,6 @@ func devEnvCacheImgAction(c *cli.Context) error {
 	}
 
 	fmt.Println("Downloading Docker container images specified by the development environment...")
-	// TODO: support overriding cached repos with any specified replacement repos from fs paths
 	if err := downloadImages(0, envPath, workspace.CachePath(wpath), replacementRepos); err != nil {
 		return err
 	}

--- a/cmd/forklift/env.go
+++ b/cmd/forklift/env.go
@@ -465,10 +465,19 @@ func listRequiredImages(
 		if depl.Pkg.Cached.Config.Deployment.DefinitionFile == "" {
 			continue
 		}
-		definitionFilePath := filepath.Join(
-			depl.Pkg.Cached.ConfigPath, depl.Pkg.Cached.Config.Deployment.DefinitionFile,
-		)
-		stackConfig, err := docker.LoadStackDefinition(cacheFS, definitionFilePath)
+		pkgPath := depl.Pkg.Cached.ConfigPath
+		var f fs.FS
+		var definitionFilePath string
+		if filepath.IsAbs(pkgPath) {
+			f = os.DirFS(pkgPath)
+			definitionFilePath = depl.Pkg.Cached.Config.Deployment.DefinitionFile
+		} else {
+			f = cacheFS
+			definitionFilePath = filepath.Join(
+				pkgPath, depl.Pkg.Cached.Config.Deployment.DefinitionFile,
+			)
+		}
+		stackConfig, err := docker.LoadStackDefinition(f, definitionFilePath)
 		if err != nil {
 			return nil, errors.Wrapf(
 				err, "couldn't load Docker stack definition from %s", definitionFilePath,

--- a/cmd/forklift/env.go
+++ b/cmd/forklift/env.go
@@ -1038,8 +1038,8 @@ func printPkgInfo(
 	var pkg forklift.VersionedPkg
 	repo, ok := forklift.FindExternalRepoOfPkg(replacementRepos, pkgPath)
 	if ok {
-		externalPkg, err := forklift.FindExternalPkg(repo, pkgPath)
-		if err != nil {
+		externalPkg, perr := forklift.FindExternalPkg(repo, pkgPath)
+		if perr != nil {
 			return errors.Wrapf(
 				err, "couldn't find external package %s from replacement repo %s",
 				pkgPath, repo.Repo.ConfigPath,

--- a/cmd/forklift/env.go
+++ b/cmd/forklift/env.go
@@ -1200,16 +1200,7 @@ func printDeplPkg(indent int, depl forklift.Depl) {
 	indent++
 
 	indentedPrintf(indent, "Description: %s\n", depl.Pkg.Cached.Config.Package.Description)
-	printDeplPkgRepo(indent, depl.Pkg)
-}
-
-func printDeplPkgRepo(indent int, pkg forklift.VersionedPkg) {
-	indentedPrintf(indent, "Provided by Pallet repository: %s\n", pkg.Repo.Path())
-	indent++
-
-	indentedPrintf(indent, "Version: %s\n", pkg.Cached.Repo.Version)
-	indentedPrintf(indent, "Description: %s\n", pkg.Cached.Repo.Config.Repository.Description)
-	indentedPrintf(indent, "Provided by Git repository: %s\n", pkg.Repo.VCSRepoPath)
+	printVersionedPkgRepo(indent, depl.Pkg)
 }
 
 func printFeatures(indent int, features map[string]forklift.PkgFeatureSpec) {

--- a/cmd/forklift/main.go
+++ b/cmd/forklift/main.go
@@ -344,6 +344,14 @@ var devEnvCmd = &cli.Command{
 	Name:    "env",
 	Aliases: []string{"environment"},
 	Usage:   "Facilitates development and maintenance of a Forklift environment",
+	Flags: []cli.Flag{
+		&cli.StringSliceFlag{
+			Name:    "repo",
+			Aliases: []string{"r"},
+			Usage: "Replaces version-locked repos from the cache with the corresponding repos in " +
+				"the specified directory paths",
+		},
+	},
 	Subcommands: []*cli.Command{
 		{
 			Name:     "cache-repo",

--- a/cmd/forklift/main.go
+++ b/cmd/forklift/main.go
@@ -112,6 +112,14 @@ var envCmd = &cli.Command{
 			Action:   envCheckAction,
 		},
 		{
+			Name:     "plan",
+			Aliases:  []string{"p"},
+			Category: "Use the environment",
+			Usage: "Determines the changes needed to update the Docker Swarm to match the deployments " +
+				"specified by the local environment",
+			Action: envPlanAction,
+		},
+		{
 			Name:     "apply",
 			Aliases:  []string{"a"},
 			Category: "Use the environment",
@@ -373,6 +381,14 @@ var devEnvCmd = &cli.Command{
 			Category: "Use the environment",
 			Usage:    "Checks whether the development environment's resource constraints are satisfied",
 			Action:   devEnvCheckAction,
+		},
+		{
+			Name:     "plan",
+			Aliases:  []string{"p"},
+			Category: "Use the environment",
+			Usage: "Determines the changes needed to update the Docker Swarm to match the deployments " +
+				"specified by the local environment",
+			Action: devEnvPlanAction,
 		},
 		{
 			Name:     "apply",

--- a/internal/app/forklift/cached-pkgs.go
+++ b/internal/app/forklift/cached-pkgs.go
@@ -35,7 +35,7 @@ func CompareCachedPkgs(p, q CachedPkg) int {
 }
 
 func ListCachedPkgs(cacheFS fs.FS, cachedPrefix string) ([]CachedPkg, error) {
-	searchPattern := "**/pallet-package.yml"
+	searchPattern := fmt.Sprintf("**/%s", PkgSpecFile)
 	if cachedPrefix != "" {
 		searchPattern = filepath.Join(cachedPrefix, searchPattern)
 	}
@@ -48,7 +48,7 @@ func ListCachedPkgs(cacheFS fs.FS, cachedPrefix string) ([]CachedPkg, error) {
 	pkgMap := make(map[string]CachedPkg)
 	for _, pkgConfigFilePath := range pkgConfigFiles {
 		filename := filepath.Base(pkgConfigFilePath)
-		if filename != "pallet-package.yml" {
+		if filename != PkgSpecFile {
 			continue
 		}
 		pkg, err := loadCachedPkg(cacheFS, pkgConfigFilePath)
@@ -116,7 +116,7 @@ func loadPkgConfig(cacheFS fs.FS, filePath string) (PkgConfig, error) {
 func findRepoOfPkg(cacheFS fs.FS, pkgConfigFilePath string) (CachedRepo, error) {
 	repoCandidatePath := filepath.Dir(pkgConfigFilePath)
 	for repoCandidatePath != "." {
-		repoConfigCandidatePath := filepath.Join(repoCandidatePath, "pallet-repository.yml")
+		repoConfigCandidatePath := filepath.Join(repoCandidatePath, RepoSpecFile)
 		repo, err := LoadCachedRepo(cacheFS, repoConfigCandidatePath)
 		if err == nil {
 			return repo, nil
@@ -138,7 +138,7 @@ func FindCachedPkg(cacheFS fs.FS, pkgPath string, version string) (CachedPkg, er
 	// filesystem directory path with the pallet-package.yml file, so we must check every
 	// directory whose name matches the last part of the package path to look for the package
 	searchPattern := fmt.Sprintf(
-		"%s@%s/**/%s/pallet-package.yml", vcsRepoPath, version, pkgInnermostDir,
+		"%s@%s/**/%s/%s", vcsRepoPath, version, pkgInnermostDir, PkgSpecFile,
 	)
 	candidatePkgConfigFiles, err := doublestar.Glob(cacheFS, searchPattern)
 	if err != nil {
@@ -154,7 +154,7 @@ func FindCachedPkg(cacheFS fs.FS, pkgPath string, version string) (CachedPkg, er
 	candidatePkgs := make([]CachedPkg, 0)
 	for _, pkgConfigFilePath := range candidatePkgConfigFiles {
 		filename := filepath.Base(pkgConfigFilePath)
-		if filename != "pallet-package.yml" {
+		if filename != PkgSpecFile {
 			continue
 		}
 		pkg, err := loadCachedPkg(cacheFS, pkgConfigFilePath)

--- a/internal/app/forklift/cached-pkgs.go
+++ b/internal/app/forklift/cached-pkgs.go
@@ -34,56 +34,6 @@ func CompareCachedPkgs(p, q CachedPkg) int {
 	return compareEQ
 }
 
-func loadPkgConfig(cacheFS fs.FS, filePath string) (PkgConfig, error) {
-	bytes, err := fs.ReadFile(cacheFS, filePath)
-	if err != nil {
-		return PkgConfig{}, errors.Wrapf(err, "couldn't read package config file %s", filePath)
-	}
-	config := PkgConfig{}
-	if err = yaml.Unmarshal(bytes, &config); err != nil {
-		return PkgConfig{}, errors.Wrap(err, "couldn't parse package config")
-	}
-	return config, nil
-}
-
-func findRepoOfPkg(cacheFS fs.FS, pkgConfigFilePath string) (CachedRepo, error) {
-	repoCandidatePath := filepath.Dir(pkgConfigFilePath)
-	for repoCandidatePath != "." {
-		repoConfigCandidatePath := filepath.Join(repoCandidatePath, "pallet-repository.yml")
-		repo, err := LoadCachedRepo(cacheFS, repoConfigCandidatePath)
-		if err == nil {
-			return repo, nil
-		}
-		repoCandidatePath = filepath.Dir(repoCandidatePath)
-	}
-	return CachedRepo{}, errors.Errorf(
-		"no repository config file found in any parent directory of %s", pkgConfigFilePath,
-	)
-}
-
-func loadCachedPkg(cacheFS fs.FS, pkgConfigFilePath string) (CachedPkg, error) {
-	config, err := loadPkgConfig(cacheFS, pkgConfigFilePath)
-	if err != nil {
-		return CachedPkg{}, errors.Wrapf(
-			err, "couldn't load cached package config from %s", pkgConfigFilePath,
-		)
-	}
-
-	pkg := CachedPkg{
-		ConfigPath: filepath.Dir(pkgConfigFilePath),
-		Config:     config,
-	}
-	pkg.Repo, err = findRepoOfPkg(cacheFS, pkgConfigFilePath)
-	if err != nil {
-		return CachedPkg{}, errors.Wrapf(
-			err, "couldn't identify cached repository for package from %s", pkgConfigFilePath,
-		)
-	}
-	pkg.PkgSubdir = strings.TrimPrefix(pkg.ConfigPath, fmt.Sprintf("%s/", pkg.Repo.ConfigPath))
-	pkg.Path = fmt.Sprintf("%s/%s", pkg.Repo.Config.Repository.Path, pkg.PkgSubdir)
-	return pkg, nil
-}
-
 func ListCachedPkgs(cacheFS fs.FS, cachedPrefix string) ([]CachedPkg, error) {
 	searchPattern := "**/pallet-package.yml"
 	if cachedPrefix != "" {
@@ -128,10 +78,60 @@ func ListCachedPkgs(cacheFS fs.FS, cachedPrefix string) ([]CachedPkg, error) {
 	return orderedPkgs, nil
 }
 
+func loadCachedPkg(cacheFS fs.FS, pkgConfigFilePath string) (CachedPkg, error) {
+	config, err := loadPkgConfig(cacheFS, pkgConfigFilePath)
+	if err != nil {
+		return CachedPkg{}, errors.Wrapf(
+			err, "couldn't load cached package config from %s", pkgConfigFilePath,
+		)
+	}
+
+	pkg := CachedPkg{
+		ConfigPath: filepath.Dir(pkgConfigFilePath),
+		Config:     config,
+	}
+	pkg.Repo, err = findRepoOfPkg(cacheFS, pkgConfigFilePath)
+	if err != nil {
+		return CachedPkg{}, errors.Wrapf(
+			err, "couldn't identify cached repository for package from %s", pkgConfigFilePath,
+		)
+	}
+	pkg.PkgSubdir = strings.TrimPrefix(pkg.ConfigPath, fmt.Sprintf("%s/", pkg.Repo.ConfigPath))
+	pkg.Path = fmt.Sprintf("%s/%s", pkg.Repo.Config.Repository.Path, pkg.PkgSubdir)
+	return pkg, nil
+}
+
+func loadPkgConfig(cacheFS fs.FS, filePath string) (PkgConfig, error) {
+	bytes, err := fs.ReadFile(cacheFS, filePath)
+	if err != nil {
+		return PkgConfig{}, errors.Wrapf(err, "couldn't read package config file %s", filePath)
+	}
+	config := PkgConfig{}
+	if err = yaml.Unmarshal(bytes, &config); err != nil {
+		return PkgConfig{}, errors.Wrap(err, "couldn't parse package config")
+	}
+	return config, nil
+}
+
+func findRepoOfPkg(cacheFS fs.FS, pkgConfigFilePath string) (CachedRepo, error) {
+	repoCandidatePath := filepath.Dir(pkgConfigFilePath)
+	for repoCandidatePath != "." {
+		repoConfigCandidatePath := filepath.Join(repoCandidatePath, "pallet-repository.yml")
+		repo, err := LoadCachedRepo(cacheFS, repoConfigCandidatePath)
+		if err == nil {
+			return repo, nil
+		}
+		repoCandidatePath = filepath.Dir(repoCandidatePath)
+	}
+	return CachedRepo{}, errors.Errorf(
+		"no repository config file found in any parent directory of %s", pkgConfigFilePath,
+	)
+}
+
 func FindCachedPkg(cacheFS fs.FS, pkgPath string, version string) (CachedPkg, error) {
 	vcsRepoPath, _, err := SplitRepoPathSubdir(pkgPath)
 	if err != nil {
-		return CachedPkg{}, errors.Wrapf(err, "couldn't parse path of Pallet repo %s", pkgPath)
+		return CachedPkg{}, errors.Wrapf(err, "couldn't parse path of Pallet package %s", pkgPath)
 	}
 	pkgInnermostDir := filepath.Base(pkgPath)
 	// The package subdirectory path in the package path (under the VCS repo path) might not match the

--- a/internal/app/forklift/cached-repos.go
+++ b/internal/app/forklift/cached-repos.go
@@ -113,7 +113,7 @@ func LoadCachedRepo(cacheFS fs.FS, repoConfigFilePath string) (CachedRepo, error
 }
 
 func ListCachedRepos(cacheFS fs.FS) ([]CachedRepo, error) {
-	repoConfigFiles, err := doublestar.Glob(cacheFS, "**/pallet-repository.yml")
+	repoConfigFiles, err := doublestar.Glob(cacheFS, fmt.Sprintf("**/%s", RepoSpecFile))
 	if err != nil {
 		return nil, errors.Wrap(err, "couldn't search for cached repo configs")
 	}
@@ -122,7 +122,7 @@ func ListCachedRepos(cacheFS fs.FS) ([]CachedRepo, error) {
 	repoMap := make(map[string]CachedRepo)
 	for _, repoConfigFilePath := range repoConfigFiles {
 		filename := filepath.Base(repoConfigFilePath)
-		if filename != "pallet-repository.yml" {
+		if filename != RepoSpecFile {
 			continue
 		}
 		repo, err := LoadCachedRepo(cacheFS, repoConfigFilePath)
@@ -158,7 +158,7 @@ func FindCachedRepo(cacheFS fs.FS, repoPath string, version string) (CachedRepo,
 	// The repo subdirectory path in the repo path (under the VCS repo path) might not match the
 	// filesystem directory path with the pallet-repository.yml file, so we must check every
 	// pallet-repository.yml file to find the actual repo path
-	searchPattern := fmt.Sprintf("%s@%s/**/pallet-repository.yml", vcsRepoPath, version)
+	searchPattern := fmt.Sprintf("%s@%s/**/%s", vcsRepoPath, version, RepoSpecFile)
 	candidateRepoConfigFiles, err := doublestar.Glob(cacheFS, searchPattern)
 	if err != nil {
 		return CachedRepo{}, errors.Wrapf(
@@ -173,7 +173,7 @@ func FindCachedRepo(cacheFS fs.FS, repoPath string, version string) (CachedRepo,
 	candidateRepos := make([]CachedRepo, 0)
 	for _, repoConfigFilePath := range candidateRepoConfigFiles {
 		filename := filepath.Base(repoConfigFilePath)
-		if filename != "pallet-repository.yml" {
+		if filename != RepoSpecFile {
 			continue
 		}
 		repo, err := LoadCachedRepo(cacheFS, repoConfigFilePath)

--- a/internal/app/forklift/cached-repos.go
+++ b/internal/app/forklift/cached-repos.go
@@ -16,6 +16,10 @@ func (r CachedRepo) FromSameVCSRepo(cr CachedRepo) bool {
 	return r.VCSRepoPath == cr.VCSRepoPath && r.Version == cr.Version
 }
 
+func (r CachedRepo) Path() string {
+	return filepath.Join(r.VCSRepoPath, r.RepoSubdir)
+}
+
 const (
 	compareLT = -1
 	compareEQ = 0

--- a/internal/app/forklift/env-depls.go
+++ b/internal/app/forklift/env-depls.go
@@ -292,7 +292,9 @@ func loadDeplConfig(deplsFS fs.FS, filePath string) (DeplConfig, error) {
 	return config, nil
 }
 
-func LoadDepl(envFS, cacheFS fs.FS, deplName string) (Depl, error) {
+func LoadDepl(
+	envFS, cacheFS fs.FS, replacementRepos map[string]ExternalRepo, deplName string,
+) (Depl, error) {
 	deplsFS, err := DeplsFS(envFS)
 	if err != nil {
 		return Depl{}, errors.Wrap(
@@ -315,6 +317,19 @@ func LoadDepl(envFS, cacheFS fs.FS, deplName string) (Depl, error) {
 	}
 
 	pkgPath := depl.Config.Package
+	repo, ok := FindExternalRepoOfPkg(replacementRepos, pkgPath)
+	if ok {
+		pkg, err := FindExternalPkg(repo, pkgPath)
+		if err != nil {
+			return Depl{}, errors.Wrapf(
+				err, "couldn't find external package %s from replacement repo %s",
+				pkgPath, repo.Repo.ConfigPath,
+			)
+		}
+		depl.Pkg = AsVersionedPkg(pkg)
+		return depl, nil
+	}
+
 	depl.Pkg, err = LoadVersionedPkg(reposFS, cacheFS, pkgPath)
 	if err != nil {
 		return Depl{}, errors.Wrapf(
@@ -325,7 +340,9 @@ func LoadDepl(envFS, cacheFS fs.FS, deplName string) (Depl, error) {
 	return depl, nil
 }
 
-func ListDepls(envFS fs.FS, cacheFS fs.FS) ([]Depl, error) {
+func ListDepls(
+	envFS fs.FS, cacheFS fs.FS, replacementRepos map[string]ExternalRepo,
+) ([]Depl, error) {
 	deplsFS, err := DeplsFS(envFS)
 	if err != nil {
 		return nil, errors.Wrap(
@@ -347,7 +364,7 @@ func ListDepls(envFS fs.FS, cacheFS fs.FS) ([]Depl, error) {
 			)
 		}
 		deplNames = append(deplNames, deplName)
-		deplMap[deplName], err = LoadDepl(envFS, cacheFS, deplName)
+		deplMap[deplName], err = LoadDepl(envFS, cacheFS, replacementRepos, deplName)
 		if err != nil {
 			return nil, errors.Wrapf(err, "couldn't load package deployment specification %s", deplName)
 		}

--- a/internal/app/forklift/env-depls.go
+++ b/internal/app/forklift/env-depls.go
@@ -311,16 +311,17 @@ func LoadDepl(
 	depl := Depl{
 		Name: deplName,
 	}
-	depl.Config, err = loadDeplConfig(deplsFS, fmt.Sprintf("%s.deploy.yml", deplName))
-	if err != nil {
+	if depl.Config, err = loadDeplConfig(
+		deplsFS, fmt.Sprintf("%s.deploy.yml", deplName),
+	); err != nil {
 		return Depl{}, errors.Wrapf(err, "couldn't load package deployment config for %s", deplName)
 	}
 
 	pkgPath := depl.Config.Package
 	repo, ok := FindExternalRepoOfPkg(replacementRepos, pkgPath)
 	if ok {
-		pkg, err := FindExternalPkg(repo, pkgPath)
-		if err != nil {
+		pkg, perr := FindExternalPkg(repo, pkgPath)
+		if perr != nil {
 			return Depl{}, errors.Wrapf(
 				err, "couldn't find external package %s from replacement repo %s",
 				pkgPath, repo.Repo.ConfigPath,
@@ -330,8 +331,7 @@ func LoadDepl(
 		return depl, nil
 	}
 
-	depl.Pkg, err = LoadVersionedPkg(reposFS, cacheFS, pkgPath)
-	if err != nil {
+	if depl.Pkg, err = LoadVersionedPkg(reposFS, cacheFS, pkgPath); err != nil {
 		return Depl{}, errors.Wrapf(
 			err, "couldn't load versioned package %s to be deployed by local environment", pkgPath,
 		)

--- a/internal/app/forklift/env-pkgs.go
+++ b/internal/app/forklift/env-pkgs.go
@@ -17,7 +17,7 @@ func ListVersionedPkgs(
 		var pkgs map[string]CachedPkg
 		var paths []string
 		if externalRepo, ok := replacementRepos[repo.Path()]; ok {
-			pkgs, paths, err = listVersionedPkgsOfExternalRepo(externalRepo, repo)
+			pkgs, paths, err = listVersionedPkgsOfExternalRepo(externalRepo)
 		} else {
 			pkgs, paths, err = listVersionedPkgsOfCachedRepo(cacheFS, repo)
 		}
@@ -39,7 +39,7 @@ func ListVersionedPkgs(
 }
 
 func listVersionedPkgsOfExternalRepo(
-	externalRepo ExternalRepo, repo VersionedRepo,
+	externalRepo ExternalRepo,
 ) (pkgMap map[string]CachedPkg, versionedPkgPaths []string, err error) {
 	pkgs, err := ListExternalPkgs(externalRepo, "")
 	if err != nil {

--- a/internal/app/forklift/env-pkgs.go
+++ b/internal/app/forklift/env-pkgs.go
@@ -8,62 +8,99 @@ import (
 	"github.com/pkg/errors"
 )
 
-func ListVersionedPkgs(cacheFS fs.FS, repos []VersionedRepo) ([]CachedPkg, error) {
+func ListVersionedPkgs(
+	cacheFS fs.FS, replacementRepos map[string]ExternalRepo, repos []VersionedRepo,
+) (orderedPkgs []CachedPkg, err error) {
 	versionedPkgPaths := make([]string, 0)
 	pkgMap := make(map[string]CachedPkg)
 	for _, repo := range repos {
-		repoVersion, err := repo.Config.Version()
-		if err != nil {
-			return nil, errors.Wrapf(err, "couldn't determine version of repo %s", repo.Path())
-		}
-		repoCachePath := filepath.Join(
-			fmt.Sprintf("%s@%s", repo.VCSRepoPath, repoVersion),
-			repo.RepoSubdir,
-		)
-		pkgs, err := ListCachedPkgs(cacheFS, repoCachePath)
-		if err != nil {
-			return nil, errors.Wrapf(
-				err, "couldn't list cached packages for repo cached at %s", repoCachePath,
-			)
+		var pkgs map[string]CachedPkg
+		var paths []string
+		if externalRepo, ok := replacementRepos[repo.Path()]; ok {
+			pkgs, paths, err = listVersionedPkgsOfExternalRepo(externalRepo, repo)
+		} else {
+			pkgs, paths, err = listVersionedPkgsOfCachedRepo(cacheFS, repo)
 		}
 
-		for _, pkg := range pkgs {
-			versionedPkgPath := fmt.Sprintf(
-				"%s@%s/%s", pkg.Repo.Config.Repository.Path, pkg.Repo.Version, pkg.PkgSubdir,
-			)
-			if prevPkg, ok := pkgMap[versionedPkgPath]; ok {
-				if prevPkg.Repo.FromSameVCSRepo(pkg.Repo) && prevPkg.ConfigPath != pkg.ConfigPath {
-					return nil, errors.Errorf(
-						"package repeatedly defined in the same version of the same cached Github repo: %s, %s",
-						prevPkg.ConfigPath, pkg.ConfigPath,
-					)
-				}
-			}
-			versionedPkgPaths = append(versionedPkgPaths, versionedPkgPath)
-			pkgMap[versionedPkgPath] = pkg
+		for k, v := range pkgs {
+			pkgMap[k] = v
+		}
+		versionedPkgPaths = append(versionedPkgPaths, paths...)
+		if err != nil {
+			return nil, errors.Wrapf(err, "couldn't list versioned packages of repo %s", repo.Path())
 		}
 	}
 
-	orderedPkgs := make([]CachedPkg, 0, len(versionedPkgPaths))
+	orderedPkgs = make([]CachedPkg, 0, len(versionedPkgPaths))
 	for _, path := range versionedPkgPaths {
 		orderedPkgs = append(orderedPkgs, pkgMap[path])
 	}
 	return orderedPkgs, nil
 }
 
-func findVersionedRepoOfPkg(reposFS fs.FS, pkgPath string) (VersionedRepo, error) {
-	repoCandidatePath := filepath.Dir(pkgPath)
-	for repoCandidatePath != "." {
-		repo, err := LoadVersionedRepo(reposFS, repoCandidatePath)
-		if err == nil {
-			return repo, nil
-		}
-		repoCandidatePath = filepath.Dir(repoCandidatePath)
+func listVersionedPkgsOfExternalRepo(
+	externalRepo ExternalRepo, repo VersionedRepo,
+) (pkgMap map[string]CachedPkg, versionedPkgPaths []string, err error) {
+	pkgs, err := ListExternalPkgs(externalRepo, "")
+	if err != nil {
+		return nil, nil, errors.Wrapf(
+			err, "couldn't list packages from external repo at %s", externalRepo.Repo.ConfigPath,
+		)
 	}
-	return VersionedRepo{}, errors.Errorf(
-		"no repository config file found in %s or any parent directory in local environment",
-		filepath.Dir(pkgPath),
+
+	pkgMap = make(map[string]CachedPkg)
+	for _, pkg := range pkgs {
+		if prevPkg, ok := pkgMap[pkg.Path]; ok {
+			if prevPkg.Repo.FromSameVCSRepo(pkg.Repo) && prevPkg.ConfigPath != pkg.ConfigPath {
+				return nil, nil, errors.Errorf(
+					"package repeatedly defined in the same version of the same cached Github repo: %s, %s",
+					prevPkg.ConfigPath, pkg.ConfigPath,
+				)
+			}
+		}
+		versionedPkgPaths = append(versionedPkgPaths, pkg.Path)
+		pkgMap[pkg.Path] = pkg
+	}
+
+	return pkgMap, versionedPkgPaths, nil
+}
+
+func listVersionedPkgsOfCachedRepo(
+	cacheFS fs.FS, repo VersionedRepo,
+) (pkgMap map[string]CachedPkg, versionedPkgPaths []string, err error) {
+	repoVersion, err := repo.Config.Version()
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "couldn't determine version of repo %s", repo.Path())
+	}
+	repoCachePath := filepath.Join(
+		fmt.Sprintf("%s@%s", repo.VCSRepoPath, repoVersion),
+		repo.RepoSubdir,
 	)
+	pkgs, err := ListCachedPkgs(cacheFS, repoCachePath)
+	if err != nil {
+		return nil, nil, errors.Wrapf(
+			err, "couldn't list packages from repo cached at %s", repoCachePath,
+		)
+	}
+
+	pkgMap = make(map[string]CachedPkg)
+	for _, pkg := range pkgs {
+		versionedPkgPath := fmt.Sprintf(
+			"%s@%s/%s", pkg.Repo.Config.Repository.Path, pkg.Repo.Version, pkg.PkgSubdir,
+		)
+		if prevPkg, ok := pkgMap[versionedPkgPath]; ok {
+			if prevPkg.Repo.FromSameVCSRepo(pkg.Repo) && prevPkg.ConfigPath != pkg.ConfigPath {
+				return nil, nil, errors.Errorf(
+					"package repeatedly defined in the same version of the same cached Github repo: %s, %s",
+					prevPkg.ConfigPath, pkg.ConfigPath,
+				)
+			}
+		}
+		versionedPkgPaths = append(versionedPkgPaths, versionedPkgPath)
+		pkgMap[versionedPkgPath] = pkg
+	}
+
+	return pkgMap, versionedPkgPaths, nil
 }
 
 func LoadVersionedPkg(reposFS, cacheFS fs.FS, pkgPath string) (VersionedPkg, error) {
@@ -91,4 +128,19 @@ func LoadVersionedPkg(reposFS, cacheFS fs.FS, pkgPath string) (VersionedPkg, err
 		Repo:   repo,
 		Cached: pkg,
 	}, nil
+}
+
+func findVersionedRepoOfPkg(reposFS fs.FS, pkgPath string) (VersionedRepo, error) {
+	repoCandidatePath := filepath.Dir(pkgPath)
+	for repoCandidatePath != "." {
+		repo, err := LoadVersionedRepo(reposFS, repoCandidatePath)
+		if err == nil {
+			return repo, nil
+		}
+		repoCandidatePath = filepath.Dir(repoCandidatePath)
+	}
+	return VersionedRepo{}, errors.Errorf(
+		"no repository config file found in %s or any parent directory in local environment",
+		filepath.Dir(pkgPath),
+	)
 }

--- a/internal/app/forklift/external-pkgs.go
+++ b/internal/app/forklift/external-pkgs.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ListExternalPkgs(repo ExternalRepo, cachedPrefix string) ([]CachedPkg, error) {
-	searchPattern := "**/pallet-package.yml"
+	searchPattern := fmt.Sprintf("**/%s", PkgSpecFile)
 	if cachedPrefix != "" {
 		searchPattern = filepath.Join(cachedPrefix, searchPattern)
 	}
@@ -23,7 +23,7 @@ func ListExternalPkgs(repo ExternalRepo, cachedPrefix string) ([]CachedPkg, erro
 	pkgMap := make(map[string]CachedPkg)
 	for _, pkgConfigFilePath := range pkgConfigFiles {
 		filename := filepath.Base(pkgConfigFilePath)
-		if filename != "pallet-package.yml" {
+		if filename != PkgSpecFile {
 			continue
 		}
 		pkg, err := loadExternalPkg(repo, pkgConfigFilePath)
@@ -86,7 +86,7 @@ func FindExternalPkg(repo ExternalRepo, pkgPath string) (CachedPkg, error) {
 	// The package subdirectory path in the package path (under the VCS repo path) might not match the
 	// filesystem directory path with the pallet-package.yml file, so we must check every
 	// directory whose name matches the last part of the package path to look for the package
-	searchPattern := fmt.Sprintf("**/%s/pallet-package.yml", pkgInnermostDir)
+	searchPattern := fmt.Sprintf("**/%s/%s", pkgInnermostDir, PkgSpecFile)
 	candidatePkgConfigFiles, err := doublestar.Glob(repo.FS, searchPattern)
 	if err != nil {
 		return CachedPkg{}, errors.Wrapf(
@@ -99,7 +99,7 @@ func FindExternalPkg(repo ExternalRepo, pkgPath string) (CachedPkg, error) {
 	candidatePkgs := make([]CachedPkg, 0)
 	for _, pkgConfigFilePath := range candidatePkgConfigFiles {
 		filename := filepath.Base(pkgConfigFilePath)
-		if filename != "pallet-package.yml" {
+		if filename != PkgSpecFile {
 			continue
 		}
 		pkg, err := loadExternalPkg(repo, pkgConfigFilePath)

--- a/internal/app/forklift/external-pkgs.go
+++ b/internal/app/forklift/external-pkgs.go
@@ -1,0 +1,136 @@
+package forklift
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/pkg/errors"
+)
+
+func ListExternalPkgs(repo ExternalRepo, cachedPrefix string) ([]CachedPkg, error) {
+	searchPattern := "**/pallet-package.yml"
+	if cachedPrefix != "" {
+		searchPattern = filepath.Join(cachedPrefix, searchPattern)
+	}
+	pkgConfigFiles, err := doublestar.Glob(repo.FS, searchPattern)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't search for external package configs")
+	}
+
+	repoPkgPaths := make([]string, 0, len(pkgConfigFiles))
+	pkgMap := make(map[string]CachedPkg)
+	for _, pkgConfigFilePath := range pkgConfigFiles {
+		filename := filepath.Base(pkgConfigFilePath)
+		if filename != "pallet-package.yml" {
+			continue
+		}
+		pkg, err := loadExternalPkg(repo, pkgConfigFilePath)
+		if err != nil {
+			return nil, errors.Wrapf(err, "couldn't load cached package from %s", pkgConfigFilePath)
+		}
+
+		if prevPkg, ok := pkgMap[pkg.Path]; ok {
+			if prevPkg.Repo.FromSameVCSRepo(pkg.Repo) && prevPkg.ConfigPath != pkg.ConfigPath {
+				return nil, errors.Errorf(
+					"package repeatedly defined in the same version of the same Github repo: %s, %s",
+					prevPkg.ConfigPath, pkg.ConfigPath,
+				)
+			}
+		}
+		repoPkgPaths = append(repoPkgPaths, pkg.Path)
+		pkgMap[pkg.Path] = pkg
+	}
+
+	orderedPkgs := make([]CachedPkg, 0, len(repoPkgPaths))
+	for _, path := range repoPkgPaths {
+		orderedPkgs = append(orderedPkgs, pkgMap[path])
+	}
+	return orderedPkgs, nil
+}
+
+func loadExternalPkg(repo ExternalRepo, pkgConfigFilePath string) (CachedPkg, error) {
+	config, err := loadPkgConfig(repo.FS, pkgConfigFilePath)
+	if err != nil {
+		return CachedPkg{}, errors.Wrapf(
+			err, "couldn't load external package config from %s", pkgConfigFilePath,
+		)
+	}
+
+	pkg := CachedPkg{
+		Repo:       repo.Repo,
+		ConfigPath: filepath.Join(repo.Repo.ConfigPath, filepath.Dir(pkgConfigFilePath)),
+		Config:     config,
+	}
+	pkg.PkgSubdir = strings.TrimPrefix(pkg.ConfigPath, fmt.Sprintf("%s/", pkg.Repo.ConfigPath))
+	pkg.Path = fmt.Sprintf("%s/%s", pkg.Repo.Config.Repository.Path, pkg.PkgSubdir)
+	return pkg, nil
+}
+
+func FindExternalRepoOfPkg(
+	repos map[string]ExternalRepo, pkgPath string,
+) (repo ExternalRepo, ok bool) {
+	repoCandidatePath := filepath.Dir(pkgPath)
+	for repoCandidatePath != "." {
+		if repo, ok = repos[repoCandidatePath]; ok {
+			return repo, true
+		}
+		repoCandidatePath = filepath.Dir(repoCandidatePath)
+	}
+	return ExternalRepo{}, false
+}
+
+func FindExternalPkg(repo ExternalRepo, pkgPath string) (CachedPkg, error) {
+	pkgInnermostDir := filepath.Base(pkgPath)
+	// The package subdirectory path in the package path (under the VCS repo path) might not match the
+	// filesystem directory path with the pallet-package.yml file, so we must check every
+	// directory whose name matches the last part of the package path to look for the package
+	searchPattern := fmt.Sprintf("**/%s/pallet-package.yml", pkgInnermostDir)
+	candidatePkgConfigFiles, err := doublestar.Glob(repo.FS, searchPattern)
+	if err != nil {
+		return CachedPkg{}, errors.Wrapf(
+			err, "couldn't search for external Pallet package configs matching pattern %s", searchPattern,
+		)
+	}
+	if len(candidatePkgConfigFiles) == 0 {
+		return CachedPkg{}, errors.New("no matching Pallet package configs were found")
+	}
+	candidatePkgs := make([]CachedPkg, 0)
+	for _, pkgConfigFilePath := range candidatePkgConfigFiles {
+		filename := filepath.Base(pkgConfigFilePath)
+		if filename != "pallet-package.yml" {
+			continue
+		}
+		pkg, err := loadExternalPkg(repo, pkgConfigFilePath)
+		if err != nil {
+			return CachedPkg{}, errors.Wrapf(
+				err, "couldn't check external pkg defined at %s", pkgConfigFilePath,
+			)
+		}
+		if pkg.Path == pkgPath {
+			if len(candidatePkgs) > 0 {
+				return CachedPkg{}, errors.Errorf(
+					"package %s repeatedly defined in the same version of the same Github repo: %s, %s",
+					pkgPath, candidatePkgs[0].ConfigPath, pkg.ConfigPath,
+				)
+			}
+			candidatePkgs = append(candidatePkgs, pkg)
+		}
+	}
+	if len(candidatePkgs) == 0 {
+		return CachedPkg{}, errors.Errorf("no external repos were found matching %s", pkgPath)
+	}
+	return candidatePkgs[0], nil
+}
+
+func AsVersionedPkg(pkg CachedPkg) VersionedPkg {
+	return VersionedPkg{
+		Path: pkg.Path,
+		Repo: VersionedRepo{
+			VCSRepoPath: pkg.Repo.VCSRepoPath,
+			RepoSubdir:  pkg.Repo.RepoSubdir,
+		},
+		Cached: pkg,
+	}
+}

--- a/internal/app/forklift/external-repos.go
+++ b/internal/app/forklift/external-repos.go
@@ -1,0 +1,68 @@
+package forklift
+
+import (
+	"io/fs"
+	"path/filepath"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/pkg/errors"
+)
+
+func LoadExternalRepo(dir fs.FS, repoConfigFilePath string) (CachedRepo, error) {
+	config, err := loadRepoConfig(dir, repoConfigFilePath)
+	if err != nil {
+		return CachedRepo{}, errors.Wrapf(
+			err, "couldn't load cached repo config from %s", repoConfigFilePath,
+		)
+	}
+
+	repo := CachedRepo{
+		ConfigPath: filepath.Dir(repoConfigFilePath),
+		Config:     config,
+	}
+	repo.VCSRepoPath, repo.RepoSubdir, err = SplitRepoPathSubdir(config.Repository.Path)
+	if err != nil {
+		return CachedRepo{}, errors.Wrapf(
+			err, "couldn't parse path of Pallet repo %s", config.Repository.Path,
+		)
+	}
+	return repo, nil
+}
+
+func ListExternalRepos(dir fs.FS) ([]CachedRepo, error) {
+	repoConfigFiles, err := doublestar.Glob(dir, "**/pallet-repository.yml")
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't search for cached repo configs")
+	}
+
+	repoPaths := make([]string, 0, len(repoConfigFiles))
+	repoMap := make(map[string]CachedRepo)
+	for _, repoConfigFilePath := range repoConfigFiles {
+		filename := filepath.Base(repoConfigFilePath)
+		if filename != "pallet-repository.yml" {
+			continue
+		}
+		repo, err := LoadExternalRepo(dir, repoConfigFilePath)
+		if err != nil {
+			return nil, errors.Wrapf(err, "couldn't load cached repo from %s", repoConfigFilePath)
+		}
+
+		repoPath := repo.Config.Repository.Path
+		if prevRepo, ok := repoMap[repoPath]; ok {
+			if prevRepo.FromSameVCSRepo(repo) && prevRepo.ConfigPath != repo.ConfigPath {
+				return nil, errors.Errorf(
+					"repository repeatedly defined in the same version of the same Github repo: %s, %s",
+					prevRepo.ConfigPath, repo.ConfigPath,
+				)
+			}
+		}
+		repoPaths = append(repoPaths, repoPath)
+		repoMap[repoPath] = repo
+	}
+
+	orderedRepos := make([]CachedRepo, 0, len(repoPaths))
+	for _, path := range repoPaths {
+		orderedRepos = append(orderedRepos, repoMap[path])
+	}
+	return orderedRepos, nil
+}

--- a/internal/app/forklift/external-repos.go
+++ b/internal/app/forklift/external-repos.go
@@ -1,6 +1,7 @@
 package forklift
 
 import (
+	"fmt"
 	"io/fs"
 	"path/filepath"
 
@@ -30,7 +31,7 @@ func LoadExternalRepo(dir fs.FS, repoConfigFilePath string) (CachedRepo, error) 
 }
 
 func ListExternalRepos(dir fs.FS) ([]CachedRepo, error) {
-	repoConfigFiles, err := doublestar.Glob(dir, "**/pallet-repository.yml")
+	repoConfigFiles, err := doublestar.Glob(dir, fmt.Sprintf("**/%s", RepoSpecFile))
 	if err != nil {
 		return nil, errors.Wrap(err, "couldn't search for cached repo configs")
 	}
@@ -39,7 +40,7 @@ func ListExternalRepos(dir fs.FS) ([]CachedRepo, error) {
 	repoMap := make(map[string]CachedRepo)
 	for _, repoConfigFilePath := range repoConfigFiles {
 		filename := filepath.Base(repoConfigFilePath)
-		if filename != "pallet-repository.yml" {
+		if filename != RepoSpecFile {
 			continue
 		}
 		repo, err := LoadExternalRepo(dir, repoConfigFilePath)

--- a/internal/app/forklift/models-forklift.go
+++ b/internal/app/forklift/models-forklift.go
@@ -1,6 +1,10 @@
 // Package forklift provides the core functionality of the forklift tool
 package forklift
 
+import (
+	"io/fs"
+)
+
 // Environment specifications
 
 type EnvSpec struct {
@@ -64,4 +68,11 @@ type CachedPkg struct {
 	PkgSubdir  string
 	ConfigPath string
 	Config     PkgConfig
+}
+
+// External repository loading
+
+type ExternalRepo struct {
+	Repo CachedRepo
+	FS   fs.FS
 }

--- a/internal/app/forklift/models-pallets.go
+++ b/internal/app/forklift/models-pallets.go
@@ -2,6 +2,8 @@ package forklift
 
 // Repository specifications
 
+const RepoSpecFile = "pallet-repository.yml"
+
 type RepoSpec struct {
 	Path        string `yaml:"path"`
 	Description string `yaml:"description"`
@@ -13,6 +15,8 @@ type RepoConfig struct {
 }
 
 // Package specifications
+
+const PkgSpecFile = "pallet-package.yml"
 
 type PkgConfig struct {
 	Package    PkgSpec                   `yaml:"package,omitempty"`


### PR DESCRIPTION
This PR adds a `--repo` flag to `dev env` overwriting cached repos with the repos in the directories specified by the `--repo` flag, for all subcommands which use cached repos. This is especially useful for the `dev env check` subcommand, allowing changes to one or more Pallet repositories/packages to be tested and checked before those changes are published.

This PR also adds `env plan` and `dev env plan` subcommands as counterparts to `env apply` and `dev env apply`.