### PR TITLE
Add `disabled` flag to the package deployment definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The `forklift-pallet.yml` file can now optionally specify a README file and a pallet path.
+- The `.deploy.yml` files now have a `disabled` boolean flag which specifies whether that deployment definition should be ignored (so that it is excluded from `plt plan`, `plt check`, and `plt apply` commands).
 
 ### Changed
 

--- a/internal/app/forklift/cli/pallets-deployments.go
+++ b/internal/app/forklift/cli/pallets-deployments.go
@@ -57,7 +57,11 @@ func PrintDeplInfo(
 }
 
 func printDepl(indent int, cache forklift.PathedRepoCache, depl *forklift.ResolvedDepl) {
-	IndentedPrintf(indent, "Package deployment: %s\n", depl.Name)
+	IndentedPrint(indent, "Package deployment")
+	if depl.Depl.Def.Disabled {
+		fmt.Print(" (disabled!)")
+	}
+	fmt.Printf(": %s\n", depl.Name)
 	indent++
 
 	printDeplPkg(indent, cache, depl)

--- a/internal/app/forklift/cli/pallets.go
+++ b/internal/app/forklift/cli/pallets.go
@@ -147,6 +147,7 @@ func CheckPallet(indent int, pallet *forklift.FSPallet, loader forklift.FSPkgLoa
 	if err != nil {
 		return err
 	}
+	depls = forklift.FilterDeplsForEnabled(depls)
 	resolved, err := forklift.ResolveDepls(pallet, loader, depls)
 	if err != nil {
 		return err
@@ -374,6 +375,7 @@ func computePlan(
 	if err != nil {
 		return nil, nil, err
 	}
+	depls = forklift.FilterDeplsForEnabled(depls)
 	resolved, err := forklift.ResolveDepls(pallet, loader, depls)
 	if err != nil {
 		return nil, nil, err

--- a/internal/app/forklift/pallets-deployments.go
+++ b/internal/app/forklift/pallets-deployments.go
@@ -292,6 +292,18 @@ func CheckDeplDeps(
 
 // Depl
 
+// FilterDeplsForEnabled filters a slice of Depls to only include those which are not disabled.
+func FilterDeplsForEnabled(depls []Depl) []Depl {
+	filtered := make([]Depl, 0, len(depls))
+	for _, depl := range depls {
+		if depl.Def.Disabled {
+			continue
+		}
+		filtered = append(filtered, depl)
+	}
+	return filtered
+}
+
 // loadDepl loads the Depl from a file path in the provided base filesystem, assuming the file path
 // is the specified name of the deployment followed by the deployment config file extension.
 func loadDepl(fsys core.PathedFS, name string) (depl Depl, err error) {

--- a/internal/app/forklift/pallets-models.go
+++ b/internal/app/forklift/pallets-models.go
@@ -71,10 +71,12 @@ type Depl struct {
 
 // A DeplDef defines a package deployment.
 type DeplDef struct {
-	// Package is the package path of the package to deploy
-	Package string `yaml:"package,omitempty"`
+	// Package is the package path of the package to deploy.
+	Package string `yaml:"package"`
 	// Features is a list of features from the package which should be enabled in the deployment.
-	Features []string `yaml:"features,omitempty"`
+	Features []string `yaml:"features"`
+	// Disabled represents whether the deployment should be ignored.
+	Disabled bool `yaml:"disabled"`
 }
 
 // Requirements


### PR DESCRIPTION
This PR adds a `disabled` boolean flag to package deployment definitions in pallets; when set, those package deployments are excluded from `plt plan`, `plt check`, and `plt apply` commands.