### PR TITLE
Try to provide the github token env var for the `make release` target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.2.2 - 2023-08-11
+
+### Fixed
+
+- Updated the Makefile for the `make release` target to provide the `GITHUB_TOKEN` environment variable to the `goreleaser-cross` Docker container used for that Makefile target.
+
 ## 0.2.1 - 2023-08-11
 
 ### Fixed
 
-- Updated the Makefile for the `make release` target to also use the `goreleaser-cross` docker image which is used for the `make build` target.
+- Updated the Makefile for the `make release` target to also use the `goreleaser-cross` Docker image which is used for the `make build` target.
 
 ## 0.2.0 - 2023-08-11
 

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ release: install
 	$(call print-target)
 	docker run \
 		--rm \
+		-e GITHUB_TOKEN=${GITHUB_TOKEN} \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \

--- a/cmd/forklift/main.go
+++ b/cmd/forklift/main.go
@@ -25,7 +25,7 @@ var app = &cli.App{
 	Name: "forklift",
 	// TODO: see if there's a way to get the version from a build tag, so that we don't have to update
 	// this manually
-	Version: "v0.2.1",
+	Version: "v0.2.2",
 	Usage:   "Manages pallets and package deployments",
 	Commands: []*cli.Command{
 		env.Cmd,


### PR DESCRIPTION
PR #49 failed to provide the `GITHUB_TOKEN` environment variable to goreleaser in the `make release` Makefile target. This is probably because we didn't pass that environment variable into the `goreleaser-cross` Docker container. This PR attempts to fix that problem.