### PR TITLE
Allow Compose files to be controlled by feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The `forklift-package.yml` files now have an optional `compose-files` field in feature flags to define Compose files which should be merged into the Compose app for every package deployment which enables that feature.
 - The `forklift-pallet.yml` file can now optionally specify a README file and a pallet path. When specified, those fields are displayed by the `plt show` and `dev plt show` commands.
 - The `.deploy.yml` files now have a `disabled` boolean flag which specifies whether that deployment definition should be ignored (so that it is excluded from `plt plan`, `plt check`, and `plt apply` commands).
+- The `show-pkg` subcommand now shows a list of Compose files associated with each package feature flag.
+- The `show-depl` subcommand now shows a list of the Compose files used to define the Compose app for a deployment.
+- The `forklift-repository.yml` and `forklift-pallet.yml` now have a `forklift-version` field which indicates that the repository/pallet was written assuming the semantics of a given version of Forklift, and which sets the minimum version of Forklift required to use the repository/pallet. The Forklift version of a pallet cannot be less than the Forklift version of any repo required by the pallet. The Forklift tool also checks version compatibility - an older version of the Forklift tool is incompatible with repositories/pallets with newer Forklift versions, and the Forklift tool is also sets the minimum Forklift version of any repository/pallet it is compatible with (so for example v0.4.0 of the Forklift tool is incompatible with any repositories/pallets with Forklift version below v0.4.0, due to other breaking changes made for Forklift v0.4.0).
 
 ### Changed
 
-- The `forklift-repository.yml` and `forklift-pallet.yml` now have a `forklift-version` field which indicates that the repository/pallet was written assuming the semantics of a given version of Forklift, and which sets the minimum version of Forklift required to use the repository/pallet. The Forklift version of a pallet cannot be less than the Forklift version of any repo required by the pallet. The Forklift tool also checks version compatibility - an older version of the Forklift tool is incompatible with repositories/pallets with newer Forklift versions, and the Forklift tool is also sets the minimum Forklift version of any repository/pallet it is compatible with (so for example v0.4.0 of the Forklift tool is incompatible with any repositories/pallets with Forklift version below v0.4.0, due to other breaking changes made for Forklift v0.4.0).
+- (Breaking change) The `definition-files` field in `forklift-package.yml` files has been renamed to `compose-files`, for unambiguity and future-proofing (so that we can add other definition types, such as for regular files rather than Docker apps).
 - (Breaking change) The `forklift-version-lock.yml` file now requires a `type` field which specifies whether the version lock is to be interpreted as a tagged version or as a pseudoversion. The `commit` and `timestamp` fields are now required for all types, instead of being used to determine whether the version lock is for a tagged version or a pseudoversion.
-- (Breaking change) The `definition-files` field in Forklift package definitions has been renamed to `compose-files`.
+- (Breaking change) The `DefinesApp` method has been removed from `PkgDeplSpec`, since now a Compose App may be defined purely by feature flags.
 
 ### Fixed
 
-- Now the `dev plt add-repo` correctly specifies version-locking information when locking a repo at a tagged version.
+- Now the `dev plt add-repo` command correctly specifies version-locking information when locking a repo at a tagged version.
 
 ## 0.3.1 - 2023-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `forklift-repository.yml` and `forklift-pallet.yml` now have a `forklift-version` field which indicates that the repository/pallet was written assuming the semantics of a given version of Forklift, and which sets the minimum version of Forklift required to use the repository/pallet. The Forklift version of a pallet cannot be less than the Forklift version of any repo required by the pallet. The Forklift tool also checks version compatibility - an older version of the Forklift tool is incompatible with repositories/pallets with newer Forklift versions, and the Forklift tool is also sets the minimum Forklift version of any repository/pallet it is compatible with (so for example v0.4.0 of the Forklift tool is incompatible with any repositories/pallets with Forklift version below v0.4.0, due to other breaking changes made for Forklift v0.4.0).
 - (Breaking change) The `forklift-version-lock.yml` file now requires a `type` field which specifies whether the version lock is to be interpreted as a tagged version or as a pseudoversion. The `commit` and `timestamp` fields are now required for all types, instead of being used to determine whether the version lock is for a tagged version or a pseudoversion.
+- (Breaking change) The `definition-files` field in Forklift package definitions has been renamed to `compose-files`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `forklift-pallet.yml` file can now optionally specify a README file and a pallet path. When specified, those fields are displayed by the `plt show` and `dev plt show` commands.
 - The `.deploy.yml` files now have a `disabled` boolean flag which specifies whether that deployment definition should be ignored (so that it is excluded from `plt plan`, `plt check`, and `plt apply` commands).
 - The `show-pkg` subcommand now shows a list of Compose files associated with each package feature flag.
-- The `show-depl` subcommand now shows a list of the Compose files used to define the Compose app for a deployment.
+- The `show-depl` subcommand now shows a list of the Compose files used to define the Compose app for the deployment.
+- The `show-depl` subcommand now shows more details about the Compose app specified by the deployment.
 - The `forklift-repository.yml` and `forklift-pallet.yml` now have a `forklift-version` field which indicates that the repository/pallet was written assuming the semantics of a given version of Forklift, and which sets the minimum version of Forklift required to use the repository/pallet. The Forklift version of a pallet cannot be less than the Forklift version of any repo required by the pallet. The Forklift tool also checks version compatibility - an older version of the Forklift tool is incompatible with repositories/pallets with newer Forklift versions, and the Forklift tool is also sets the minimum Forklift version of any repository/pallet it is compatible with (so for example v0.4.0 of the Forklift tool is incompatible with any repositories/pallets with Forklift version below v0.4.0, due to other breaking changes made for Forklift v0.4.0).
 
 ### Changed

