### PR TITLE
Disable Windows & Darwin builds to keep disk usage under CI limits

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,9 +12,9 @@ builds:
     - linux_amd64_v1
     - linux_arm64
     - linux_arm_7
-    - darwin_amd64_v1
-    - darwin_arm64
-    - windows_amd64_v1
+    # - darwin_amd64_v1
+    # - darwin_arm64
+    # - windows_amd64_v1
   overrides:
     - goos: darwin
       goarch: amd64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.3.1 - 2023-08-24
+
+### Removed
+
+- Removed builds for Darwin and Windows targets, because v0.3.0 couldn't be released due to the CI workflow running out of disk space.
+
 ## 0.3.0 - 2023-08-23
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -64,26 +64,28 @@ diff: ## git diff
 build: ## Use goreleaser-cross (due to macOS CGo requirement) to run goreleaser --snapshot --skip-publish --clean
 build: install
 	$(call print-target)
-	docker run \
-		--rm \
-		-v /var/run/docker.sock:/var/run/docker.sock \
-		-v `pwd`:/go/src/$(PACKAGE_NAME) \
-		-w /go/src/$(PACKAGE_NAME) \
-		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		--snapshot --skip-publish --clean
+	goreleaser --snapshot --skip-publish --clean
+	# docker run \
+	# 	--rm \
+	# 	-v /var/run/docker.sock:/var/run/docker.sock \
+	# 	-v `pwd`:/go/src/$(PACKAGE_NAME) \
+	# 	-w /go/src/$(PACKAGE_NAME) \
+	# 	ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
+	# 	--snapshot --skip-publish --clean
 
 .PHONY: release
 release: ## Use goreleaser-cross (due to macOS CGo requirement) to run goreleaser --clean
 release: install
 	$(call print-target)
-	docker run \
-		--rm \
-		-e GITHUB_TOKEN=${GITHUB_TOKEN} \
-		-v /var/run/docker.sock:/var/run/docker.sock \
-		-v `pwd`:/go/src/$(PACKAGE_NAME) \
-		-w /go/src/$(PACKAGE_NAME) \
-		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		--clean
+	goreleaser --clean
+	# docker run \
+	# 	--rm \
+	# 	-e GITHUB_TOKEN=${GITHUB_TOKEN} \
+	# 	-v /var/run/docker.sock:/var/run/docker.sock \
+	# 	-v `pwd`:/go/src/$(PACKAGE_NAME) \
+	# 	-w /go/src/$(PACKAGE_NAME) \
+	# 	ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
+	# 	--clean
 
 .PHONY: run
 run: ## go run

--- a/cmd/forklift/main.go
+++ b/cmd/forklift/main.go
@@ -25,7 +25,7 @@ var app = &cli.App{
 	Name: "forklift",
 	// TODO: see if there's a way to get the version from a build tag, so that we don't have to update
 	// this manually
-	Version: "v0.3.0",
+	Version: "v0.3.1",
 	Usage:   "Manages pallets and package deployments",
 	Commands: []*cli.Command{
 		plt.Cmd,


### PR DESCRIPTION
The CI release for v0.3.0 [kept failing](https://github.com/PlanktoScope/forklift/actions/runs/5947068359/job/16164666222) because the GitHub Actions Runner would keep running out of disk space. Probably a big contributor to this is the goreleaser-cross Docker image used to enable CGo builds on Darwin (even though we don't need/want the part of Docker Compose which pulls in the CGo-requiring dependency). This PR just removes the build targets for Darwin & Windows, since forklift probably isn't really all that valuable to run on those platforms anyways. We might be able to restore these builds in the future, but it's not a priority for now.

This PR preserves the build CI checks for successful builds on macOS and Windows, since we might want to release for those platforms again at some point in the future.