### PR TITLE
Load and print the repo readme in `show-repo` subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `cache show-repo`, `env show-repo`, and `dev env show-repo` now print the Pallet repository's readme file, hard-wrapped to a max line length of 100 characters.
+
 ### Fixed
 
 - The `dev env add-repo` subcommand now makes any directories it needs to make in order to write repository requirement definition files to the appropriate locations.

--- a/cmd/forklift/cache/repos.go
+++ b/cmd/forklift/cache/repos.go
@@ -60,17 +60,27 @@ func showRepoAction(c *cli.Context) error {
 	if err != nil {
 		return errors.Wrapf(err, "couldn't find Pallet repository %s@%s", repoPath, version)
 	}
-	printCachedRepo(0, cache, repo)
-	return nil
+	return printCachedRepo(0, cache, repo)
 }
 
-func printCachedRepo(indent int, cache *forklift.FSCache, repo *pallets.FSRepo) {
-	fcli.IndentedPrintf(indent, "Cached Pallet repository: %s\n", repo.Def.Repository.Path)
+func printCachedRepo(indent int, cache *forklift.FSCache, repo *pallets.FSRepo) error {
+	fcli.IndentedPrintf(indent, "Cached Pallet repository: %s\n", repo.Path())
 	indent++
 
 	fcli.IndentedPrintf(indent, "Version: %s\n", repo.Version)
 	fcli.IndentedPrintf(indent, "Provided by Git repository: %s\n", repo.VCSRepoPath)
 	fcli.IndentedPrintf(indent, "Path in cache: %s\n", pallets.GetSubdirPath(cache, repo.FS.Path()))
 	fcli.IndentedPrintf(indent, "Description: %s\n", repo.Def.Repository.Description)
-	// TODO: show the README file
+
+	readme, err := repo.LoadReadme()
+	if err != nil {
+		return errors.Wrapf(
+			err, "couldn't load readme file for Pallet repository %s@%s from cache",
+			repo.Path(), repo.Version,
+		)
+	}
+	fcli.IndentedPrintln(indent, "Readme:")
+	const widthLimit = 100
+	fcli.PrintReadme(indent+1, readme, widthLimit)
+	return nil
 }

--- a/pkg/pallets/repo.go
+++ b/pkg/pallets/repo.go
@@ -165,6 +165,16 @@ func (r *FSRepo) LoadFSPkgs(searchPattern string) ([]*FSPkg, error) {
 	return pkgs, nil
 }
 
+// LoadReadme loads the readme file defined by the repository.
+func (r *FSRepo) LoadReadme() ([]byte, error) {
+	readmePath := r.Def.Repository.ReadmeFile
+	bytes, err := fs.ReadFile(r.FS, readmePath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "couldn't read repo readme %s/%s", r.FS.Path(), readmePath)
+	}
+	return bytes, nil
+}
+
 // Repo
 
 // Path returns the Pallet repository path of the Repo instance.


### PR DESCRIPTION
This PR adds display of any Pallet repository's readme file in the `cache show-repo`, `env show-repo`, and `dev env show-repo` subcommands.