### PR TITLE
Fix incorrect display of resolved versions for added repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.1.9 - 2023-07-29
+
+### Fixed
+
+- Fixed regression from v0.1.8 where the `dev env add-repo` would not properly print out the resolved versions of repo version queries.
+
 ## 0.1.8 - 2023-07-29
 
 ### Added

--- a/cmd/forklift/dev/env/repos.go
+++ b/cmd/forklift/dev/env/repos.go
@@ -211,7 +211,7 @@ func determinePalletRepoDefs(
 
 		config := vcsRepoDefs[vcsRepoRelease]
 		config.RepoSubdir = repoSubdir
-		fmt.Printf("Resolved %s as %s", remoteRelease, config.VersionLock.Version)
+		fmt.Printf("Resolved %s as %+v", remoteRelease, config.VersionLock.Version)
 		if config.VersionLock.Def.BaseVersion != "" {
 			fmt.Printf(", version %s", config.VersionLock.Def.BaseVersion)
 		}
@@ -255,6 +255,9 @@ func resolveVCSRepoVersionQuery(
 		)
 	}
 	if repo.VersionLock.Def, err = lockCommit(gitRepo, commit); err != nil {
+		return forklift.RepoReq{}, err
+	}
+	if repo.VersionLock.Version, err = repo.VersionLock.Def.Version(); err != nil {
 		return forklift.RepoReq{}, err
 	}
 	return repo, nil

--- a/cmd/forklift/main.go
+++ b/cmd/forklift/main.go
@@ -25,7 +25,7 @@ var app = &cli.App{
 	Name: "forklift",
 	// TODO: see if there's a way to get the version from a build tag, so that we don't have to update
 	// this manually
-	Version: "v0.1.8",
+	Version: "v0.1.9",
 	Usage:   "Manages Pallet repositories and package deployments",
 	Commands: []*cli.Command{
 		env.Cmd,


### PR DESCRIPTION
This PR fixes a regression introduced by #42 where the resolved version strings of repos added in the `dev env add-repo` command were displayed as empty strings, rather than with their actual values.