--- a/cmd/forklift/dev/cli.go
+++ b/cmd/forklift/dev/cli.go
@@ -11,13 +11,13 @@ import (
 
 var defaultWorkingDir, _ = os.Getwd()
 
-func MakeCmd(toolVersion, minVersion string) *cli.Command {
+func MakeCmd(toolVersion, repoMinVersion, palletMinVersion string) *cli.Command {
 	return &cli.Command{
 		Name:    "dev",
 		Aliases: []string{"development"},
 		Usage:   "Facilitates development and maintenance in the current working directory",
 		Subcommands: []*cli.Command{
-			plt.MakeCmd(toolVersion, minVersion),
+			plt.MakeCmd(toolVersion, repoMinVersion, palletMinVersion),
 		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -5,9 +5,9 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func MakeCmd(toolVersion, minVersion string) *cli.Command {
+func MakeCmd(toolVersion, repoMinVersion, palletMinVersion string) *cli.Command {
 	var subcommands []*cli.Command
-	for _, group := range makeSubcommandGroups(toolVersion, minVersion) {
+	for _, group := range makeSubcommandGroups(toolVersion, repoMinVersion, palletMinVersion) {
 		subcommands = append(subcommands, group...)
 	}
 	return &cli.Command{
@@ -26,15 +26,15 @@ func MakeCmd(toolVersion, minVersion string) *cli.Command {
 	}
 }
 
-func makeSubcommandGroups(toolVersion, minVersion string) [][]*cli.Command {
+func makeSubcommandGroups(toolVersion, repoMinVersion, palletMinVersion string) [][]*cli.Command {
 	return [][]*cli.Command{
-		makeUseSubcmds(toolVersion, minVersion),
+		makeUseSubcmds(toolVersion, repoMinVersion, palletMinVersion),
 		makeQuerySubcmds(),
-		makeModifySubcmds(toolVersion, minVersion),
+		makeModifySubcmds(toolVersion, repoMinVersion, palletMinVersion),
 	}
 }
 
-func makeUseSubcmds(toolVersion, minVersion string) []*cli.Command {
+func makeUseSubcmds(toolVersion, repoMinVersion, palletMinVersion string) []*cli.Command {
 	const category = "Use the pallet"
 	return []*cli.Command{
 		{
@@ -42,33 +42,33 @@ func makeUseSubcmds(toolVersion, minVersion string) []*cli.Command {
 			Aliases:  []string{"cache-repositories"},
 			Category: category,
 			Usage:    "Updates the cache with the repos available in the development pallet",
-			Action:   cacheRepoAction(toolVersion, minVersion),
+			Action:   cacheRepoAction(toolVersion, repoMinVersion, palletMinVersion),
 		},
 		{
 			Name:     "cache-img",
 			Aliases:  []string{"cache-images"},
 			Category: category,
 			Usage:    "Pre-downloads the Docker container images required by the development pallet",
-			Action:   cacheImgAction(toolVersion, minVersion),
+			Action:   cacheImgAction(toolVersion, repoMinVersion, palletMinVersion),
 		},
 		{
 			Name:     "check",
 			Category: category,
 			Usage:    "Checks whether the development pallet's resource constraints are satisfied",
-			Action:   checkAction(toolVersion, minVersion),
+			Action:   checkAction(toolVersion, repoMinVersion, palletMinVersion),
 		},
 		{
 			Name:     "plan",
 			Category: category,
 			Usage: "Determines the changes needed to update the Docker host to match the deployments " +
 				"specified by the local pallet",
-			Action: planAction(toolVersion, minVersion),
+			Action: planAction(toolVersion, repoMinVersion, palletMinVersion),
 		},
 		{
 			Name:     "apply",
 			Category: category,
 			Usage:    "Updates the Docker host to match the deployments specified by the development pallet",
-			Action:   applyAction(toolVersion, minVersion),
+			Action:   applyAction(toolVersion, repoMinVersion, palletMinVersion),
 		},
 	}
 }
@@ -130,7 +130,7 @@ func makeQuerySubcmds() []*cli.Command {
 	}
 }
 
-func makeModifySubcmds(toolVersion, minVersion string) []*cli.Command {
+func makeModifySubcmds(toolVersion, repoMinVersion, palletMinVersion string) []*cli.Command {
 	const category = "Modify the pallet"
 	return []*cli.Command{
 		{
@@ -139,7 +139,7 @@ func makeModifySubcmds(toolVersion, minVersion string) []*cli.Command {
 			Category:  category,
 			Usage:     "Adds repos to the pallet, tracking specified versions or branches",
 			ArgsUsage: "[repo_path@version_query]...",
-			Action:    addRepoAction(toolVersion, minVersion),
+			Action:    addRepoAction(toolVersion, repoMinVersion, palletMinVersion),
 		},
 		// TODO: add an rm-repo action
 		// TODO: add an add-depl action

--- a/cmd/forklift/dev/plt/images.go
+++ b/cmd/forklift/dev/plt/images.go
@@ -10,7 +10,7 @@ import (
 
 // cache-img
 
-func cacheImgAction(toolVersion, minVersion string) cli.ActionFunc {
+func cacheImgAction(toolVersion, repoMinVersion, palletMinVersion string) cli.ActionFunc {
 	return func(c *cli.Context) error {
 		pallet, cache, overrideCache, err := processFullBaseArgs(c, true)
 		if err != nil {
@@ -20,7 +20,7 @@ func cacheImgAction(toolVersion, minVersion string) cli.ActionFunc {
 			return err
 		}
 		if err = fcli.CheckCompatibility(
-			pallet, cache, toolVersion, minVersion, c.Bool("ignore-tool-version"),
+			pallet, cache, toolVersion, repoMinVersion, palletMinVersion, c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}

--- a/cmd/forklift/dev/plt/pallets.go
+++ b/cmd/forklift/dev/plt/pallets.go
@@ -130,7 +130,7 @@ func showAction(c *cli.Context) error {
 
 // check
 
-func checkAction(toolVersion, minVersion string) cli.ActionFunc {
+func checkAction(toolVersion, repoMinVersion, palletMinVersion string) cli.ActionFunc {
 	return func(c *cli.Context) error {
 		pallet, cache, overrideCache, err := processFullBaseArgs(c, true)
 		if err != nil {
@@ -140,7 +140,7 @@ func checkAction(toolVersion, minVersion string) cli.ActionFunc {
 			return err
 		}
 		if err = fcli.CheckCompatibility(
-			pallet, cache, toolVersion, minVersion, c.Bool("ignore-tool-version"),
+			pallet, cache, toolVersion, repoMinVersion, palletMinVersion, c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}
@@ -154,7 +154,7 @@ func checkAction(toolVersion, minVersion string) cli.ActionFunc {
 
 // plan
 
-func planAction(toolVersion, minVersion string) cli.ActionFunc {
+func planAction(toolVersion, repoMinVersion, palletMinVersion string) cli.ActionFunc {
 	return func(c *cli.Context) error {
 		pallet, cache, overrideCache, err := processFullBaseArgs(c, true)
 		if err != nil {
@@ -164,7 +164,7 @@ func planAction(toolVersion, minVersion string) cli.ActionFunc {
 			return err
 		}
 		if err = fcli.CheckCompatibility(
-			pallet, cache, toolVersion, minVersion, c.Bool("ignore-tool-version"),
+			pallet, cache, toolVersion, repoMinVersion, palletMinVersion, c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}
@@ -178,7 +178,7 @@ func planAction(toolVersion, minVersion string) cli.ActionFunc {
 
 // apply
 
-func applyAction(toolVersion, minVersion string) cli.ActionFunc {
+func applyAction(toolVersion, repoMinVersion, palletMinVersion string) cli.ActionFunc {
 	return func(c *cli.Context) error {
 		pallet, cache, overrideCache, err := processFullBaseArgs(c, true)
 		if err != nil {
@@ -188,7 +188,7 @@ func applyAction(toolVersion, minVersion string) cli.ActionFunc {
 			return err
 		}
 		if err = fcli.CheckCompatibility(
-			pallet, cache, toolVersion, minVersion, c.Bool("ignore-tool-version"),
+			pallet, cache, toolVersion, repoMinVersion, palletMinVersion, c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}

--- a/cmd/forklift/dev/plt/repositories.go
+++ b/cmd/forklift/dev/plt/repositories.go
@@ -26,7 +26,7 @@ func cacheRepoAction(toolVersion, repoMinVersion, palletMinVersion string) cli.A
 		if err != nil {
 			return err
 		}
-		if err = fcli.CheckCompatibility(
+		if err = fcli.CheckShallowCompatibility(
 			pallet, cache, toolVersion, repoMinVersion, palletMinVersion, c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
@@ -82,7 +82,7 @@ func addRepoAction(toolVersion, repoMinVersion, palletMinVersion string) cli.Act
 		if err != nil {
 			return err
 		}
-		if err = fcli.CheckCompatibility(
+		if err = fcli.CheckShallowCompatibility(
 			pallet, cache, toolVersion, repoMinVersion, palletMinVersion, c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err

--- a/cmd/forklift/dev/plt/repositories.go
+++ b/cmd/forklift/dev/plt/repositories.go
@@ -20,14 +20,14 @@ import (
 
 // cache-repo
 
-func cacheRepoAction(toolVersion, minVersion string) cli.ActionFunc {
+func cacheRepoAction(toolVersion, repoMinVersion, palletMinVersion string) cli.ActionFunc {
 	return func(c *cli.Context) error {
 		pallet, cache, _, err := processFullBaseArgs(c, false)
 		if err != nil {
 			return err
 		}
 		if err = fcli.CheckCompatibility(
-			pallet, cache, toolVersion, minVersion, c.Bool("ignore-tool-version"),
+			pallet, cache, toolVersion, repoMinVersion, palletMinVersion, c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}
@@ -76,14 +76,14 @@ func showRepoAction(c *cli.Context) error {
 
 // add-repo
 
-func addRepoAction(toolVersion, minVersion string) cli.ActionFunc {
+func addRepoAction(toolVersion, repoMinVersion, palletMinVersion string) cli.ActionFunc {
 	return func(c *cli.Context) error {
 		pallet, cache, _, err := processFullBaseArgs(c, false)
 		if err != nil {
 			return err
 		}
 		if err = fcli.CheckCompatibility(
-			pallet, cache, toolVersion, minVersion, c.Bool("ignore-tool-version"),
+			pallet, cache, toolVersion, repoMinVersion, palletMinVersion, c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}

--- a/cmd/forklift/main.go
+++ b/cmd/forklift/main.go
@@ -28,10 +28,10 @@ var app = &cli.App{
 	Version: toolVersion,
 	Usage:   "Manages pallets and package deployments",
 	Commands: []*cli.Command{
-		plt.MakeCmd(toolVersion, minVersion),
+		plt.MakeCmd(toolVersion, repoMinVersion, palletMinVersion),
 		cache.Cmd,
 		host.Cmd,
-		dev.MakeCmd(toolVersion, minVersion),
+		dev.MakeCmd(toolVersion, repoMinVersion, palletMinVersion),
 	},
 	Flags: []cli.Flag{
 		&cli.StringFlag{
@@ -54,8 +54,9 @@ var app = &cli.App{
 // Versioning
 
 const (
-	minVersion      = "v0.4.0-dev" // minimum supported version among artifacts
-	fallbackVersion = "v0.4.0-dev"
+	repoMinVersion   = "v0.4.0-dev" // minimum supported Forklift version among repos
+	palletMinVersion = "v0.4.0-dev" // minimum supported Forklift version among pallets
+	fallbackVersion  = "v0.4.0-dev" // version reported by Forklift tool if actual version is unknown
 )
 
 var (

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -5,9 +5,9 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func MakeCmd(toolVersion, minVersion string) *cli.Command {
+func MakeCmd(toolVersion, repoMinVersion, palletMinVersion string) *cli.Command {
 	var subcommands []*cli.Command
-	for _, group := range makeSubcommandGroups(toolVersion, minVersion) {
+	for _, group := range makeSubcommandGroups(toolVersion, repoMinVersion, palletMinVersion) {
 		subcommands = append(subcommands, group...)
 	}
 	return &cli.Command{
@@ -18,15 +18,15 @@ func MakeCmd(toolVersion, minVersion string) *cli.Command {
 	}
 }
 
-func makeSubcommandGroups(toolVersion, minVersion string) [][]*cli.Command {
+func makeSubcommandGroups(toolVersion, repoMinVersion, palletMinVersion string) [][]*cli.Command {
 	return [][]*cli.Command{
-		makeUseSubcmds(toolVersion, minVersion),
+		makeUseSubcmds(toolVersion, repoMinVersion, palletMinVersion),
 		makeQuerySubcmds(),
 		makeModifySubcmds(),
 	}
 }
 
-func makeUseSubcmds(toolVersion, minVersion string) []*cli.Command {
+func makeUseSubcmds(toolVersion, repoMinVersion, palletMinVersion string) []*cli.Command {
 	const category = "Use the pallet"
 	return []*cli.Command{
 		{
@@ -34,33 +34,33 @@ func makeUseSubcmds(toolVersion, minVersion string) []*cli.Command {
 			Aliases:  []string{"cache-repositories"},
 			Category: category,
 			Usage:    "Updates the cache with the repos available in the local pallet",
-			Action:   cacheRepoAction(toolVersion, minVersion),
+			Action:   cacheRepoAction(toolVersion, repoMinVersion, palletMinVersion),
 		},
 		{
 			Name:     "cache-img",
 			Aliases:  []string{"cache-images"},
 			Category: category,
 			Usage:    "Pre-downloads the Docker container images required by the local pallet",
-			Action:   cacheImgAction(toolVersion, minVersion),
+			Action:   cacheImgAction(toolVersion, repoMinVersion, palletMinVersion),
 		},
 		{
 			Name:     "check",
 			Category: category,
 			Usage:    "Checks whether the local pallet's resource constraints are satisfied",
-			Action:   checkAction(toolVersion, minVersion),
+			Action:   checkAction(toolVersion, repoMinVersion, palletMinVersion),
 		},
 		{
 			Name:     "plan",
 			Category: category,
 			Usage: "Determines the changes needed to update the Docker host to match the deployments " +
 				"specified by the local pallet",
-			Action: planAction(toolVersion, minVersion),
+			Action: planAction(toolVersion, repoMinVersion, palletMinVersion),
 		},
 		{
 			Name:     "apply",
 			Category: category,
 			Usage:    "Updates the Docker host to match the deployments specified by the local pallet",
-			Action:   applyAction(toolVersion, minVersion),
+			Action:   applyAction(toolVersion, repoMinVersion, palletMinVersion),
 		},
 	}
 }

--- a/cmd/forklift/plt/images.go
+++ b/cmd/forklift/plt/images.go
@@ -10,14 +10,14 @@ import (
 
 // cache-img
 
-func cacheImgAction(toolVersion, minVersion string) cli.ActionFunc {
+func cacheImgAction(toolVersion, repoMinVersion, palletMinVersion string) cli.ActionFunc {
 	return func(c *cli.Context) error {
 		pallet, cache, err := processFullBaseArgs(c, true)
 		if err != nil {
 			return err
 		}
 		if err = fcli.CheckCompatibility(
-			pallet, cache, toolVersion, minVersion, c.Bool("ignore-tool-version"),
+			pallet, cache, toolVersion, repoMinVersion, palletMinVersion, c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -194,14 +194,14 @@ func showAction(c *cli.Context) error {
 
 // check
 
-func checkAction(toolVersion, minVersion string) cli.ActionFunc {
+func checkAction(toolVersion, repoMinVersion, palletMinVersion string) cli.ActionFunc {
 	return func(c *cli.Context) error {
 		pallet, cache, err := processFullBaseArgs(c, true)
 		if err != nil {
 			return err
 		}
 		if err = fcli.CheckCompatibility(
-			pallet, cache, toolVersion, minVersion, c.Bool("ignore-tool-version"),
+			pallet, cache, toolVersion, repoMinVersion, palletMinVersion, c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}
@@ -215,14 +215,14 @@ func checkAction(toolVersion, minVersion string) cli.ActionFunc {
 
 // plan
 
-func planAction(toolVersion, minVersion string) cli.ActionFunc {
+func planAction(toolVersion, repoMinVersion, palletMinVersion string) cli.ActionFunc {
 	return func(c *cli.Context) error {
 		pallet, cache, err := processFullBaseArgs(c, true)
 		if err != nil {
 			return err
 		}
 		if err = fcli.CheckCompatibility(
-			pallet, cache, toolVersion, minVersion, c.Bool("ignore-tool-version"),
+			pallet, cache, toolVersion, repoMinVersion, palletMinVersion, c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}
@@ -238,14 +238,14 @@ func planAction(toolVersion, minVersion string) cli.ActionFunc {
 
 // apply
 
-func applyAction(toolVersion, minVersion string) cli.ActionFunc {
+func applyAction(toolVersion, repoMinVersion, palletMinVersion string) cli.ActionFunc {
 	return func(c *cli.Context) error {
 		pallet, cache, err := processFullBaseArgs(c, true)
 		if err != nil {
 			return err
 		}
 		if err = fcli.CheckCompatibility(
-			pallet, cache, toolVersion, minVersion, c.Bool("ignore-tool-version"),
+			pallet, cache, toolVersion, repoMinVersion, palletMinVersion, c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}

--- a/cmd/forklift/plt/repositories.go
+++ b/cmd/forklift/plt/repositories.go
@@ -10,14 +10,14 @@ import (
 
 // cache-repo
 
-func cacheRepoAction(toolVersion, minVersion string) cli.ActionFunc {
+func cacheRepoAction(toolVersion, repoMinVersion, palletMinVersion string) cli.ActionFunc {
 	return func(c *cli.Context) error {
 		pallet, cache, err := processFullBaseArgs(c, false)
 		if err != nil {
 			return err
 		}
 		if err = fcli.CheckCompatibility(
-			pallet, cache, toolVersion, minVersion, c.Bool("ignore-tool-version"),
+			pallet, cache, toolVersion, repoMinVersion, palletMinVersion, c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}

--- a/cmd/forklift/plt/repositories.go
+++ b/cmd/forklift/plt/repositories.go
@@ -16,7 +16,7 @@ func cacheRepoAction(toolVersion, repoMinVersion, palletMinVersion string) cli.A
 		if err != nil {
 			return err
 		}
-		if err = fcli.CheckCompatibility(
+		if err = fcli.CheckShallowCompatibility(
 			pallet, cache, toolVersion, repoMinVersion, palletMinVersion, c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err

--- a/docs/specs/00-package.md
+++ b/docs/specs/00-package.md
@@ -124,13 +124,25 @@ It is the reponsibility of the package maintainer to document the package's exte
 The definition of a repository is stored in a YAML file named `forklift-repository.yml` in the repository's root directory. Here is an example of a `forklift-repository.yml` file:
 
 ```yaml
+forklift-version: v0.4.0
+
 repository:
   path: github.com/PlanktoScope/device-pkgs
   description: Packages for the PlanktoScope software distribution
   readme-file: README.md
 ```
 
-Currently, all fields in the repository metadata file are under a `repository` section.
+### `forklift-version` field
+This field of the `forklift-repository.yml` file declares that the repository was written assuming the semantics of a given version of Forklift.
+- This field is required.
+- The version must be a valid version of the Forklift tool or the Forklift specification.
+- The version sets the minimum version of the Forklift tool required to use the repository. The Forklift tool refuses to use repositories declaring newer Forklift versions (or excessively old Forklift versions) for any operations beyond printing information.
+- Example:
+  ```yaml
+  forklift-version: v0.4.0
+  ```
+
+All other fields in the repository metadata file are under a `repository` section.
 
 ### `repository` section
 

--- a/docs/specs/00-package.md
+++ b/docs/specs/00-package.md
@@ -199,8 +199,8 @@ package:
 
 deployment:
   name: caddy-ingress
-  definition-files:
-    - docker-compose.yml
+  compose-files:
+    - compose.yml
 
 features:
   service-proxy:
@@ -506,24 +506,24 @@ This optional section of the `forklift-package.yml` file specifies the Docker Co
 
 ```yaml
 deployment:
-  definition-files:
-    - docker-compose.yml
+  compose-files:
+    - compose.yml
   provides:
     networks:
       - description: Overlay network for the Portainer server to connect to Portainer agents
         name: portainer-agent
 ```
 
-#### `definition-files` field
+#### `compose-files` field
 This field of the `deployment` section is an array of the string filenames of one or more Docker Compose files specifying the Docker Compose application which will be deployed when the package is deployed.
 - This field is optional.
 - The filenames must be for YAML files following the [Docker Compose file specification](https://docs.docker.com/compose/compose-file/).
 - The files must be located in the same directory as the `forklift-package.yml` file, or in subdirectories.
-- It only makes sense to omit the Docker Compose file from a package if the package also specifies some host resources in the `host` section of the `forklift-package.yml` file; otherwise, the package would do nothing and have no effect.
+- It only makes sense to omit the Docker Compose file from a package if the package also specifies some host resources in the `host` section of the `forklift-package.yml` file, or if the package defines some features with associated Compose files; otherwise, the package would do nothing and have no effect.
 - Example:
   ```yaml
-  definition-files:
-    - docker-compose.yml
+  compose-files:
+    - compose.yml
   ```
 
 #### `tags` field
@@ -806,9 +806,59 @@ This optional section of the `forklift-package.yml` file specifies the optional 
 The `features` section is a map (i.e. dictionary) whose keys are feature names and whose values are feature specification objects.  Here is an example of a `features` section:
 
 ```yaml
+package:
+  description: Web GUI for operating the PlanktoScope
+  maintainers:
+    - name: Ethan Li
+      email: lietk12@gmail.com
+  license: GPL-3.0-or-later
+  sources:
+    - https://github.com/PlanktoScope/PlanktoScope
+
+host:
+  provides:
+    listeners:
+      - description: Node-RED server for the PlanktoScope v2 dashboard
+        port: 1880
+        protocol: tcp
+    services:
+      - description: The Node-RED editor for the v2 PlanktoScope dashboard
+        port: 1880
+        protocol: http
+        paths:
+          - /admin/ps/node-red-v2
+          - /admin/ps/node-red-v2/*
+      - description: The v2 PlanktoScope dashboard for configuring the PlanktoScope and collecting data
+        port: 1880
+        protocol: http
+        paths:
+          - /ps/node-red-v2/ui
+          - /ps/node-red-v2/ui/*
+
+deployment:
+  compose-files: [compose.yml]
+  requires:
+    services:
+      - tags: [planktoscope-api-v2]
+        port: 1883
+        protocol: mqtt
+        paths:
+          - /actuator/pump
+          - /actuator/focus
+          - /imager/image
+          - /segmenter/segment
+          - /status/pump
+          - /status/focus
+          - /status/imager
+          - /status/segmenter
+          - /status/segmenter/name
+          - /status/segmenter/object_id
+          - /status/segmenter/metric
+
 features:
   editor:
     description: Provides access to the Node-RED admin editor for modifying the GUI
+    compose-files: [compose-editor.yml]
     tags:
     - device-portal.name=Node-RED dashboard editor
     - device-portal.description=Provides a Node-RED flow editor to modify the Node-RED dashboard
@@ -837,6 +887,7 @@ features:
             - /admin/ps/node-red-v2/*
   frontend:
     description: Provides access to the GUI
+    compose-files: [compose-frontend.yml]
     tags:
     - device-portal.name=Node-RED dashboard
     - device-portal.description=Provides a Node-RED dashboard to operate the PlanktoScope
@@ -878,6 +929,16 @@ A feature specification object consists of the following fields:
   - Example:
     ```yaml
     description: Provides access to the GUI
+    ```
+
+- `compose-files` is an array of the string filenames of one or more Docker Compose files specifying modifications to the Docker Compose application which will be applied if the feature is enabled.
+  - This field is optional.
+  - The filenames must be for YAML files which are fragments of a [Docker Compose file specification](https://docs.docker.com/compose/compose-file/). These files will be merged together with any other Compose files specified in the [`deployment` section](#deployment-section) of the `forklift-package.yml` file and in any other enabled features according to Docker Compose's [compose file merging mechanism](https://docs.docker.com/compose/multiple-compose-files/merge/).
+  - The files must be located in the same directory as the `forklift-package.yml` file, or in subdirectories.
+  - For clarity, it is strongly recommended that the order in which the files for different feature flags are merged should not affect the final result of merging.
+  - Example:
+    ```yaml
+    compose-files: [compose-frontend.yml]
     ```
 
 - `tags` is an array of strings to associate with the feature or with resources required or provided by the feature.

--- a/internal/app/forklift/cli/compatibility.go
+++ b/internal/app/forklift/cli/compatibility.go
@@ -12,7 +12,8 @@ import (
 // CheckCompatibility returns an error upon any version compatibility errors between a pallet, its
 // required pallets & repos (as loaded by repoLoader), and - unless the ignoreTool flag is set - the
 // Forklift tool (whose version is specified as toolVersion, and whose minimum compatible Forklift
-// versions are specified as repoMinVersion and palletMinVersion).
+// versions are specified as repoMinVersion and palletMinVersion). Note that minimum versions are
+// still enforced even if the ignoreTool flag is set.
 func CheckCompatibility(
 	pallet *forklift.FSPallet, repoLoader forklift.FSRepoLoader,
 	toolVersion, repoMinVersion, palletMinVersion string, ignoreTool bool,
@@ -50,6 +51,32 @@ func CheckCompatibility(
 				err, "forklift tool has a version incompatibility with required repo %s", v.reqPath,
 			)
 		}
+	}
+	return nil
+}
+
+// CheckShallowCompatibility returns an error upon any version compatibility errors between a pallet
+// and - unless the ignoreTool flag is set - the Forklift tool (whose version is specified as
+// toolVersion, and whose minimum compatible Forklift versions are specified as repoMinVersion and
+// palletMinVersion). Note that minimum versions are still enforced even if the ignoreTool flag is
+// set.
+func CheckShallowCompatibility(
+	pallet *forklift.FSPallet, repoLoader forklift.FSRepoLoader,
+	toolVersion, repoMinVersion, palletMinVersion string, ignoreTool bool,
+) error {
+	if ignoreTool {
+		fmt.Printf(
+			"Warning: ignoring the tool's version (%s) for version compatibility checking!\n",
+			toolVersion,
+		)
+	}
+
+	if err := checkArtifactCompatibility(
+		pallet.Def.ForkliftVersion, toolVersion, palletMinVersion, pallet.Path(), ignoreTool,
+	); err != nil {
+		return errors.Wrapf(
+			err, "forklift tool has a version incompatibility with pallet %s", pallet.Path(),
+		)
 	}
 	return nil
 }

--- a/internal/app/forklift/cli/images.go
+++ b/internal/app/forklift/cli/images.go
@@ -57,7 +57,7 @@ func listRequiredImages(
 			continue
 		}
 
-		appDef, err := loadAppDefinition(depl.Pkg)
+		appDef, err := loadAppDefinition(depl)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/app/forklift/cli/images.go
+++ b/internal/app/forklift/cli/images.go
@@ -4,14 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
 
-	dct "github.com/compose-spec/compose-go/types"
 	"github.com/pkg/errors"
 
 	"github.com/PlanktoScope/forklift/internal/app/forklift"
 	"github.com/PlanktoScope/forklift/internal/clients/docker"
-	"github.com/PlanktoScope/forklift/pkg/core"
 )
 
 // Download
@@ -73,18 +70,4 @@ func listRequiredImages(
 		}
 	}
 	return orderedImages, nil
-}
-
-func loadAppDefinition(pkg *core.FSPkg) (*dct.Project, error) {
-	appDef, err := docker.LoadAppDefinition(
-		pkg.FS, path.Base(pkg.Path()), pkg.Def.Deployment.ComposeFiles, nil,
-	)
-	// TODO: also load the docker compose files for all features
-	if err != nil {
-		return nil, errors.Wrapf(
-			err, "couldn't load Docker Compose app definition for a basic deployment of %s",
-			pkg.FS.Path(),
-		)
-	}
-	return appDef, nil
 }

--- a/internal/app/forklift/cli/images.go
+++ b/internal/app/forklift/cli/images.go
@@ -53,13 +53,19 @@ func listRequiredImages(
 		IndentedPrintf(
 			indent, "Checking Docker container images used by package deployment %s...\n", depl.Name,
 		)
-		if !depl.Pkg.Def.Deployment.DefinesApp() {
+		definesApp, err := depl.DefinesApp()
+		if err != nil {
+			return nil, errors.Wrapf(
+				err, "couldn't determine whether package deployment %s defines a Compose app", depl.Name,
+			)
+		}
+		if !definesApp {
 			continue
 		}
 
 		appDef, err := loadAppDefinition(depl)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "couldn't load Compose app definition")
 		}
 		for _, service := range appDef.Services {
 			BulletedPrintf(indent+1, "%s: %s\n", service.Name, service.Image)

--- a/internal/app/forklift/cli/images.go
+++ b/internal/app/forklift/cli/images.go
@@ -77,7 +77,7 @@ func listRequiredImages(
 
 func loadAppDefinition(pkg *core.FSPkg) (*dct.Project, error) {
 	appDef, err := docker.LoadAppDefinition(
-		pkg.FS, path.Base(pkg.Path()), pkg.Def.Deployment.DefinitionFiles, nil,
+		pkg.FS, path.Base(pkg.Path()), pkg.Def.Deployment.ComposeFiles, nil,
 	)
 	// TODO: also load the docker compose files for all features
 	if err != nil {

--- a/internal/app/forklift/cli/packages.go
+++ b/internal/app/forklift/cli/packages.go
@@ -83,14 +83,14 @@ func PrintDeplSpec(indent int, spec core.PkgDeplSpec) {
 	IndentedPrintf(indent, "Deployment:\n")
 	indent++
 
-	// TODO: actually display the app definition?
-	IndentedPrintf(indent, "Definition files: ")
-	if len(spec.DefinitionFiles) == 0 {
+	// TODO: actually display the app definition
+	IndentedPrintf(indent, "Compose files: ")
+	if len(spec.ComposeFiles) == 0 {
 		fmt.Printf("(none)")
 		return
 	}
 	fmt.Println()
-	for _, file := range spec.DefinitionFiles {
+	for _, file := range spec.ComposeFiles {
 		BulletedPrintln(indent+1, file)
 	}
 }

--- a/internal/app/forklift/cli/packages.go
+++ b/internal/app/forklift/cli/packages.go
@@ -83,7 +83,6 @@ func PrintDeplSpec(indent int, spec core.PkgDeplSpec) {
 	IndentedPrintf(indent, "Deployment:\n")
 	indent++
 
-	// TODO: actually display the app definition
 	IndentedPrintf(indent, "Compose files: ")
 	if len(spec.ComposeFiles) == 0 {
 		fmt.Printf("(none)")
@@ -109,10 +108,23 @@ func PrintFeatureSpecs(indent int, features map[string]core.PkgFeatureSpec) {
 	indent++
 
 	for _, name := range names {
-		if description := features[name].Description; description != "" {
-			IndentedPrintf(indent, "%s: %s\n", name, description)
-			continue
-		}
-		IndentedPrintf(indent, "%s\n", name)
+		PrintFeatureSpec(indent, name, features[name])
+	}
+}
+
+func PrintFeatureSpec(indent int, name string, spec core.PkgFeatureSpec) {
+	IndentedPrintf(indent, "%s:\n", name)
+	indent++
+
+	IndentedPrintf(indent, "Description: %s\n", spec.Description)
+
+	IndentedPrintf(indent, "Compose files: ")
+	if len(spec.ComposeFiles) == 0 {
+		fmt.Printf("(none)")
+		return
+	}
+	fmt.Println()
+	for _, file := range spec.ComposeFiles {
+		BulletedPrintln(indent+1, file)
 	}
 }

--- a/internal/app/forklift/cli/pallets-deployments.go
+++ b/internal/app/forklift/cli/pallets-deployments.go
@@ -141,7 +141,8 @@ func printDockerAppDefFiles(indent int, depl *forklift.ResolvedDepl) error {
 
 func printDockerAppDef(indent int, appDef *dct.Project) {
 	printDockerAppServices(indent, appDef.Services)
-	// TODO: also print networks, volumes, etc.
+	printDockerAppNetworks(indent, appDef.Networks)
+	printDockerAppVolumes(indent, appDef.Volumes)
 }
 
 func printDockerAppServices(indent int, services []dct.ServiceConfig) {
@@ -160,5 +161,51 @@ func printDockerAppServices(indent int, services []dct.ServiceConfig) {
 
 	for _, service := range services {
 		IndentedPrintf(indent, "%s: %s\n", service.Name, service.Image)
+	}
+}
+
+func printDockerAppNetworks(indent int, networks dct.Networks) {
+	if len(networks) == 0 {
+		return
+	}
+	networkNames := make([]string, 0, len(networks))
+	for name := range networks {
+		networkNames = append(networkNames, name)
+	}
+	IndentedPrint(indent, "Networks:")
+	sort.Slice(networkNames, func(i, j int) bool {
+		return networkNames[i] < networkNames[j]
+	})
+	if len(networkNames) == 0 {
+		fmt.Print(" (none)")
+	}
+	fmt.Println()
+	indent++
+
+	for _, name := range networkNames {
+		BulletedPrintln(indent, networks[name].Name)
+	}
+}
+
+func printDockerAppVolumes(indent int, volumes dct.Volumes) {
+	if len(volumes) == 0 {
+		return
+	}
+	volumeNames := make([]string, 0, len(volumes))
+	for name := range volumes {
+		volumeNames = append(volumeNames, name)
+	}
+	IndentedPrint(indent, "Volumes:")
+	sort.Slice(volumeNames, func(i, j int) bool {
+		return volumeNames[i] < volumeNames[j]
+	})
+	if len(volumeNames) == 0 {
+		fmt.Print(" (none)")
+	}
+	fmt.Println()
+	indent++
+
+	for _, name := range volumeNames {
+		BulletedPrintln(indent, name)
 	}
 }

--- a/internal/app/forklift/cli/pallets-deployments.go
+++ b/internal/app/forklift/cli/pallets-deployments.go
@@ -2,12 +2,14 @@ package cli
 
 import (
 	"fmt"
+	"path"
 	"sort"
 
 	dct "github.com/compose-spec/compose-go/types"
 	"github.com/pkg/errors"
 
 	"github.com/PlanktoScope/forklift/internal/app/forklift"
+	"github.com/PlanktoScope/forklift/internal/clients/docker"
 	"github.com/PlanktoScope/forklift/pkg/core"
 )
 
@@ -131,4 +133,18 @@ func printDockerAppServices(indent int, services []dct.ServiceConfig) {
 	for _, service := range services {
 		IndentedPrintf(indent, "%s: %s\n", service.Name, service.Image)
 	}
+}
+
+func loadAppDefinition(pkg *core.FSPkg) (*dct.Project, error) {
+	appDef, err := docker.LoadAppDefinition(
+		pkg.FS, path.Base(pkg.Path()), pkg.Def.Deployment.ComposeFiles, nil,
+	)
+	// TODO: also load the docker compose files for all features
+	if err != nil {
+		return nil, errors.Wrapf(
+			err, "couldn't load Docker Compose app definition for a basic deployment of %s",
+			pkg.FS.Path(),
+		)
+	}
+	return appDef, nil
 }

--- a/internal/app/forklift/cli/pallets.go
+++ b/internal/app/forklift/cli/pallets.go
@@ -790,7 +790,7 @@ func deployApp(indent int, depl *forklift.ResolvedDepl, name string, dc *docker.
 	}
 
 	appDef, err := docker.LoadAppDefinition(
-		depl.Pkg.FS, name, depl.Pkg.Def.Deployment.DefinitionFiles, nil,
+		depl.Pkg.FS, name, depl.Pkg.Def.Deployment.ComposeFiles, nil,
 	)
 	if err != nil {
 		return err

--- a/internal/app/forklift/cli/pallets.go
+++ b/internal/app/forklift/cli/pallets.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	dct "github.com/compose-spec/compose-go/types"
 	"github.com/docker/compose/v2/pkg/api"
 	ggit "github.com/go-git/go-git/v5"
 	"github.com/pkg/errors"
@@ -388,6 +389,37 @@ type reconciliationChange struct {
 	App  api.Stack
 }
 
+func newAddReconciliationChange(deplName string, depl *forklift.ResolvedDepl) reconciliationChange {
+	return reconciliationChange{
+		Name: getAppName(deplName),
+		Type: addReconciliationChange,
+		Depl: depl,
+	}
+}
+
+func newUpdateReconciliationChange(
+	deplName string, depl *forklift.ResolvedDepl, app api.Stack,
+) reconciliationChange {
+	return reconciliationChange{
+		Name: getAppName(deplName),
+		Type: updateReconciliationChange,
+		Depl: depl,
+		App:  app,
+	}
+}
+
+func newRemoveReconciliationChange(appName string, app api.Stack) reconciliationChange {
+	return reconciliationChange{
+		Name: appName,
+		Type: removeReconciliationChange,
+		App:  app,
+	}
+}
+
+func getAppName(deplName string) string {
+	return strings.ReplaceAll(deplName, "/", "_")
+}
+
 func computePlan(
 	indent int, pallet *forklift.FSPallet, loader forklift.FSPkgLoader,
 ) ([]reconciliationChange, *docker.Client, error) {
@@ -438,7 +470,10 @@ func computePlan(
 
 	fmt.Println()
 	IndentedPrintln(indent, "Determining package deployment changes...")
-	changes := planReconciliation(resolved, deps, apps)
+	changes, err := planReconciliation(resolved, deps, apps)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "couldn't plan changes")
+	}
 	for _, change := range changes {
 		printReconciliationChange(indent, change)
 	}
@@ -561,54 +596,49 @@ func invertDeps(deps map[string]map[string]struct{}) map[string]map[string]struc
 // closure of the deployments depending on each deployment, and a list of
 // Docker Compose apps describing the current complete state of the Docker host.
 func planReconciliation(
-	depls []*forklift.ResolvedDepl, deps map[string]map[string]struct{},
-	apps []api.Stack,
-) []reconciliationChange {
+	depls []*forklift.ResolvedDepl, deps map[string]map[string]struct{}, apps []api.Stack,
+) ([]reconciliationChange, error) {
 	deplSet := make(map[string]*forklift.ResolvedDepl)
+	composeAppDefinerSet := make(map[string]struct{})
 	for _, depl := range depls {
 		deplSet[depl.Name] = depl
+		definesApp, err := depl.DefinesApp()
+		if err != nil {
+			return nil, errors.Wrapf(
+				err, "couldn't determine whether package deployment %s defines a Compose app", depl.Name,
+			)
+		}
+		if definesApp {
+			composeAppDefinerSet[depl.Name] = struct{}{}
+		}
 	}
 	appSet := make(map[string]api.Stack)
 	for _, app := range apps {
 		appSet[app.Name] = app
 	}
-	appDeplNames := make(map[string]string)
 
+	appDeplNames := make(map[string]string)
 	changes := make([]reconciliationChange, 0, len(deplSet)+len(appSet))
 	for name, depl := range deplSet {
 		appDeplNames[getAppName(name)] = name
-		definesApp := depl.Pkg.Def.Deployment.DefinesApp()
 		app, ok := appSet[getAppName(name)]
 		if !ok {
-			if definesApp {
-				changes = append(changes, reconciliationChange{
-					Name: getAppName(name),
-					Type: addReconciliationChange,
-					Depl: depl,
-				})
+			if _, ok := composeAppDefinerSet[name]; ok {
+				changes = append(changes, newAddReconciliationChange(name, depl))
 			}
 			continue
 		}
-		if definesApp {
-			changes = append(changes, reconciliationChange{
-				Name: getAppName(name),
-				Type: updateReconciliationChange,
-				Depl: depl,
-				App:  app,
-			})
+		if _, ok := composeAppDefinerSet[name]; ok {
+			changes = append(changes, newUpdateReconciliationChange(name, depl, app))
 		}
 	}
 	for name, app := range appSet {
 		if deplName, ok := appDeplNames[name]; ok {
-			if depl, ok := deplSet[deplName]; ok && depl.Pkg.Def.Deployment.DefinesApp() {
+			if _, ok = composeAppDefinerSet[deplName]; ok {
 				continue
 			}
 		}
-		changes = append(changes, reconciliationChange{
-			Name: name,
-			Type: removeReconciliationChange,
-			App:  app,
-		})
+		changes = append(changes, newRemoveReconciliationChange(name, app))
 	}
 
 	dependents := invertDeps(deps)
@@ -616,11 +646,7 @@ func planReconciliation(
 	sort.Slice(changes, func(i, j int) bool {
 		return compareChanges(changes[i], changes[j], deps, dependents) == core.CompareLT
 	})
-	return changes
-}
-
-func getAppName(deplName string) string {
-	return strings.ReplaceAll(deplName, "/", "_")
+	return changes, nil
 }
 
 // compareChanges returns a comparison for generating a total ordering of reconciliation changes
@@ -784,19 +810,41 @@ func applyReconciliationChange(
 }
 
 func deployApp(indent int, depl *forklift.ResolvedDepl, name string, dc *docker.Client) error {
-	if !depl.Pkg.Def.Deployment.DefinesApp() {
+	definesApp, err := depl.DefinesApp()
+	if err != nil {
+		return errors.Wrapf(
+			err, "couldn't determine whether package deployment %s defines a Compose app", depl.Name,
+		)
+	}
+	if !definesApp {
 		IndentedPrintln(indent, "No Docker Compose app to deploy!")
 		return nil
 	}
 
-	appDef, err := docker.LoadAppDefinition(
-		depl.Pkg.FS, name, depl.Pkg.Def.Deployment.ComposeFiles, nil,
-	)
+	appDef, err := loadAppDefinition(depl)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "couldn't load Compose app definition")
 	}
 	if err = dc.DeployApp(context.Background(), appDef, 0); err != nil {
 		return errors.Wrapf(err, "couldn't deploy Compose app '%s'", name)
 	}
 	return nil
+}
+
+func loadAppDefinition(depl *forklift.ResolvedDepl) (*dct.Project, error) {
+	composeFiles, err := depl.GetComposeFilenames()
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't determine Compose files for deployment")
+	}
+
+	appDef, err := docker.LoadAppDefinition(
+		depl.Pkg.FS, getAppName(depl.Name), composeFiles, nil,
+	)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err, "couldn't load Docker Compose app definition for deployment %s of %s",
+			depl.Name, depl.Pkg.FS.Path(),
+		)
+	}
+	return appDef, nil
 }

--- a/pkg/core/packages-models.go
+++ b/pkg/core/packages-models.go
@@ -89,6 +89,10 @@ type PkgDeplSpec struct {
 type PkgFeatureSpec struct {
 	// Description is a short description of the feature to be shown to users.
 	Description string `yaml:"description"`
+	// ComposeFiles is a list of the names of Docker Compose files specifying the Docker Compose
+	// application which will be merged together with any other Compose files as part of a package
+	// deployment which enables the feature.
+	ComposeFiles []string `yaml:"compose-files,omitempty"`
 	// Tags is a list of strings associated with the feature.
 	Tags []string `yaml:"tags,omitempty"`
 	// Provides describes resource requirements which must be met for a deployment of the package to

--- a/pkg/core/packages-models.go
+++ b/pkg/core/packages-models.go
@@ -73,9 +73,9 @@ type PkgHostSpec struct {
 
 // PkgDeplSpec contains information about any deployment of the package.
 type PkgDeplSpec struct {
-	// DefinitionFiles is a list of the names of Docker Compose files specifying the Docker Compose
+	// ComposeFiles is a list of the names of Docker Compose files specifying the Docker Compose
 	// application which will be deployed as part of a package deployment.
-	DefinitionFiles []string `yaml:"definition-files,omitempty"`
+	ComposeFiles []string `yaml:"compose-files,omitempty"`
 	// Tags is a list of strings associated with the deployment.
 	Tags []string `yaml:"tags,omitempty"`
 	// Provides describes resource requirements which must be met for a deployment of the package to

--- a/pkg/core/packages.go
+++ b/pkg/core/packages.go
@@ -270,12 +270,6 @@ func (s PkgDeplSpec) ResAttachmentSource(parentSource []string) []string {
 	return append(parentSource, "deployment specification")
 }
 
-// DefinesApp determines whether the PkgDeplSpec instance defines a Docker Compose app to be
-// deployed.
-func (s PkgDeplSpec) DefinesApp() bool {
-	return len(s.ComposeFiles) > 0 && s.ComposeFiles[0] != ""
-}
-
 // PkgFeatureSpec
 
 // ResAttachmentSource returns the source path for resources under the PkgFeatureSpec instance,

--- a/pkg/core/packages.go
+++ b/pkg/core/packages.go
@@ -273,7 +273,7 @@ func (s PkgDeplSpec) ResAttachmentSource(parentSource []string) []string {
 // DefinesApp determines whether the PkgDeplSpec instance defines a Docker Compose app to be
 // deployed.
 func (s PkgDeplSpec) DefinesApp() bool {
-	return len(s.DefinitionFiles) > 0 && s.DefinitionFiles[0] != ""
+	return len(s.ComposeFiles) > 0 && s.ComposeFiles[0] != ""
 }
 
 // PkgFeatureSpec


### PR DESCRIPTION
This PR adds a `compose-files` field to feature definitions in packages, so that Compose files (or Compose file fragments) can be merged into the Compose app definition when their respective feature flags are enabled. This PR also renames the `definition-files` field in package definitions to `compose-files`.