### PR TITLE
Sequence changes by dependency relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.1.10 - 2023-08-03
+
 ### Added
 
+- `env plan`, `dev env plan`, `env apply`, and `dev env apply` now return an error (and report the problems) if there are resource conflicts or missing resource dependencies (the same problems which would be reported by `env check` and `dev env check`).
 - `cache show-repo`, `env show-repo`, and `dev env show-repo` now print the Pallet repository's readme file, hard-wrapped to a max line length of 100 characters.
 
 ### Fixed
 
+- `env plan`, `dev env plan`, `env apply`, and `dev env apply` now account for the resource dependency relationships among package deployments when planning the sequence of changes to make to the Docker host, so that a Docker stack which requires a network provided by another Docker stack won't be deployed before that other Docker stack (since such a deployment would fail).
 - The `dev env add-repo` subcommand now makes any directories it needs to make in order to write repository requirement definition files to the appropriate locations.
 - File path separators should no longer be obviously incorrect on Windows systems (though they may still be incorrect, since Forklift is not tested on Windows).
 

--- a/cmd/forklift/main.go
+++ b/cmd/forklift/main.go
@@ -25,7 +25,7 @@ var app = &cli.App{
 	Name: "forklift",
 	// TODO: see if there's a way to get the version from a build tag, so that we don't have to update
 	// this manually
-	Version: "v0.1.9",
+	Version: "v0.1.10",
 	Usage:   "Manages Pallet repositories and package deployments",
 	Commands: []*cli.Command{
 		env.Cmd,

--- a/internal/app/forklift/constraints-models.go
+++ b/internal/app/forklift/constraints-models.go
@@ -15,6 +15,13 @@ type DeplConflict struct {
 	Services  []pallets.ResourceConflict[pallets.ServiceResource]
 }
 
+type SatisfiedDeplDependencies struct {
+	Depl *ResolvedDepl
+
+	Networks []pallets.SatisfiedResourceDependency[pallets.NetworkResource]
+	Services []pallets.SatisfiedResourceDependency[pallets.ServiceResource]
+}
+
 type MissingDeplDependencies struct {
 	Depl *ResolvedDepl
 

--- a/internal/app/forklift/constraints-models.go
+++ b/internal/app/forklift/constraints-models.go
@@ -10,21 +10,21 @@ type DeplConflict struct {
 
 	// Possible conflicts
 	Name      bool
-	Listeners []pallets.ResourceConflict[pallets.ListenerResource]
-	Networks  []pallets.ResourceConflict[pallets.NetworkResource]
-	Services  []pallets.ResourceConflict[pallets.ServiceResource]
+	Listeners []pallets.ResConflict[pallets.ListenerRes]
+	Networks  []pallets.ResConflict[pallets.NetworkRes]
+	Services  []pallets.ResConflict[pallets.ServiceRes]
 }
 
-type SatisfiedDeplDependencies struct {
+type SatisfiedDeplDeps struct {
 	Depl *ResolvedDepl
 
-	Networks []pallets.SatisfiedResourceDependency[pallets.NetworkResource]
-	Services []pallets.SatisfiedResourceDependency[pallets.ServiceResource]
+	Networks []pallets.SatisfiedResDep[pallets.NetworkRes]
+	Services []pallets.SatisfiedResDep[pallets.ServiceRes]
 }
 
-type MissingDeplDependencies struct {
+type MissingDeplDeps struct {
 	Depl *ResolvedDepl
 
-	Networks []pallets.MissingResourceDependency[pallets.NetworkResource]
-	Services []pallets.MissingResourceDependency[pallets.ServiceResource]
+	Networks []pallets.MissingResDep[pallets.NetworkRes]
+	Services []pallets.MissingResDep[pallets.ServiceRes]
 }

--- a/internal/app/forklift/constraints.go
+++ b/internal/app/forklift/constraints.go
@@ -23,30 +23,30 @@ func (c DeplConflict) HasConflict() bool {
 		c.HasListenerConflict() || c.HasNetworkConflict() || c.HasServiceConflict()
 }
 
-// SatisfiedDeplDependencies
+// SatisfiedDeplDeps
 
-func (d SatisfiedDeplDependencies) HasSatisfiedNetworkDependency() bool {
+func (d SatisfiedDeplDeps) HasSatisfiedNetworkDep() bool {
 	return len(d.Networks) > 0
 }
 
-func (d SatisfiedDeplDependencies) HasSatisfiedServiceDependency() bool {
+func (d SatisfiedDeplDeps) HasSatisfiedServiceDep() bool {
 	return len(d.Services) > 0
 }
 
-func (d SatisfiedDeplDependencies) HasSatisfiedDependency() bool {
-	return d.HasSatisfiedNetworkDependency() || d.HasSatisfiedServiceDependency()
+func (d SatisfiedDeplDeps) HasSatisfiedDep() bool {
+	return d.HasSatisfiedNetworkDep() || d.HasSatisfiedServiceDep()
 }
 
-// MissingDeplDependencies
+// MissingDeplDeps
 
-func (d MissingDeplDependencies) HasMissingNetworkDependency() bool {
+func (d MissingDeplDeps) HasMissingNetworkDep() bool {
 	return len(d.Networks) > 0
 }
 
-func (d MissingDeplDependencies) HasMissingServiceDependency() bool {
+func (d MissingDeplDeps) HasMissingServiceDep() bool {
 	return len(d.Services) > 0
 }
 
-func (d MissingDeplDependencies) HasMissingDependency() bool {
-	return d.HasMissingNetworkDependency() || d.HasMissingServiceDependency()
+func (d MissingDeplDeps) HasMissingDep() bool {
+	return d.HasMissingNetworkDep() || d.HasMissingServiceDep()
 }

--- a/internal/app/forklift/constraints.go
+++ b/internal/app/forklift/constraints.go
@@ -23,16 +23,30 @@ func (c DeplConflict) HasConflict() bool {
 		c.HasListenerConflict() || c.HasNetworkConflict() || c.HasServiceConflict()
 }
 
+// SatisfiedDeplDependencies
+
+func (d SatisfiedDeplDependencies) HasSatisfiedNetworkDependency() bool {
+	return len(d.Networks) > 0
+}
+
+func (d SatisfiedDeplDependencies) HasSatisfiedServiceDependency() bool {
+	return len(d.Services) > 0
+}
+
+func (d SatisfiedDeplDependencies) HasSatisfiedDependency() bool {
+	return d.HasSatisfiedNetworkDependency() || d.HasSatisfiedServiceDependency()
+}
+
 // MissingDeplDependencies
 
-func (c MissingDeplDependencies) HasMissingNetworkDependency() bool {
-	return len(c.Networks) > 0
+func (d MissingDeplDependencies) HasMissingNetworkDependency() bool {
+	return len(d.Networks) > 0
 }
 
-func (c MissingDeplDependencies) HasMissingServiceDependency() bool {
-	return len(c.Services) > 0
+func (d MissingDeplDependencies) HasMissingServiceDependency() bool {
+	return len(d.Services) > 0
 }
 
-func (c MissingDeplDependencies) HasMissingDependency() bool {
-	return c.HasMissingNetworkDependency() || c.HasMissingServiceDependency()
+func (d MissingDeplDependencies) HasMissingDependency() bool {
+	return d.HasMissingNetworkDependency() || d.HasMissingServiceDependency()
 }

--- a/internal/app/forklift/env-depl.go
+++ b/internal/app/forklift/env-depl.go
@@ -137,13 +137,13 @@ func (d *ResolvedDepl) CheckConflicts(candidate *ResolvedDepl) (DeplConflict, er
 		First:  d,
 		Second: candidate,
 		Name:   d.Name == candidate.Name,
-		Listeners: pallets.CheckResourcesConflicts(
+		Listeners: pallets.CheckResConflicts(
 			d.providedListeners(enabledFeatures), candidate.providedListeners(candidateEnabledFeatures),
 		),
-		Networks: pallets.CheckResourcesConflicts(
+		Networks: pallets.CheckResConflicts(
 			d.providedNetworks(enabledFeatures), candidate.providedNetworks(candidateEnabledFeatures),
 		),
-		Services: pallets.CheckResourcesConflicts(
+		Services: pallets.CheckResConflicts(
 			d.providedServices(enabledFeatures), candidate.providedServices(candidateEnabledFeatures),
 		),
 	}, nil
@@ -153,40 +153,40 @@ func (d *ResolvedDepl) CheckConflicts(candidate *ResolvedDepl) (DeplConflict, er
 // deployment, depending on the enabled features, with feature names as the keys of the map.
 func (d *ResolvedDepl) providedListeners(
 	enabledFeatures map[string]pallets.PkgFeatureSpec,
-) (provided []pallets.AttachedResource[pallets.ListenerResource]) {
-	return d.Pkg.ProvidedListeners(d.ResourceAttachmentSource(), sortKeys(enabledFeatures))
+) (provided []pallets.AttachedRes[pallets.ListenerRes]) {
+	return d.Pkg.ProvidedListeners(d.ResAttachmentSource(), sortKeys(enabledFeatures))
 }
 
 // requiredNetworks returns a slice of all Docker networks required by the Pallet package
 // deployment, depending on the enabled features, with feature names as the keys of the map.
 func (d *ResolvedDepl) requiredNetworks(
 	enabledFeatures map[string]pallets.PkgFeatureSpec,
-) (required []pallets.AttachedResource[pallets.NetworkResource]) {
-	return d.Pkg.RequiredNetworks(d.ResourceAttachmentSource(), sortKeys(enabledFeatures))
+) (required []pallets.AttachedRes[pallets.NetworkRes]) {
+	return d.Pkg.RequiredNetworks(d.ResAttachmentSource(), sortKeys(enabledFeatures))
 }
 
 // providedNetworks returns a slice of all Docker networks provided by the Pallet package
 // deployment, depending on the enabled features, with feature names as the keys of the map.
 func (d *ResolvedDepl) providedNetworks(
 	enabledFeatures map[string]pallets.PkgFeatureSpec,
-) (provided []pallets.AttachedResource[pallets.NetworkResource]) {
-	return d.Pkg.ProvidedNetworks(d.ResourceAttachmentSource(), sortKeys(enabledFeatures))
+) (provided []pallets.AttachedRes[pallets.NetworkRes]) {
+	return d.Pkg.ProvidedNetworks(d.ResAttachmentSource(), sortKeys(enabledFeatures))
 }
 
 // requiredServices returns a slice of all network services required by the Pallet package
 // deployment, depending on the enabled features, with feature names as the keys of the map.
 func (d *ResolvedDepl) requiredServices(
 	enabledFeatures map[string]pallets.PkgFeatureSpec,
-) (required []pallets.AttachedResource[pallets.ServiceResource]) {
-	return d.Pkg.RequiredServices(d.ResourceAttachmentSource(), sortKeys(enabledFeatures))
+) (required []pallets.AttachedRes[pallets.ServiceRes]) {
+	return d.Pkg.RequiredServices(d.ResAttachmentSource(), sortKeys(enabledFeatures))
 }
 
 // providedServices returns a slice of all network services provided by the Pallet package
 // deployment, depending on the enabled features, with feature names as the keys of the map.
 func (d *ResolvedDepl) providedServices(
 	enabledFeatures map[string]pallets.PkgFeatureSpec,
-) (provided []pallets.AttachedResource[pallets.ServiceResource]) {
-	return d.Pkg.ProvidedServices(d.ResourceAttachmentSource(), sortKeys(enabledFeatures))
+) (provided []pallets.AttachedRes[pallets.ServiceRes]) {
+	return d.Pkg.ProvidedServices(d.ResAttachmentSource(), sortKeys(enabledFeatures))
 }
 
 // CheckAllConflicts produces a slice of reports of all resource conflicts between the ResolvedDepl
@@ -207,14 +207,14 @@ func (d *ResolvedDepl) CheckAllConflicts(
 	return conflicts, nil
 }
 
-// CheckDependencies produces a report of all resource requirements from the ResolvedDepl
+// CheckDeps produces a report of all resource requirements from the ResolvedDepl
 // instance and which were and were not met by any candidate ResolvedDepl.
-func (d *ResolvedDepl) CheckDependencies(
+func (d *ResolvedDepl) CheckDeps(
 	candidates []*ResolvedDepl,
-) (SatisfiedDeplDependencies, MissingDeplDependencies, error) {
+) (SatisfiedDeplDeps, MissingDeplDeps, error) {
 	enabledFeatures, err := d.EnabledFeatures()
 	if err != nil {
-		return SatisfiedDeplDependencies{}, MissingDeplDependencies{}, errors.Errorf(
+		return SatisfiedDeplDeps{}, MissingDeplDeps{}, errors.Errorf(
 			"couldn't determine enabled features of deployment %s", d.Name,
 		)
 	}
@@ -222,7 +222,7 @@ func (d *ResolvedDepl) CheckDependencies(
 	for _, candidate := range candidates {
 		f, err := candidate.EnabledFeatures()
 		if err != nil {
-			return SatisfiedDeplDependencies{}, MissingDeplDependencies{}, errors.Errorf(
+			return SatisfiedDeplDeps{}, MissingDeplDeps{}, errors.Errorf(
 				"couldn't determine enabled features of deployment %s", candidate.Name,
 			)
 		}
@@ -230,8 +230,8 @@ func (d *ResolvedDepl) CheckDependencies(
 	}
 
 	var (
-		allProvidedNetworks []pallets.AttachedResource[pallets.NetworkResource]
-		allProvidedServices []pallets.AttachedResource[pallets.ServiceResource]
+		allProvidedNetworks []pallets.AttachedRes[pallets.NetworkRes]
+		allProvidedServices []pallets.AttachedRes[pallets.ServiceRes]
 	)
 	for i, candidate := range candidates {
 		allProvidedNetworks = append(
@@ -242,17 +242,17 @@ func (d *ResolvedDepl) CheckDependencies(
 		)
 	}
 
-	satisfiedNetworkDeps, missingNetworkDeps := pallets.CheckResourcesDependencies(
+	satisfiedNetworkDeps, missingNetworkDeps := pallets.CheckResDeps(
 		d.requiredNetworks(enabledFeatures), allProvidedNetworks,
 	)
-	satisfiedServiceDeps, missingServiceDeps := pallets.CheckResourcesDependencies(
+	satisfiedServiceDeps, missingServiceDeps := pallets.CheckResDeps(
 		pallets.SplitServicesByPath(d.requiredServices(enabledFeatures)), allProvidedServices,
 	)
-	return SatisfiedDeplDependencies{
+	return SatisfiedDeplDeps{
 			Depl:     d,
 			Networks: satisfiedNetworkDeps,
 			Services: satisfiedServiceDeps,
-		}, MissingDeplDependencies{
+		}, MissingDeplDeps{
 			Depl:     d,
 			Networks: missingNetworkDeps,
 			Services: missingServiceDeps,
@@ -272,17 +272,17 @@ func CheckDeplConflicts(depls []*ResolvedDepl) (conflicts []DeplConflict, err er
 	return conflicts, nil
 }
 
-// CheckDeplDependencies produces reports of all satisfied and unsatisfied resource dependencies
+// CheckDeplDeps produces reports of all satisfied and unsatisfied resource dependencies
 // among all provided ResolvedDepl instances.
-func CheckDeplDependencies(
+func CheckDeplDeps(
 	depls []*ResolvedDepl,
-) (satisfiedDeps []SatisfiedDeplDependencies, missingDeps []MissingDeplDependencies, err error) {
+) (satisfiedDeps []SatisfiedDeplDeps, missingDeps []MissingDeplDeps, err error) {
 	for _, depl := range depls {
-		satisfied, missing, err := depl.CheckDependencies(depls)
+		satisfied, missing, err := depl.CheckDeps(depls)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "couldn't check dependencies of deployment %s", depl.Name)
 		}
-		if missing.HasMissingDependency() {
+		if missing.HasMissingDep() {
 			missingDeps = append(missingDeps, missing)
 			continue
 		}
@@ -335,9 +335,9 @@ func loadDepls(fsys pallets.PathedFS, searchPattern string) ([]Depl, error) {
 	return depls, nil
 }
 
-// ResourceAttachmentSource returns the source path for resources under the Depl instance.
-// The resulting slice is useful for constructing [pallets.AttachedResource] instances.
-func (d *Depl) ResourceAttachmentSource() []string {
+// ResAttachmentSource returns the source path for resources under the Depl instance.
+// The resulting slice is useful for constructing [pallets.AttachedRes] instances.
+func (d *Depl) ResAttachmentSource() []string {
 	return []string{
 		fmt.Sprintf("deployment %s", d.Name),
 	}

--- a/pkg/pallets/constraints-models.go
+++ b/pkg/pallets/constraints-models.go
@@ -1,9 +1,9 @@
 package pallets
 
-// An AttachedResource is a binding between a resource and the source of that resource.
-type AttachedResource[Resource interface{}] struct {
-	// Resource is a resource subject to various possible constraints.
-	Resource Resource
+// An AttachedRes is a binding between a resource and the source of that resource.
+type AttachedRes[Res interface{}] struct {
+	// Res is a resource subject to various possible constraints.
+	Res Res
 	// Source is a list of strings describing how to locate the resource in a package spec, to be
 	// shown to users when a resource constraint is not met. Typically the elements of the list will
 	// correspond to the parts of a path.
@@ -15,53 +15,53 @@ type AttachedResource[Resource interface{}] struct {
 // A ConflictChecker is something which may conflict with a resource, and which can determine
 // whether it conflicts with another resource. Typically, resource types will implement this
 // interface.
-type ConflictChecker[Resource interface{}] interface {
-	CheckConflict(candidate Resource) []error
+type ConflictChecker[Res interface{}] interface {
+	CheckConflict(candidate Res) []error
 }
 
-// A ResourceConflict is a report of a conflict between two resources.
-type ResourceConflict[Resource interface{}] struct {
+// A ResConflict is a report of a conflict between two resources.
+type ResConflict[Res interface{}] struct {
 	// First is one of the two conflicting resources.
-	First AttachedResource[Resource]
+	First AttachedRes[Res]
 	// Second is the other of the two conflicting resources.
-	Second AttachedResource[Resource]
+	Second AttachedRes[Res]
 	// Errs is a list of errors describing how the two resources conflict with each other.
 	Errs []error
 }
 
 // Resource dependencies
 
-// A DependencyChecker is something which may depend on a resource, and which can determine whether
+// A DepChecker is something which may depend on a resource, and which can determine whether
 // its dependency is satisfied by a resource. Typically, resource requirement types will implement
 // this interface.
-type DependencyChecker[Resource interface{}] interface {
-	CheckDependency(candidate Resource) []error
+type DepChecker[Res interface{}] interface {
+	CheckDep(candidate Res) []error
 }
 
-// A SatisfiedResourceDependency is a report of a resource requirement which is satisfied by a set
+// A SatisfiedResDep is a report of a resource requirement which is satisfied by a set
 // of resources.
-type SatisfiedResourceDependency[Resource interface{}] struct {
+type SatisfiedResDep[Res interface{}] struct {
 	// Required is the resource requirement.
-	Required AttachedResource[Resource]
+	Required AttachedRes[Res]
 	// Provided is the resource which satisfies the resource requirement.
-	Provided AttachedResource[Resource]
+	Provided AttachedRes[Res]
 }
 
-// A MissingResourceDependency is a report of a resource requirement which is not satisfied by any
+// A MissingResDep is a report of a resource requirement which is not satisfied by any
 // resources.
-type MissingResourceDependency[Resource interface{}] struct {
+type MissingResDep[Res interface{}] struct {
 	// Required is the resource requirement.
-	Required AttachedResource[Resource]
+	Required AttachedRes[Res]
 	// BestCandidates is a list of the resources which are closest to satisfying the resource
 	// requirement.
-	BestCandidates []ResourceDependencyCandidate[Resource]
+	BestCandidates []ResDepCandidate[Res]
 }
 
-// ResourceDependencyCandidate is a report of a resource which either satisfied a resource
+// ResDepCandidate is a report of a resource which either satisfied a resource
 // requirement or (if Errs contains errors) failed to satisfy that resource requirement.
-type ResourceDependencyCandidate[Resource interface{}] struct {
+type ResDepCandidate[Res interface{}] struct {
 	// Provided is the resource which did not satisfy the requirement.
-	Provided AttachedResource[Resource]
+	Provided AttachedRes[Res]
 	// Errs is a list of errors describing how the resource did not satisfy the requirement.
 	Errs []error
 }

--- a/pkg/pallets/constraints-models.go
+++ b/pkg/pallets/constraints-models.go
@@ -38,6 +38,15 @@ type DependencyChecker[Resource interface{}] interface {
 	CheckDependency(candidate Resource) []error
 }
 
+// A SatisfiedResourceDependency is a report of a resource requirement which is satisfied by a set
+// of resources.
+type SatisfiedResourceDependency[Resource interface{}] struct {
+	// Required is the resource requirement.
+	Required AttachedResource[Resource]
+	// Provided is the resource which satisfies the resource requirement.
+	Provided AttachedResource[Resource]
+}
+
 // A MissingResourceDependency is a report of a resource requirement which is not satisfied by any
 // resources.
 type MissingResourceDependency[Resource interface{}] struct {
@@ -48,7 +57,8 @@ type MissingResourceDependency[Resource interface{}] struct {
 	BestCandidates []ResourceDependencyCandidate[Resource]
 }
 
-// ResourceDependencyCandidate is a report of a resource which failed to satisfy a resource requirement.
+// ResourceDependencyCandidate is a report of a resource which either satisfied a resource
+// requirement or (if Errs contains errors) failed to satisfy that resource requirement.
 type ResourceDependencyCandidate[Resource interface{}] struct {
 	// Provided is the resource which did not satisfy the requirement.
 	Provided AttachedResource[Resource]

--- a/pkg/pallets/constraints.go
+++ b/pkg/pallets/constraints.go
@@ -1,16 +1,16 @@
 package pallets
 
-// AttachedResource
+// AttachedRes
 
-// attachResources attaches the specified source to all of the specified resources.
-func attachResources[Resource any](
-	resources []Resource, source []string,
-) (attached []AttachedResource[Resource]) {
-	attached = make([]AttachedResource[Resource], 0, len(resources))
+// attachRes attaches the specified source to all of the specified resources.
+func attachRes[Res any](
+	resources []Res, source []string,
+) (attached []AttachedRes[Res]) {
+	attached = make([]AttachedRes[Res], 0, len(resources))
 	for _, resource := range resources {
-		attached = append(attached, AttachedResource[Resource]{
-			Resource: resource,
-			Source:   source,
+		attached = append(attached, AttachedRes[Res]{
+			Res:    resource,
+			Source: source,
 		})
 	}
 	return attached
@@ -18,16 +18,16 @@ func attachResources[Resource any](
 
 // Resource conflicts
 
-// CheckResourcesConflicts identifies all resource conflicts between the first list of resources and
+// CheckResConflicts identifies all resource conflicts between the first list of resources and
 // the second list of resources. It does not identify resource conflicts within the first list of
 // resources, nor within the second list of resources.
-func CheckResourcesConflicts[Resource ConflictChecker[Resource]](
-	first []AttachedResource[Resource], second []AttachedResource[Resource],
-) (conflicts []ResourceConflict[Resource]) {
+func CheckResConflicts[Res ConflictChecker[Res]](
+	first []AttachedRes[Res], second []AttachedRes[Res],
+) (conflicts []ResConflict[Res]) {
 	for _, f := range first {
 		for _, s := range second {
-			if errs := f.Resource.CheckConflict(s.Resource); errs != nil {
-				conflicts = append(conflicts, ResourceConflict[Resource]{
+			if errs := f.Res.CheckConflict(s.Res); errs != nil {
+				conflicts = append(conflicts, ResConflict[Res]{
 					First:  f,
 					Second: s,
 					Errs:   errs,
@@ -40,39 +40,39 @@ func CheckResourcesConflicts[Resource ConflictChecker[Resource]](
 
 // Resource dependencies
 
-// CheckResourcesDependencies identifies all unsatisfied resource dependencies between the provided
+// CheckResDeps identifies all unsatisfied resource dependencies between the provided
 // list of resource requirements and the provided list of resources.
-func CheckResourcesDependencies[Resource DependencyChecker[Resource]](
-	required []AttachedResource[Resource], provided []AttachedResource[Resource],
+func CheckResDeps[Res DepChecker[Res]](
+	required []AttachedRes[Res], provided []AttachedRes[Res],
 ) (
-	satisfied []SatisfiedResourceDependency[Resource], missing []MissingResourceDependency[Resource],
+	satisfied []SatisfiedResDep[Res], missing []MissingResDep[Res],
 ) {
 	for _, r := range required {
 		bestErrsCount := -1
-		bestCandidates := make([]ResourceDependencyCandidate[Resource], 0, len(provided))
+		bestCandidates := make([]ResDepCandidate[Res], 0, len(provided))
 		for i, p := range provided {
-			errs := r.Resource.CheckDependency(p.Resource)
+			errs := r.Res.CheckDep(p.Res)
 			if bestErrsCount != -1 && len(errs) > bestErrsCount {
 				continue
 			}
 			if bestErrsCount == -1 || len(errs) < bestErrsCount {
 				// we've found a provided resource which is strictly better than all previous candidates
 				bestErrsCount = len(errs)
-				bestCandidates = make([]ResourceDependencyCandidate[Resource], 0, len(provided)-i)
+				bestCandidates = make([]ResDepCandidate[Res], 0, len(provided)-i)
 			}
-			bestCandidates = append(bestCandidates, ResourceDependencyCandidate[Resource]{
+			bestCandidates = append(bestCandidates, ResDepCandidate[Res]{
 				Provided: p,
 				Errs:     errs,
 			})
 		}
 		if bestErrsCount != 0 {
-			missing = append(missing, MissingResourceDependency[Resource]{
+			missing = append(missing, MissingResDep[Res]{
 				Required:       r,
 				BestCandidates: bestCandidates,
 			})
 			continue
 		}
-		satisfied = append(satisfied, SatisfiedResourceDependency[Resource]{
+		satisfied = append(satisfied, SatisfiedResDep[Res]{
 			Required: r,
 			Provided: bestCandidates[0].Provided,
 		})

--- a/pkg/pallets/pkg-models.go
+++ b/pkg/pallets/pkg-models.go
@@ -68,7 +68,7 @@ type PkgHostSpec struct {
 	// Tags is a list of strings associated with the host.
 	Tags []string `yaml:"tags,omitempty"`
 	// Provides describes resources ambiently provided by the Docker host.
-	Provides ProvidedResources `yaml:"provides,omitempty"`
+	Provides ProvidedRes `yaml:"provides,omitempty"`
 }
 
 // PkgDeplSpec contains information about any deployment of the Pallet package.
@@ -80,9 +80,9 @@ type PkgDeplSpec struct {
 	Tags []string `yaml:"tags,omitempty"`
 	// Provides describes resource requirements which must be met for a deployment of the package to
 	// succeed.
-	Requires RequiredResources `yaml:"requires,omitempty"`
+	Requires RequiredRes `yaml:"requires,omitempty"`
 	// Provides describes resources provided by a successful deployment of the package.
-	Provides ProvidedResources `yaml:"provides,omitempty"`
+	Provides ProvidedRes `yaml:"provides,omitempty"`
 }
 
 // PkgFeatureSpec defines an optional feature of the Pallet package.
@@ -93,34 +93,34 @@ type PkgFeatureSpec struct {
 	Tags []string `yaml:"tags,omitempty"`
 	// Provides describes resource requirements which must be met for a deployment of the package to
 	// succeed, if the feature is enabled.
-	Requires RequiredResources `yaml:"requires,omitempty"`
+	Requires RequiredRes `yaml:"requires,omitempty"`
 	// Provides describes resources provided by a successful deployment of the package, if the feature
 	// is enabled.
-	Provides ProvidedResources `yaml:"provides,omitempty"`
+	Provides ProvidedRes `yaml:"provides,omitempty"`
 }
 
 // Resources
 
-// RequiredResources describes a set of resource requirements for some aspect of a Pallet package.
-type RequiredResources struct {
+// RequiredRes describes a set of resource requirements for some aspect of a Pallet package.
+type RequiredRes struct {
 	// Networks is a list of requirements for Docker networks.
-	Networks []NetworkResource `yaml:"networks,omitempty"`
+	Networks []NetworkRes `yaml:"networks,omitempty"`
 	// Services is a list of requirements for network services.
-	Services []ServiceResource `yaml:"services,omitempty"`
+	Services []ServiceRes `yaml:"services,omitempty"`
 }
 
-// ProvidedResources describes a set of resources provided by some aspect of a Pallet package.
-type ProvidedResources struct {
+// ProvidedRes describes a set of resources provided by some aspect of a Pallet package.
+type ProvidedRes struct {
 	// Listeners is a list of host port listeners.
-	Listeners []ListenerResource `yaml:"listeners,omitempty"`
+	Listeners []ListenerRes `yaml:"listeners,omitempty"`
 	// Networks is a list of Docker networks.
-	Networks []NetworkResource `yaml:"networks,omitempty"`
+	Networks []NetworkRes `yaml:"networks,omitempty"`
 	// Services is a list of network services.
-	Services []ServiceResource `yaml:"services,omitempty"`
+	Services []ServiceRes `yaml:"services,omitempty"`
 }
 
-// ListenerResource describes a host port listener.
-type ListenerResource struct {
+// ListenerRes describes a host port listener.
+type ListenerRes struct {
 	// Description is a short description of the host port listener to be shown to users.
 	Description string `yaml:"description,omitempty"`
 	// Port is the port number which the host port listener is bound to.
@@ -130,16 +130,16 @@ type ListenerResource struct {
 	Protocol string `yaml:"protocol,omitempty"`
 }
 
-// NetworkResource describes a Docker network.
-type NetworkResource struct {
+// NetworkRes describes a Docker network.
+type NetworkRes struct {
 	// Description is a short description of the Docker network to be shown to users.
 	Description string `yaml:"description,omitempty"`
 	// Name is the name of the Docker network.
 	Name string `yaml:"name,omitempty"`
 }
 
-// ServiceResource describes a network service.
-type ServiceResource struct {
+// ServiceRes describes a network service.
+type ServiceRes struct {
 	// Description is a short description of the network service to be shown to users.
 	Description string `yaml:"description,omitempty"`
 	// Port is the network port used for accessing the service.

--- a/pkg/pallets/pkg-resources.go
+++ b/pkg/pallets/pkg-resources.go
@@ -7,55 +7,55 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ProvidedResources
+// ProvidedRes
 
 const (
 	providesSourcePart = "provides resource"
 	requiresSourcePart = "requires resource"
 )
 
-// AttachedListeners returns a list of [AttachedResource] instances for each respective host port
-// listener in the ProvidedResources instance, adding a string to the provided list of source
-// elements which describes the source of the ProvidedResources instance.
-func (r ProvidedResources) AttachedListeners(source []string) []AttachedResource[ListenerResource] {
-	return attachResources(r.Listeners, append(source, providesSourcePart))
+// AttachedListeners returns a list of [AttachedRes] instances for each respective host port
+// listener in the ProvidedRes instance, adding a string to the provided list of source
+// elements which describes the source of the ProvidedRes instance.
+func (r ProvidedRes) AttachedListeners(source []string) []AttachedRes[ListenerRes] {
+	return attachRes(r.Listeners, append(source, providesSourcePart))
 }
 
-// AttachedNetworks returns a list of [AttachedResource] instances for each respective Docker
-// network in the ProvidedResources instance, adding a string to the provided list of source
-// elements which describes the source of the ProvidedResources instance.
-func (r ProvidedResources) AttachedNetworks(source []string) []AttachedResource[NetworkResource] {
-	return attachResources(r.Networks, append(source, providesSourcePart))
+// AttachedNetworks returns a list of [AttachedRes] instances for each respective Docker
+// network in the ProvidedRes instance, adding a string to the provided list of source
+// elements which describes the source of the ProvidedRes instance.
+func (r ProvidedRes) AttachedNetworks(source []string) []AttachedRes[NetworkRes] {
+	return attachRes(r.Networks, append(source, providesSourcePart))
 }
 
-// AttachedServices returns a list of [AttachedResource] instances for each respective network
-// service in the ProvidedResources instance, adding a string to the provided list of source
-// elements which describes the source of the ProvidedResources instance.
-func (r ProvidedResources) AttachedServices(source []string) []AttachedResource[ServiceResource] {
-	return attachResources(r.Services, append(source, providesSourcePart))
+// AttachedServices returns a list of [AttachedRes] instances for each respective network
+// service in the ProvidedRes instance, adding a string to the provided list of source
+// elements which describes the source of the ProvidedRes instance.
+func (r ProvidedRes) AttachedServices(source []string) []AttachedRes[ServiceRes] {
+	return attachRes(r.Services, append(source, providesSourcePart))
 }
 
-// RequiredResources
+// RequiredRes
 
-// AttachedNetworks returns a list of [AttachedResource] instances for each respective Docker
-// network resource requirement in the RequiredResources instance, adding a string to the provided
-// list of source elements which describes the source of the RequiredResources instance.
-func (r RequiredResources) AttachedNetworks(source []string) []AttachedResource[NetworkResource] {
-	return attachResources(r.Networks, append(source, requiresSourcePart))
+// AttachedNetworks returns a list of [AttachedRes] instances for each respective Docker
+// network resource requirement in the RequiredRes instance, adding a string to the provided
+// list of source elements which describes the source of the RequiredRes instance.
+func (r RequiredRes) AttachedNetworks(source []string) []AttachedRes[NetworkRes] {
+	return attachRes(r.Networks, append(source, requiresSourcePart))
 }
 
-// AttachedServices returns a list of [AttachedResource] instances for each respective network
-// service resource requirement in the RequiredResources instance, adding a string to the provided
-// list of source elements which describes the source of the RequiredResources instance.
-func (r RequiredResources) AttachedServices(source []string) []AttachedResource[ServiceResource] {
-	return attachResources(r.Services, append(source, requiresSourcePart))
+// AttachedServices returns a list of [AttachedRes] instances for each respective network
+// service resource requirement in the RequiredRes instance, adding a string to the provided
+// list of source elements which describes the source of the RequiredRes instance.
+func (r RequiredRes) AttachedServices(source []string) []AttachedRes[ServiceRes] {
+	return attachRes(r.Services, append(source, requiresSourcePart))
 }
 
-// ListenerResource
+// ListenerRes
 
-// CheckDependency checks whether the host port listener resource requirement, represented by the
-// ListenerResource instance, is satisfied by the candidate host port listener resource.
-func (r ListenerResource) CheckDependency(candidate ListenerResource) (errs []error) {
+// CheckDep checks whether the host port listener resource requirement, represented by the
+// ListenerRes instance, is satisfied by the candidate host port listener resource.
+func (r ListenerRes) CheckDep(candidate ListenerRes) (errs []error) {
 	if r.Port != candidate.Port {
 		errs = append(errs, fmt.Errorf("unmatched port '%d'", r.Port))
 	}
@@ -65,40 +65,40 @@ func (r ListenerResource) CheckDependency(candidate ListenerResource) (errs []er
 	return errs
 }
 
-// CheckConflict checks whether the host port listener resource, represented by the ListenerResource
+// CheckConflict checks whether the host port listener resource, represented by the ListenerRes
 // instance, conflicts with the candidate host port listener resource.
-func (r ListenerResource) CheckConflict(candidate ListenerResource) (errs []error) {
+func (r ListenerRes) CheckConflict(candidate ListenerRes) (errs []error) {
 	if r.Port == candidate.Port && r.Protocol == candidate.Protocol {
 		errs = append(errs, fmt.Errorf("same port/protocol '%d/%s'", r.Port, r.Protocol))
 	}
 	return errs
 }
 
-// NetworkResource
+// NetworkRes
 
-// CheckDependency checks whether the Docker network resource requirement, represented by the
-// NetworkResource instance, is satisfied by the candidate Docker network resource.
-func (r NetworkResource) CheckDependency(candidate NetworkResource) (errs []error) {
+// CheckDep checks whether the Docker network resource requirement, represented by the
+// NetworkRes instance, is satisfied by the candidate Docker network resource.
+func (r NetworkRes) CheckDep(candidate NetworkRes) (errs []error) {
 	if r.Name != candidate.Name {
 		errs = append(errs, fmt.Errorf("unmatched name '%s'", r.Name))
 	}
 	return errs
 }
 
-// CheckConflict checks whether the Docker network resource, represented by the NetworkResource
+// CheckConflict checks whether the Docker network resource, represented by the NetworkRes
 // instance, conflicts with the candidate Docker network resource.
-func (r NetworkResource) CheckConflict(candidate NetworkResource) (errs []error) {
+func (r NetworkRes) CheckConflict(candidate NetworkRes) (errs []error) {
 	if r.Name == candidate.Name {
 		errs = append(errs, fmt.Errorf("same name '%s'", r.Name))
 	}
 	return errs
 }
 
-// ServiceResource
+// ServiceRes
 
-// CheckDependency checks whether the network service resource requirement, represented by the
-// ServiceResource instance, is satisfied by the candidate network service resource.
-func (r ServiceResource) CheckDependency(candidate ServiceResource) (errs []error) {
+// CheckDep checks whether the network service resource requirement, represented by the
+// ServiceRes instance, is satisfied by the candidate network service resource.
+func (r ServiceRes) CheckDep(candidate ServiceRes) (errs []error) {
 	if r.Port != candidate.Port {
 		errs = append(errs, fmt.Errorf("unmatched port '%d'", r.Port))
 	}
@@ -163,9 +163,9 @@ func pathMatchesPrefix(path string, pathPrefixes map[string]struct{}) (match boo
 	return false, ""
 }
 
-// CheckConflict checks whether the network service resource, represented by the ServiceResource
+// CheckConflict checks whether the network service resource, represented by the ServiceRes
 // instance, conflicts with the candidate network service resource.
-func (r ServiceResource) CheckConflict(candidate ServiceResource) (errs []error) {
+func (r ServiceRes) CheckConflict(candidate ServiceRes) (errs []error) {
 	if r.Port != candidate.Port || r.Protocol != candidate.Protocol {
 		return nil
 	}
@@ -235,20 +235,18 @@ func checkConflictingPaths(provided, candidate []string) (errs []error) {
 // SplitServicesByPath produces a slice of network service resources from the input slice, where
 // each network service resource in the input slice with multiple paths results in multiple
 // corresponding network service resources with one path each.
-func SplitServicesByPath(
-	serviceResources []AttachedResource[ServiceResource],
-) (split []AttachedResource[ServiceResource]) {
-	split = make([]AttachedResource[ServiceResource], 0, len(serviceResources))
-	for _, service := range serviceResources {
-		if len(service.Resource.Paths) == 0 {
+func SplitServicesByPath(serviceRes []AttachedRes[ServiceRes]) (split []AttachedRes[ServiceRes]) {
+	split = make([]AttachedRes[ServiceRes], 0, len(serviceRes))
+	for _, service := range serviceRes {
+		if len(service.Res.Paths) == 0 {
 			split = append(split, service)
 		}
-		for _, path := range service.Resource.Paths {
-			pathService := service.Resource
+		for _, path := range service.Res.Paths {
+			pathService := service.Res
 			pathService.Paths = []string{path}
-			split = append(split, AttachedResource[ServiceResource]{
-				Resource: pathService,
-				Source:   service.Source,
+			split = append(split, AttachedRes[ServiceRes]{
+				Res:    pathService,
+				Source: service.Source,
 			})
 		}
 	}

--- a/pkg/pallets/pkg.go
+++ b/pkg/pallets/pkg.go
@@ -125,9 +125,9 @@ func (p Pkg) Check() (errs []error) {
 	return errs
 }
 
-// ResourceAttachmentSource returns the source path for resources under the Pkg instance.
-// The resulting slice is useful for constructing [AttachedResource] instances.
-func (p Pkg) ResourceAttachmentSource(parentSource []string) []string {
+// ResAttachmentSource returns the source path for resources under the Pkg instance.
+// The resulting slice is useful for constructing [AttachedRes] instances.
+func (p Pkg) ResAttachmentSource(parentSource []string) []string {
 	return append(parentSource, fmt.Sprintf("package %s", p.Path()))
 }
 
@@ -135,19 +135,19 @@ func (p Pkg) ResourceAttachmentSource(parentSource []string) []string {
 // Pallet package with the specified features enabled.
 func (p Pkg) ProvidedListeners(
 	parentSource []string, enabledFeatures []string,
-) (provided []AttachedResource[ListenerResource]) {
-	parentSource = p.ResourceAttachmentSource(parentSource)
+) (provided []AttachedRes[ListenerRes]) {
+	parentSource = p.ResAttachmentSource(parentSource)
 	provided = append(provided, p.Def.Host.Provides.AttachedListeners(
-		p.Def.Host.ResourceAttachmentSource(parentSource),
+		p.Def.Host.ResAttachmentSource(parentSource),
 	)...)
 	provided = append(provided, p.Def.Deployment.Provides.AttachedListeners(
-		p.Def.Deployment.ResourceAttachmentSource(parentSource),
+		p.Def.Deployment.ResAttachmentSource(parentSource),
 	)...)
 
 	for _, featureName := range enabledFeatures {
 		feature := p.Def.Features[featureName]
 		provided = append(provided, feature.Provides.AttachedListeners(
-			feature.ResourceAttachmentSource(parentSource, featureName),
+			feature.ResAttachmentSource(parentSource, featureName),
 		)...)
 	}
 	return provided
@@ -157,16 +157,16 @@ func (p Pkg) ProvidedListeners(
 // package with the specified features enabled.
 func (p Pkg) RequiredNetworks(
 	parentSource []string, enabledFeatures []string,
-) (required []AttachedResource[NetworkResource]) {
-	parentSource = p.ResourceAttachmentSource(parentSource)
+) (required []AttachedRes[NetworkRes]) {
+	parentSource = p.ResAttachmentSource(parentSource)
 	required = append(required, p.Def.Deployment.Requires.AttachedNetworks(
-		p.Def.Deployment.ResourceAttachmentSource(parentSource),
+		p.Def.Deployment.ResAttachmentSource(parentSource),
 	)...)
 
 	for _, featureName := range enabledFeatures {
 		feature := p.Def.Features[featureName]
 		required = append(required, feature.Requires.AttachedNetworks(
-			feature.ResourceAttachmentSource(parentSource, featureName),
+			feature.ResAttachmentSource(parentSource, featureName),
 		)...)
 	}
 	return required
@@ -176,19 +176,19 @@ func (p Pkg) RequiredNetworks(
 // package with the specified features enabled.
 func (p Pkg) ProvidedNetworks(
 	parentSource []string, enabledFeatures []string,
-) (provided []AttachedResource[NetworkResource]) {
-	parentSource = p.ResourceAttachmentSource(parentSource)
+) (provided []AttachedRes[NetworkRes]) {
+	parentSource = p.ResAttachmentSource(parentSource)
 	provided = append(provided, p.Def.Host.Provides.AttachedNetworks(
-		p.Def.Host.ResourceAttachmentSource(parentSource),
+		p.Def.Host.ResAttachmentSource(parentSource),
 	)...)
 	provided = append(provided, p.Def.Deployment.Provides.AttachedNetworks(
-		p.Def.Deployment.ResourceAttachmentSource(parentSource),
+		p.Def.Deployment.ResAttachmentSource(parentSource),
 	)...)
 
 	for _, featureName := range enabledFeatures {
 		feature := p.Def.Features[featureName]
 		provided = append(provided, feature.Provides.AttachedNetworks(
-			feature.ResourceAttachmentSource(parentSource, featureName),
+			feature.ResAttachmentSource(parentSource, featureName),
 		)...)
 	}
 	return provided
@@ -198,16 +198,16 @@ func (p Pkg) ProvidedNetworks(
 // package with the specified features enabled.
 func (p Pkg) RequiredServices(
 	parentSource []string, enabledFeatures []string,
-) (required []AttachedResource[ServiceResource]) {
-	parentSource = p.ResourceAttachmentSource(parentSource)
+) (required []AttachedRes[ServiceRes]) {
+	parentSource = p.ResAttachmentSource(parentSource)
 	required = append(required, p.Def.Deployment.Requires.AttachedServices(
-		p.Def.Deployment.ResourceAttachmentSource(parentSource),
+		p.Def.Deployment.ResAttachmentSource(parentSource),
 	)...)
 
 	for _, featureName := range enabledFeatures {
 		feature := p.Def.Features[featureName]
 		required = append(required, feature.Requires.AttachedServices(
-			feature.ResourceAttachmentSource(parentSource, featureName),
+			feature.ResAttachmentSource(parentSource, featureName),
 		)...)
 	}
 	return required
@@ -217,19 +217,19 @@ func (p Pkg) RequiredServices(
 // package with the specified features enabled.
 func (p Pkg) ProvidedServices(
 	parentSource []string, enabledFeatures []string,
-) (provided []AttachedResource[ServiceResource]) {
-	parentSource = p.ResourceAttachmentSource(parentSource)
+) (provided []AttachedRes[ServiceRes]) {
+	parentSource = p.ResAttachmentSource(parentSource)
 	provided = append(provided, p.Def.Host.Provides.AttachedServices(
-		p.Def.Host.ResourceAttachmentSource(parentSource),
+		p.Def.Host.ResAttachmentSource(parentSource),
 	)...)
 	provided = append(provided, p.Def.Deployment.Provides.AttachedServices(
-		p.Def.Deployment.ResourceAttachmentSource(parentSource),
+		p.Def.Deployment.ResAttachmentSource(parentSource),
 	)...)
 
 	for _, featureName := range enabledFeatures {
 		feature := p.Def.Features[featureName]
 		provided = append(provided, feature.Provides.AttachedServices(
-			feature.ResourceAttachmentSource(parentSource, featureName),
+			feature.ResAttachmentSource(parentSource, featureName),
 		)...)
 	}
 	return provided
@@ -254,21 +254,21 @@ func LoadPkgDef(fsys PathedFS, filePath string) (PkgDef, error) {
 
 // PkgHostSpec
 
-// ResourceAttachmentSource returns the source path for resources under the PkgHostSpec instance,
+// ResAttachmentSource returns the source path for resources under the PkgHostSpec instance,
 // adding a string to the provided list of source elements which describes the source of the
 // PkgHostSpec instance.
-// The resulting slice is useful for constructing [AttachedResource] instances.
-func (s PkgHostSpec) ResourceAttachmentSource(parentSource []string) []string {
+// The resulting slice is useful for constructing [AttachedRes] instances.
+func (s PkgHostSpec) ResAttachmentSource(parentSource []string) []string {
 	return append(parentSource, "host specification")
 }
 
 // PkgDeplSpec
 
-// ResourceAttachmentSource returns the source path for resources under the PkgDeplSpec instance,
+// ResAttachmentSource returns the source path for resources under the PkgDeplSpec instance,
 // adding a string to the provided list of source elements which describes the source of the
 // PkgDeplSpec instance.
-// The resulting slice is useful for constructing [AttachedResource] instances.
-func (s PkgDeplSpec) ResourceAttachmentSource(parentSource []string) []string {
+// The resulting slice is useful for constructing [AttachedRes] instances.
+func (s PkgDeplSpec) ResAttachmentSource(parentSource []string) []string {
 	return append(parentSource, "deployment specification")
 }
 
@@ -279,10 +279,10 @@ func (s PkgDeplSpec) DefinesStack() bool {
 
 // PkgFeatureSpec
 
-// ResourceAttachmentSource returns the source path for resources under the PkgFeatureSpec instance,
+// ResAttachmentSource returns the source path for resources under the PkgFeatureSpec instance,
 // adding a string to the provided list of source elements which describes the source of the
 // PkgFeatureSpec instance.
-// The resulting slice is useful for constructing [AttachedResource] instances.
-func (s PkgFeatureSpec) ResourceAttachmentSource(parentSource []string, featureName string) []string {
+// The resulting slice is useful for constructing [AttachedRes] instances.
+func (s PkgFeatureSpec) ResAttachmentSource(parentSource []string, featureName string) []string {
 	return append(parentSource, fmt.Sprintf("feature %s", featureName))
 }


### PR DESCRIPTION
This PR adds dependency resolution to the `env plan`, `env apply`, `dev env plan`, and `dev env apply` commands, along with a total ordering of host state reconciliation changes in those commands based upon the results of dependency resolution. This way, forklift will not attempt to deploy/update a Docker stack requiring a Docker network provided by another Docker stack before that other Docker stack is deployed/updated. Additionally, those commands now include the resource constraint checking and reporting functionalities provided by `env check` and `dev env check`.