### PR TITLE
Replace erroneous uses of `path/filepath`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- The `dev env add-repo` subcommand now makes any directories it needs to make in order to write repository requirement definition files to the appropriate locations.
+- File path separators should no longer be obviously incorrect on Windows systems (though they may still be incorrect, since Forklift is not tested on Windows).
+
 ## 0.1.9 - 2023-07-29
 
 ### Fixed

--- a/cmd/forklift/dev/env/repos.go
+++ b/cmd/forklift/dev/env/repos.go
@@ -110,6 +110,11 @@ func addRepoAction(c *cli.Context) error {
 		if err != nil {
 			return errors.Wrapf(err, "couldn't marshal config for %s", repoReqPath)
 		}
+		if err := forklift.EnsureExists(filepath.FromSlash(path.Dir(repoReqPath))); err != nil {
+			return errors.Wrapf(
+				err, "couldn't make directory %s", filepath.FromSlash(path.Dir(repoReqPath)),
+			)
+		}
 		const perm = 0o644 // owner rw, group r, public r
 		if err := os.WriteFile(filepath.FromSlash(repoReqPath), marshaled, perm); err != nil {
 			return errors.Wrapf(err, "couldn't save config to %s", filepath.FromSlash(repoReqPath))

--- a/cmd/forklift/dev/env/repos.go
+++ b/cmd/forklift/dev/env/repos.go
@@ -3,6 +3,7 @@ package env
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -102,17 +103,16 @@ func addRepoAction(c *cli.Context) error {
 		if !ok {
 			return errors.Errorf("couldn't find configuration for %s", remoteRelease)
 		}
-		// TODO: write configs as files
-		path := filepath.Join(
+		repoReqPath := path.Join(
 			env.FS.Path(), "repositories", config.VCSRepoPath, config.RepoSubdir, "forklift-repo.yml",
 		)
 		marshaled, err := yaml.Marshal(config.VersionLock.Def)
 		if err != nil {
-			return errors.Wrapf(err, "couldn't marshal config for %s", path)
+			return errors.Wrapf(err, "couldn't marshal config for %s", repoReqPath)
 		}
 		const perm = 0o644 // owner rw, group r, public r
-		if err := os.WriteFile(path, marshaled, perm); err != nil {
-			return errors.Wrapf(err, "couldn't save config to %s", path)
+		if err := os.WriteFile(filepath.FromSlash(repoReqPath), marshaled, perm); err != nil {
+			return errors.Wrapf(err, "couldn't save config to %s", filepath.FromSlash(repoReqPath))
 		}
 	}
 	fmt.Println("Done!")
@@ -155,7 +155,7 @@ func updateLocalRepoMirrors(remoteReleases []string, cachePath string) error {
 		}
 
 		if err = updateLocalRepoMirror(
-			vcsRepoPath, filepath.Join(cachePath, vcsRepoPath),
+			vcsRepoPath, path.Join(cachePath, vcsRepoPath),
 		); err != nil {
 			return errors.Wrapf(
 				err, "couldn't update local mirror of %s", vcsRepoPath,
@@ -167,6 +167,8 @@ func updateLocalRepoMirrors(remoteReleases []string, cachePath string) error {
 }
 
 func updateLocalRepoMirror(remote, cachedPath string) error {
+	remote = filepath.FromSlash(remote)
+	cachedPath = filepath.FromSlash(cachedPath)
 	if _, err := os.Stat(cachedPath); err == nil {
 		fmt.Printf("Fetching updates for %s...\n", cachedPath)
 		if _, err = git.Fetch(cachedPath); err == nil {
@@ -232,7 +234,7 @@ func resolveVCSRepoVersionQuery(
 			"support for empty version queries is not yet implemented!",
 		)
 	}
-	localPath := filepath.Join(cachePath, vcsRepoPath)
+	localPath := filepath.FromSlash(path.Join(cachePath, vcsRepoPath))
 	gitRepo, err := git.Open(localPath)
 	if err != nil {
 		return forklift.RepoReq{}, errors.Wrapf(

--- a/internal/app/forklift/caching.go
+++ b/internal/app/forklift/caching.go
@@ -3,6 +3,7 @@ package forklift
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -17,12 +18,12 @@ import (
 
 // Exists checks whether the cache actually exists on the OS's filesystem.
 func (c *FSCache) Exists() bool {
-	return Exists(c.FS.Path())
+	return Exists(filepath.FromSlash(c.FS.Path()))
 }
 
 // Remove deletes the cache from the OS's filesystem, if it exists.
 func (c *FSCache) Remove() error {
-	return os.RemoveAll(c.FS.Path())
+	return os.RemoveAll(filepath.FromSlash(c.FS.Path()))
 }
 
 // Path returns the path of the cache's filesystem.
@@ -131,7 +132,7 @@ func (c *FSCache) LoadFSPkg(pkgPath string, version string) (*pallets.FSPkg, err
 	if err != nil {
 		return nil, errors.Wrapf(err, "couldn't parse path of Pallet package %s", pkgPath)
 	}
-	pkgInnermostDir := filepath.Base(pkgPath)
+	pkgInnermostDir := path.Base(pkgPath)
 	// The package subdirectory path in the package path (under the VCS repo path) might not match the
 	// filesystem directory path with the pallet-package.yml file, so we must check every
 	// directory whose name matches the last part of the package path to look for the package
@@ -487,7 +488,7 @@ func (f *RepoOverrideCache) LoadFSPkgs(searchPattern string) ([]*pallets.FSPkg, 
 				if err != nil {
 					return nil, err
 				}
-				pkgCachePath := filepath.Join(repoCachePath, pkg.Subdir)
+				pkgCachePath := path.Join(repoCachePath, pkg.Subdir)
 				pkgCachePaths = append(pkgCachePaths, pkgCachePath)
 				pkgs[pkgCachePath] = pkg
 			}

--- a/internal/app/forklift/cli/env-pkgs.go
+++ b/internal/app/forklift/cli/env-pkgs.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"path/filepath"
+	"path"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -22,7 +22,7 @@ func PrintEnvPkgs(indent int, env *forklift.FSEnv, loader forklift.FSPkgLoader) 
 	pkgs := make([]*pallets.FSPkg, 0)
 	for _, req := range reqs {
 		repoCachePath := req.GetCachePath()
-		loaded, err := loader.LoadFSPkgs(filepath.Join(repoCachePath, "**"))
+		loaded, err := loader.LoadFSPkgs(path.Join(repoCachePath, "**"))
 		if err != nil {
 			return errors.Wrapf(err, "couldn't load packages from repo cached at %s", repoCachePath)
 		}

--- a/internal/app/forklift/env-reqs.go
+++ b/internal/app/forklift/env-reqs.go
@@ -2,7 +2,7 @@ package forklift
 
 import (
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -37,7 +37,7 @@ func LoadRequiredFSPkg(
 // vcsPath@version/repoSubdir/pkgSubdir
 // (e.g. github.com/PlanktoScope/pallets@v0.1.0/core/infrastructure/caddy-ingress).
 func (r PkgReq) GetCachePath() string {
-	return filepath.Join(r.Repo.GetCachePath(), r.PkgSubdir)
+	return path.Join(r.Repo.GetCachePath(), r.PkgSubdir)
 }
 
 // GetQueryPath returns the path of the package in version queries, which is of form
@@ -49,7 +49,7 @@ func (r PkgReq) GetQueryPath() string {
 
 // Path returns the Pallet package path of the required package.
 func (r PkgReq) Path() string {
-	return filepath.Join(r.Repo.Path(), r.PkgSubdir)
+	return path.Join(r.Repo.Path(), r.PkgSubdir)
 }
 
 // RepoReq
@@ -89,7 +89,7 @@ func loadFSRepoReqContaining(fsys pallets.PathedFS, subdirPath string) (*FSRepoR
 		if repo, err := loadFSRepoReq(fsys, repoCandidatePath); err == nil {
 			return repo, nil
 		}
-		repoCandidatePath = filepath.Dir(repoCandidatePath)
+		repoCandidatePath = path.Dir(repoCandidatePath)
 		if repoCandidatePath == "/" || repoCandidatePath == "." {
 			// we can't go up anymore!
 			return nil, errors.Errorf(
@@ -107,7 +107,7 @@ func loadFSRepoReqContaining(fsys pallets.PathedFS, subdirPath string) (*FSRepoR
 // path and Pallet repository subdirectory are initialized from the Pallet repository path declared
 // in the repository's configuration file, while the Pallet repository version is not initialized.
 func loadFSRepoReqs(fsys pallets.PathedFS, searchPattern string) ([]*FSRepoReq, error) {
-	searchPattern = filepath.Join(searchPattern, VersionLockDefFile)
+	searchPattern = path.Join(searchPattern, VersionLockDefFile)
 	repoReqFiles, err := doublestar.Glob(fsys, searchPattern)
 	if err != nil {
 		return nil, errors.Wrapf(
@@ -118,11 +118,11 @@ func loadFSRepoReqs(fsys pallets.PathedFS, searchPattern string) ([]*FSRepoReq, 
 
 	reqs := make([]*FSRepoReq, 0, len(repoReqFiles))
 	for _, repoReqDefFilePath := range repoReqFiles {
-		if filepath.Base(repoReqDefFilePath) != VersionLockDefFile {
+		if path.Base(repoReqDefFilePath) != VersionLockDefFile {
 			continue
 		}
 
-		req, err := loadFSRepoReq(fsys, filepath.Dir(repoReqDefFilePath))
+		req, err := loadFSRepoReq(fsys, path.Dir(repoReqDefFilePath))
 		if err != nil {
 			return nil, errors.Wrapf(err, "couldn't load repo requirement from %s", repoReqDefFilePath)
 		}
@@ -133,7 +133,7 @@ func loadFSRepoReqs(fsys pallets.PathedFS, searchPattern string) ([]*FSRepoReq, 
 
 // Path returns the Pallet repository path of the required repository.
 func (r RepoReq) Path() string {
-	return filepath.Join(r.VCSRepoPath, r.RepoSubdir)
+	return path.Join(r.VCSRepoPath, r.RepoSubdir)
 }
 
 // GetPkgSubdir returns the Pallet package subdirectory within the required repo for the provided

--- a/internal/app/forklift/env.go
+++ b/internal/app/forklift/env.go
@@ -29,6 +29,7 @@ func LoadFSEnv(fsys pallets.PathedFS, subdirPath string) (e *FSEnv, err error) {
 
 // LoadFSEnvContaining loads the FSEnv containing the specified sub-directory path in the provided
 // base filesystem.
+// The provided path should use the host OS's path separators.
 // The sub-directory path does not have to actually exist.
 func LoadFSEnvContaining(path string) (*FSEnv, error) {
 	envCandidatePath, err := filepath.Abs(path)

--- a/internal/app/forklift/workspace.go
+++ b/internal/app/forklift/workspace.go
@@ -2,39 +2,41 @@ package forklift
 
 import (
 	"os"
-	"path/filepath"
+	"path"
 
 	"github.com/pkg/errors"
 
 	"github.com/PlanktoScope/forklift/pkg/pallets"
 )
 
-func Exists(path string) bool {
-	dir, err := os.Stat(path)
+func Exists(dirPath string) bool {
+	dir, err := os.Stat(dirPath)
 	if err == nil && dir.IsDir() {
 		return true
 	}
 	return false
 }
 
-func EnsureExists(path string) error {
+func EnsureExists(dirPath string) error {
 	const perm = 0o755 // owner rwx, group rx, public rx
-	return os.MkdirAll(path, perm)
+	return os.MkdirAll(dirPath, perm)
 }
 
 // FSWorkspace
 
-func LoadWorkspace(path string) (*FSWorkspace, error) {
-	if !Exists(path) {
-		return nil, errors.Errorf("couldn't find workspace at %s", path)
+// LoadWorkspace loads the workspace at the specified path.
+// The provided path must use the host OS's path separators.
+func LoadWorkspace(dirPath string) (*FSWorkspace, error) {
+	if !Exists(dirPath) {
+		return nil, errors.Errorf("couldn't find workspace at %s", dirPath)
 	}
 	return &FSWorkspace{
-		FS: pallets.AttachPath(os.DirFS(path), path),
+		FS: pallets.AttachPath(os.DirFS(dirPath), dirPath),
 	}, nil
 }
 
 func (w *FSWorkspace) GetCurrentEnvPath() string {
-	return filepath.Join(w.FS.Path(), currentEnvDirName)
+	return path.Join(w.FS.Path(), currentEnvDirName)
 }
 
 func (w *FSWorkspace) GetCurrentEnv() (*FSEnv, error) {
@@ -48,7 +50,7 @@ func (w *FSWorkspace) GetCurrentEnv() (*FSEnv, error) {
 }
 
 func (w *FSWorkspace) GetCachePath() string {
-	return filepath.Join(w.FS.Path(), cacheDirName)
+	return path.Join(w.FS.Path(), cacheDirName)
 }
 
 func (w *FSWorkspace) GetCache() (*FSCache, error) {

--- a/internal/clients/docker/stacks-loading.go
+++ b/internal/clients/docker/stacks-loading.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"io/fs"
 	"os"
-	"path/filepath"
+	"path"
 	"runtime"
 	"strings"
 
@@ -54,7 +54,7 @@ func getConfigDetails(f fs.FS, filePath string) (types.ConfigDetails, error) {
 	// GetConfigDetails function, which is licensed under Apache-2.0. This function was changed to
 	// take a single compose file from a fs.FS.
 	details := types.ConfigDetails{
-		WorkingDir: filepath.Dir(filePath),
+		WorkingDir: path.Dir(filePath),
 	}
 	configFile, err := loadConfigFile(f, filePath)
 	if err != nil {

--- a/pkg/pallets/fs.go
+++ b/pkg/pallets/fs.go
@@ -3,7 +3,7 @@ package pallets
 import (
 	"fmt"
 	"io/fs"
-	"path/filepath"
+	"path"
 	"strings"
 )
 
@@ -27,7 +27,7 @@ func GetSubdirPath(pather Pather, path string) string {
 	if len(pather.Path()) == 0 {
 		return path
 	}
-	// TODO: handle "/", ".", and ".."...maybe use filepath.Rel?
+	// TODO: handle "/", ".", and ".."...maybe use path.Rel?
 	return strings.TrimPrefix(path, fmt.Sprintf("%s/", pather.Path()))
 }
 
@@ -59,6 +59,6 @@ func (f pathedFS) Sub(dir string) (PathedFS, error) {
 	subFS, err := fs.Sub(f.FS, dir)
 	return pathedFS{
 		FS:   subFS,
-		path: filepath.Join(f.path, dir),
+		path: path.Join(f.path, dir),
 	}, err
 }

--- a/pkg/pallets/pkg.go
+++ b/pkg/pallets/pkg.go
@@ -3,7 +3,7 @@ package pallets
 import (
 	"fmt"
 	"io/fs"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -37,7 +37,7 @@ func LoadFSPkg(fsys PathedFS, subdirPath string) (p *FSPkg, err error) {
 // The Pallet repository path, and the Pallet package subdirectory, and the pointer to the Pallet
 // repository are all left uninitialized.
 func LoadFSPkgs(fsys PathedFS, searchPattern string) ([]*FSPkg, error) {
-	searchPattern = filepath.Join(searchPattern, PkgDefFile)
+	searchPattern = path.Join(searchPattern, PkgDefFile)
 	pkgDefFiles, err := doublestar.Glob(fsys, searchPattern)
 	if err != nil {
 		return nil, errors.Wrapf(
@@ -47,11 +47,11 @@ func LoadFSPkgs(fsys PathedFS, searchPattern string) ([]*FSPkg, error) {
 
 	pkgs := make([]*FSPkg, 0, len(pkgDefFiles))
 	for _, pkgDefFilePath := range pkgDefFiles {
-		if filepath.Base(pkgDefFilePath) != PkgDefFile {
+		if path.Base(pkgDefFilePath) != PkgDefFile {
 			continue
 		}
 
-		pkg, err := LoadFSPkg(fsys, filepath.Dir(pkgDefFilePath))
+		pkg, err := LoadFSPkg(fsys, path.Dir(pkgDefFilePath))
 		if err != nil {
 			return nil, errors.Wrapf(err, "couldn't load package from %s", pkgDefFilePath)
 		}
@@ -109,7 +109,7 @@ func ComparePkgs(p, q Pkg) int {
 
 // Path returns the Pallet package path of the Pkg instance.
 func (p Pkg) Path() string {
-	return filepath.Join(p.RepoPath, p.Subdir)
+	return path.Join(p.RepoPath, p.Subdir)
 }
 
 // Check looks for errors in the construction of the package.

--- a/pkg/pallets/repo.go
+++ b/pkg/pallets/repo.go
@@ -2,7 +2,7 @@ package pallets
 
 import (
 	"io/fs"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -70,7 +70,7 @@ func LoadFSRepoContaining(fsys PathedFS, subdirPath string) (*FSRepo, error) {
 		if repo, err := LoadFSRepo(fsys, repoCandidatePath); err == nil {
 			return repo, nil
 		}
-		repoCandidatePath = filepath.Dir(repoCandidatePath)
+		repoCandidatePath = path.Dir(repoCandidatePath)
 		if repoCandidatePath == "/" || repoCandidatePath == "." {
 			// we can't go up anymore!
 			return nil, errors.Errorf(
@@ -93,7 +93,7 @@ func LoadFSRepoContaining(fsys PathedFS, subdirPath string) (*FSRepo, error) {
 func LoadFSRepos(
 	fsys PathedFS, searchPattern string, processor func(repo *FSRepo) error,
 ) ([]*FSRepo, error) {
-	searchPattern = filepath.Join(searchPattern, RepoDefFile)
+	searchPattern = path.Join(searchPattern, RepoDefFile)
 	repoDefFiles, err := doublestar.Glob(fsys, searchPattern)
 	if err != nil {
 		return nil, errors.Wrapf(
@@ -104,10 +104,10 @@ func LoadFSRepos(
 	orderedRepos := make([]*FSRepo, 0, len(repoDefFiles))
 	repos := make(map[string]*FSRepo)
 	for _, repoDefFilePath := range repoDefFiles {
-		if filepath.Base(repoDefFilePath) != RepoDefFile {
+		if path.Base(repoDefFilePath) != RepoDefFile {
 			continue
 		}
-		repo, err := LoadFSRepo(fsys, filepath.Dir(repoDefFilePath))
+		repo, err := LoadFSRepo(fsys, path.Dir(repoDefFilePath))
 		if err != nil {
 			return nil, errors.Wrapf(
 				err, "couldn't load repo from %s/%s", fsys.Path(), repoDefFilePath,
@@ -169,7 +169,7 @@ func (r *FSRepo) LoadFSPkgs(searchPattern string) ([]*FSPkg, error) {
 
 // Path returns the Pallet repository path of the Repo instance.
 func (r Repo) Path() string {
-	return filepath.Join(r.VCSRepoPath, r.Subdir)
+	return path.Join(r.VCSRepoPath, r.Subdir)
 }
 
 // FromSameVCSRepo determines whether the candidate Pallet repository is provided by the same VCS


### PR DESCRIPTION
This PR replaces the use of Go's `path/filepath` package with the `path` library for manipulating paths in `fs.FS` filesystems. This PR also fixes a bug with handling of missing directories in the `dev env add-repo` subcommand.