### PR TITLE
Try to fix the `make release` target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.2.1 - 2023-08-11
+
+### Fixed
+
+- Updated the Makefile for the `make release` target to also use the `goreleaser-cross` docker image which is used for the `make build` target.
+
 ## 0.2.0 - 2023-08-11
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,13 @@ build: install
 release: ## Use goreleaser-cross (due to macOS CGo requirement) to run goreleaser --clean
 release: install
 	$(call print-target)
-	goreleaser --clean
+	docker run \
+		--rm \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/$(PACKAGE_NAME) \
+		-w /go/src/$(PACKAGE_NAME) \
+		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
+		--clean
 
 .PHONY: run
 run: ## go run

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # forklift
-A software distribution and configuration management system to simplify maintenance and customization of software in embedded computers at scale.
+
+A GitOps-inspired software distribution and configuration system for operating customizable scientific instruments at scale.
+
+Note: this is still an experimental prototype and is not yet ready for general use.
 
 ## Introduction
 
@@ -7,7 +10,7 @@ An industrial forklift is a tool for moving pallets of packages:
 
 ![Photograph of a forklift being used to move stacks of cardboard boxes on a pallet](https://images.rawpixel.com/image_1000/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTExL2ZsNDk3OTgwOTA2MjctaW1hZ2UuanBn.jpg)
 
-This repository provides a [reference specification](reference.md) of _Forklift_, a declarative software package management system for uniformly distributing, deploying, and configuring software as Docke Compose applications. This repository also provides `forklift`, a Git-based command-line tool for applying, removing, upgrading, and downgrading Forklift package deployments on a Docker host.
+This repository provides a [reference specification](reference.md) of _Forklift_, a declarative software package management system for uniformly distributing, deploying, and configuring software as Docker Compose applications, mean to simplify deployment of software distributions on PlanktoScopes and other networked scientific instruments which may be operated as cattle (i.e. interchangeable units from a large, uniform pool of machines) or pets (i.e. with a custom unique configuration per machine). This repository also provides `forklift`, a Git-based command-line tool for applying, removing, upgrading, and downgrading Forklift package deployments on a Docker host.
 
 ## Usage
 

--- a/cmd/forklift/main.go
+++ b/cmd/forklift/main.go
@@ -25,7 +25,7 @@ var app = &cli.App{
 	Name: "forklift",
 	// TODO: see if there's a way to get the version from a build tag, so that we don't have to update
 	// this manually
-	Version: "v0.2.0",
+	Version: "v0.2.1",
 	Usage:   "Manages pallets and package deployments",
 	Commands: []*cli.Command{
 		env.Cmd,


### PR DESCRIPTION
This PR updates the `make release` target of the Makefile so that it also uses the `goreleaser-cross` Docker image which was added to the `make build` target of the Makefile in #48. This is needed so that the build works on macOS, which requires CGo.