### PR TITLE
Support running Docker operations in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `cache rm-repo` subcommand which only deletes cached repositories.
 - Added a `cache rm-img` subcommand which only deletes unused Docker container images.
 - Added a `--include-disabled` flag to the `plt cache-img` and `dev plt cache-img` subcommands to also cache images used by disabled package deployments.
+- Added a `--parallel` flag to the `plt apply` and `dev plt apply` subcommands to enable parallel bringup of Docker Compose apps without any dependency relationships between them.
 - Added a `--parallel` flag to the `plt cache-img` and `dev plt cache-img` subcommands to enable parallel caching of Docker container images. Speedup will depend on the host machine, but on a high-performance laptop it led to a ~40% speedup.
+- Added a `nonblocking` field to service resource requirement objects in the package specification to allow a resource requirement to be ignored for the purposes of planning the order in which package deployments are to be added or modified.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `cache rm-repo` subcommand which only deletes cached repositories.
 - Added a `cache rm-img` subcommand which only deletes unused Docker container images.
 - Added a `--include-disabled` flag to the `plt cache-img` and `dev plt cache-img` subcommands to also cache images used by disabled package deployments.
+- Added a `--parallel` flag to the `plt cache-img` and `dev plt cache-img` subcommands to enable parallel caching of Docker container images. Speedup will depend on the host machine, but on a high-performance laptop it led to a ~40% speedup.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a `cache rm-repo` subcommand which only deletes cached repositories.
 - Added a `cache rm-img` subcommand which only deletes unused Docker container images.
+- Added a `--include-disabled` flag to the `plt cache-img` and `dev plt cache-img` subcommands to also cache images used by disabled package deployments.
 
 ### Changed
 
 - (Breaking change) Renamed the `cache rm` command to `cache rm-all`
+- (Breaking change) By default, now the `plt cache-img` and `dev plt cache-img` commands don't cache images used only by disabled package deployments.
 
 ## 0.4.0 - 2023-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Breaking change) Renamed the `cache rm` command to `cache rm-all`
 - (Breaking change) By default, now the `plt cache-img` and `dev plt cache-img` commands don't cache images used only by disabled package deployments.
 
+### Fixed
+
+- `plt clone` can now resolve a branch name as the version query, because it now treats the branch name as the name of a remote branch from the "origin" remote (since that is the only source of branches immediately after cloning).
+
 ## 0.4.0 - 2023-10-23
 
 ### Added

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -50,6 +50,16 @@ func makeUseSubcmds(toolVersion, repoMinVersion, palletMinVersion string) []*cli
 			Category: category,
 			Usage:    "Pre-downloads the Docker container images required by the development pallet",
 			Action:   cacheImgAction(toolVersion, repoMinVersion, palletMinVersion),
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "include-disabled",
+					Usage: "also download images for disabled package deployments",
+				},
+				&cli.BoolFlag{
+					Name:  "parallel",
+					Usage: "parallelize downloading of images",
+				},
+			},
 		},
 		{
 			Name:     "check",

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -73,12 +73,24 @@ func makeUseSubcmds(toolVersion, repoMinVersion, palletMinVersion string) []*cli
 			Usage: "Determines the changes needed to update the Docker host to match the deployments " +
 				"specified by the local pallet",
 			Action: planAction(toolVersion, repoMinVersion, palletMinVersion),
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "parallel",
+					Usage: "parallelize downloading of images",
+				},
+			},
 		},
 		{
 			Name:     "apply",
 			Category: category,
 			Usage:    "Updates the Docker host to match the deployments specified by the development pallet",
 			Action:   applyAction(toolVersion, repoMinVersion, palletMinVersion),
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "parallel",
+					Usage: "parallelize downloading of images",
+				},
+			},
 		},
 	}
 }

--- a/cmd/forklift/dev/plt/images.go
+++ b/cmd/forklift/dev/plt/images.go
@@ -26,7 +26,9 @@ func cacheImgAction(toolVersion, repoMinVersion, palletMinVersion string) cli.Ac
 		}
 
 		fmt.Println("Downloading Docker container images specified by the development pallet...")
-		if err := fcli.DownloadImages(0, pallet, cache); err != nil {
+		if err := fcli.DownloadImages(
+			0, pallet, cache, c.Bool("include-disabled"), c.Bool("parallel"),
+		); err != nil {
 			return err
 		}
 		fmt.Println()

--- a/cmd/forklift/dev/plt/pallets.go
+++ b/cmd/forklift/dev/plt/pallets.go
@@ -145,7 +145,7 @@ func checkAction(toolVersion, repoMinVersion, palletMinVersion string) cli.Actio
 			return err
 		}
 
-		if err := fcli.CheckPallet(0, pallet, cache); err != nil {
+		if _, _, err := fcli.CheckPallet(0, pallet, cache); err != nil {
 			return err
 		}
 		return nil
@@ -169,7 +169,7 @@ func planAction(toolVersion, repoMinVersion, palletMinVersion string) cli.Action
 			return err
 		}
 
-		if err := fcli.PlanPallet(0, pallet, cache); err != nil {
+		if _, _, err = fcli.PlanPallet(0, pallet, cache, c.Bool("parallel")); err != nil {
 			return err
 		}
 		return nil
@@ -193,7 +193,7 @@ func applyAction(toolVersion, repoMinVersion, palletMinVersion string) cli.Actio
 			return err
 		}
 
-		if err := fcli.ApplyPallet(0, pallet, cache); err != nil {
+		if err := fcli.ApplyPallet(0, pallet, cache, c.Bool("parallel")); err != nil {
 			return err
 		}
 		fmt.Println()

--- a/cmd/forklift/dev/plt/pallets.go
+++ b/cmd/forklift/dev/plt/pallets.go
@@ -64,7 +64,7 @@ func getCache(
 	if ensureCache && !fsCache.Exists() {
 		return nil, nil, errors.New(
 			"you first need to cache the repos specified by your pallet with " +
-				"`forklift dev plt cache-repos`",
+				"`forklift dev plt cache-repo`",
 		)
 	}
 	return cache, override, nil

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -65,12 +65,24 @@ func makeUseSubcmds(toolVersion, repoMinVersion, palletMinVersion string) []*cli
 			Usage: "Determines the changes needed to update the Docker host to match the deployments " +
 				"specified by the local pallet",
 			Action: planAction(toolVersion, repoMinVersion, palletMinVersion),
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "parallel",
+					Usage: "parallelize downloading of images",
+				},
+			},
 		},
 		{
 			Name:     "apply",
 			Category: category,
 			Usage:    "Updates the Docker host to match the deployments specified by the local pallet",
 			Action:   applyAction(toolVersion, repoMinVersion, palletMinVersion),
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "parallel",
+					Usage: "parallelize downloading of images",
+				},
+			},
 		},
 	}
 }

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -42,6 +42,16 @@ func makeUseSubcmds(toolVersion, repoMinVersion, palletMinVersion string) []*cli
 			Category: category,
 			Usage:    "Pre-downloads the Docker container images required by the local pallet",
 			Action:   cacheImgAction(toolVersion, repoMinVersion, palletMinVersion),
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "include-disabled",
+					Usage: "also download images for disabled package deployments",
+				},
+				&cli.BoolFlag{
+					Name:  "parallel",
+					Usage: "parallelize downloading of images",
+				},
+			},
 		},
 		{
 			Name:     "check",

--- a/cmd/forklift/plt/images.go
+++ b/cmd/forklift/plt/images.go
@@ -23,7 +23,9 @@ func cacheImgAction(toolVersion, repoMinVersion, palletMinVersion string) cli.Ac
 		}
 
 		fmt.Println("Downloading Docker container images specified by the local pallet...")
-		if err := fcli.DownloadImages(0, pallet, cache); err != nil {
+		if err := fcli.DownloadImages(
+			0, pallet, cache, c.Bool("include-disabled"), c.Bool("parallel"),
+		); err != nil {
 			return err
 		}
 		fmt.Println()

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -206,7 +206,7 @@ func checkAction(toolVersion, repoMinVersion, palletMinVersion string) cli.Actio
 			return err
 		}
 
-		if err := fcli.CheckPallet(0, pallet, cache); err != nil {
+		if _, _, err := fcli.CheckPallet(0, pallet, cache); err != nil {
 			return err
 		}
 		return nil
@@ -227,7 +227,7 @@ func planAction(toolVersion, repoMinVersion, palletMinVersion string) cli.Action
 			return err
 		}
 
-		if err := fcli.PlanPallet(0, pallet, cache); err != nil {
+		if _, _, err = fcli.PlanPallet(0, pallet, cache, c.Bool("parallel")); err != nil {
 			return errors.Wrap(
 				err, "couldn't deploy local pallet (have you run `forklift plt cache` recently?)",
 			)
@@ -250,7 +250,7 @@ func applyAction(toolVersion, repoMinVersion, palletMinVersion string) cli.Actio
 			return err
 		}
 
-		if err := fcli.ApplyPallet(0, pallet, cache); err != nil {
+		if err := fcli.ApplyPallet(0, pallet, cache, c.Bool("parallel")); err != nil {
 			return errors.Wrap(
 				err, "couldn't deploy local pallet (have you run `forklift plt cache` recently?)",
 			)

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -92,7 +92,7 @@ func clonePallet(remote, release, wpath string, force bool) error {
 			return errors.Wrap(
 				err,
 				"you need to first delete your local pallet with `forklift plt rm` before "+
-					"cloning another remote release to it",
+					"cloning another remote release to it, or re-run this command with the `--force` flag",
 			)
 		}
 
@@ -115,7 +115,7 @@ func clonePallet(remote, release, wpath string, force bool) error {
 		}
 	}
 	fmt.Printf("Checking out release %s...\n", release)
-	if err = gitRepo.Checkout(release); err != nil {
+	if err = gitRepo.Checkout(release, "origin"); err != nil {
 		return errors.Wrapf(err, "couldn't check out release %s at %s", release, local)
 	}
 	return nil

--- a/docs/specs/00-package.md
+++ b/docs/specs/00-package.md
@@ -642,6 +642,15 @@ A network service object consists of the following fields:
       - /stream.mjpg
     ```
 
+- `nonblocking` is a boolean flag specifying whether the package deployment providing the required service is allowed to start after starting the package deployment with the service requirement.
+  - This field is optional.
+  - This is a performance optimization hint which may be ignored; it's only meaningful if package deployments can be started concurrently. However, it can help to reduce the startup time needed for the critical path of a chain of dependencies between package deployments.
+  - This field can be set to true if the service client can gracefully handle the temporary absence of the service while package deployments are being applied; otherwise, this field should not be set to true.
+  - Example:
+    ```yaml
+    nonblocking: true
+    ```
+
 #### `provides` subsection
 
 This optional subsection of the `deployment` section specifies the resources provided by an active deployment of the package. This is the same as the `provides` subsection of the `host` section, except that here the resources only exist when a package deployment is active. Here is an example of a `provides` section:

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli/v2 v2.27.1
 	golang.org/x/mod v0.14.0
+	golang.org/x/sync v0.5.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -167,7 +168,6 @@ require (
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/oauth2 v0.11.0 // indirect
-	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/internal/app/forklift/cli/images.go
+++ b/internal/app/forklift/cli/images.go
@@ -42,9 +42,9 @@ func listRequiredImages(
 	if err != nil {
 		return nil, err
 	}
-  if !includeDisabled {
-    depls = forklift.FilterDeplsForEnabled(depls)
-  }
+	if !includeDisabled {
+		depls = forklift.FilterDeplsForEnabled(depls)
+	}
 	resolved, err := forklift.ResolveDepls(pallet, loader, depls)
 	if err != nil {
 		return nil, err

--- a/internal/app/forklift/cli/images.go
+++ b/internal/app/forklift/cli/images.go
@@ -13,8 +13,11 @@ import (
 
 // Download
 
-func DownloadImages(indent int, pallet *forklift.FSPallet, loader forklift.FSPkgLoader) error {
-	orderedImages, err := listRequiredImages(indent, pallet, loader)
+func DownloadImages(
+	indent int, pallet *forklift.FSPallet, loader forklift.FSPkgLoader,
+	includeDisabled, parallel bool,
+) error {
+	orderedImages, err := listRequiredImages(indent, pallet, loader, includeDisabled)
 	if err != nil {
 		return errors.Wrap(err, "couldn't determine images required by package deployments")
 	}
@@ -36,7 +39,7 @@ func DownloadImages(indent int, pallet *forklift.FSPallet, loader forklift.FSPkg
 }
 
 func listRequiredImages(
-	indent int, pallet *forklift.FSPallet, loader forklift.FSPkgLoader,
+	indent int, pallet *forklift.FSPallet, loader forklift.FSPkgLoader, includeDisabled bool,
 ) ([]string, error) {
 	depls, err := pallet.LoadDepls("**/*")
 	if err != nil {
@@ -50,6 +53,10 @@ func listRequiredImages(
 	orderedImages := make([]string, 0, len(resolved))
 	images := make(map[string]struct{})
 	for _, depl := range resolved {
+		if depl.Def.Disabled && !includeDisabled {
+			continue
+		}
+
 		IndentedPrintf(
 			indent, "Checking Docker container images used by package deployment %s...\n", depl.Name,
 		)

--- a/internal/app/forklift/cli/images.go
+++ b/internal/app/forklift/cli/images.go
@@ -42,6 +42,9 @@ func listRequiredImages(
 	if err != nil {
 		return nil, err
 	}
+  if !includeDisabled {
+    depls = forklift.FilterDeplsForEnabled(depls)
+  }
 	resolved, err := forklift.ResolveDepls(pallet, loader, depls)
 	if err != nil {
 		return nil, err
@@ -50,10 +53,6 @@ func listRequiredImages(
 	orderedImages := make([]string, 0, len(resolved))
 	images := make(map[string]struct{})
 	for _, depl := range resolved {
-		if depl.Def.Disabled && !includeDisabled {
-			continue
-		}
-
 		IndentedPrintf(
 			indent, "Checking Docker container images used by package deployment %s...\n", depl.Name,
 		)

--- a/internal/app/forklift/cli/pallets-repositories.go
+++ b/internal/app/forklift/cli/pallets-repositories.go
@@ -162,7 +162,7 @@ func downloadRepo(
 	}
 
 	// Checkout commit
-	if err = gitRepo.Checkout(repo.VersionLock.Def.Commit); err != nil {
+	if err = gitRepo.Checkout(repo.VersionLock.Def.Commit, ""); err != nil {
 		if cerr := os.RemoveAll(repoCachePath); cerr != nil {
 			IndentedPrintf(
 				indent, "Error: couldn't clean up %s! You'll need to delete it yourself.\n", repoCachePath,

--- a/internal/app/forklift/cli/pallets.go
+++ b/internal/app/forklift/cli/pallets.go
@@ -15,6 +15,7 @@ import (
 	"github.com/PlanktoScope/forklift/internal/clients/docker"
 	"github.com/PlanktoScope/forklift/internal/clients/git"
 	"github.com/PlanktoScope/forklift/pkg/core"
+	"github.com/PlanktoScope/forklift/pkg/structures"
 )
 
 // Print
@@ -163,29 +164,31 @@ func printRemoteInfo(indent int, remote *ggit.Remote) {
 
 // Check
 
-func CheckPallet(indent int, pallet *forklift.FSPallet, loader forklift.FSPkgLoader) error {
+func CheckPallet(
+	indent int, pallet *forklift.FSPallet, loader forklift.FSPkgLoader,
+) ([]*forklift.ResolvedDepl, []forklift.SatisfiedDeplDeps, error) {
 	depls, err := pallet.LoadDepls("**/*")
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 	depls = forklift.FilterDeplsForEnabled(depls)
 	resolved, err := forklift.ResolveDepls(pallet, loader, depls)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	conflicts, err := checkDeplConflicts(indent, resolved)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-	_, missingDeps, err := checkDeplDeps(indent, resolved)
+	satisfied, missingDeps, err := checkDeplDeps(indent, resolved)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 	if len(conflicts) > 0 || len(missingDeps) > 0 {
-		return errors.New("pallet failed resource constraint checks")
+		return nil, nil, errors.New("pallet failed resource constraint checks")
 	}
-	return nil
+	return resolved, satisfied, nil
 }
 
 func checkDeplConflicts(
@@ -368,51 +371,40 @@ func printDepCandidate[Res any](indent int, candidate core.ResDepCandidate[Res])
 
 // Plan
 
-func PlanPallet(indent int, pallet *forklift.FSPallet, loader forklift.FSPkgLoader) error {
-	_, _, err := computePlan(indent, pallet, loader)
-	if err != nil {
-		return errors.Wrap(err, "couldn't compute plan for changes")
-	}
-	return nil
-}
-
 const (
-	addReconciliationChange    = "Add"
-	removeReconciliationChange = "Remove"
-	updateReconciliationChange = "Update"
+	addReconciliationChange    = "add"
+	removeReconciliationChange = "remove"
+	updateReconciliationChange = "update"
 )
 
-type reconciliationChange struct {
+type ReconciliationChange struct {
 	Name string
 	Type string
-	Depl *forklift.ResolvedDepl
-	App  api.Stack
+	Depl *forklift.ResolvedDepl // this is nil for an app to be removed
+	App  api.Stack              // this is empty for an app which does not yet exist
 }
 
-func newAddReconciliationChange(deplName string, depl *forklift.ResolvedDepl) reconciliationChange {
-	return reconciliationChange{
+func (c *ReconciliationChange) String() string {
+	if c.Depl == nil {
+		return fmt.Sprintf("(%s %s)", c.Type, c.Name)
+	}
+	return fmt.Sprintf("(%s %s)", c.Type, c.Depl.Name)
+}
+
+func (c *ReconciliationChange) PlanString() string {
+	if c.Depl == nil {
+		return fmt.Sprintf("%s Compose app %s (from unknown deployment)", c.Type, c.Name)
+	}
+	return fmt.Sprintf("%s deployment %s as Compose app %s", c.Type, c.Depl.Name, c.Name)
+}
+
+func newAddReconciliationChange(
+	deplName string, depl *forklift.ResolvedDepl,
+) *ReconciliationChange {
+	return &ReconciliationChange{
 		Name: getAppName(deplName),
 		Type: addReconciliationChange,
 		Depl: depl,
-	}
-}
-
-func newUpdateReconciliationChange(
-	deplName string, depl *forklift.ResolvedDepl, app api.Stack,
-) reconciliationChange {
-	return reconciliationChange{
-		Name: getAppName(deplName),
-		Type: updateReconciliationChange,
-		Depl: depl,
-		App:  app,
-	}
-}
-
-func newRemoveReconciliationChange(appName string, app api.Stack) reconciliationChange {
-	return reconciliationChange{
-		Name: appName,
-		Type: removeReconciliationChange,
-		App:  app,
 	}
 }
 
@@ -420,188 +412,236 @@ func getAppName(deplName string) string {
 	return strings.ReplaceAll(deplName, "/", "_")
 }
 
-func computePlan(
-	indent int, pallet *forklift.FSPallet, loader forklift.FSPkgLoader,
-) ([]reconciliationChange, *docker.Client, error) {
-	depls, err := pallet.LoadDepls("**/*")
-	if err != nil {
-		return nil, nil, err
+func newUpdateReconciliationChange(
+	deplName string, depl *forklift.ResolvedDepl, app api.Stack,
+) *ReconciliationChange {
+	return &ReconciliationChange{
+		Name: getAppName(deplName),
+		Type: updateReconciliationChange,
+		Depl: depl,
+		App:  app,
 	}
-	depls = forklift.FilterDeplsForEnabled(depls)
-	resolved, err := forklift.ResolveDepls(pallet, loader, depls)
-	if err != nil {
-		return nil, nil, err
-	}
+}
 
+func newRemoveReconciliationChange(appName string, app api.Stack) *ReconciliationChange {
+	return &ReconciliationChange{
+		Name: appName,
+		Type: removeReconciliationChange,
+		App:  app,
+	}
+}
+
+// PlanPallet builds a plan for changes to make to the Docker host in order to reconcile it with the
+// desired state as expressed by the pallet. The plan is expressed as a dependency graph which can
+// be used to build a partial ordering of the changes (where each change is a node in the graph)
+// for concurrent execution, and - if serial execution is required either because the parallel arg
+// is set to true or because a dependency cycle was detected - a total ordering of the changes for
+// serial (rather than concurrent) execution.
+func PlanPallet(
+	indent int, pallet *forklift.FSPallet, loader forklift.FSPkgLoader, parallel bool,
+) (
+	changeDeps structures.Digraph[*ReconciliationChange], serialization []*ReconciliationChange,
+	err error,
+) {
 	dc, err := docker.NewClient()
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "couldn't make Docker API client")
 	}
+
+	resolvedDepls, satisfiedDeps, err := CheckPallet(indent, pallet, loader)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "couldn't ensure pallet validity")
+	}
+	IndentedPrintln(indent, "Resolving resource dependencies among package deployments...")
+	resolvedDeps := forklift.ResolveDeps(satisfiedDeps)
+	IndentedPrintln(indent, "Direct dependencies:")
+	printDigraph(indent+1, resolvedDeps, "requires")
+
+	fmt.Println()
+	IndentedPrintln(indent, "Determining and ordering package deployment changes...")
 	apps, err := dc.ListApps(context.Background())
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "couldn't list active Docker Compose apps")
 	}
-
-	conflicts, err := checkDeplConflicts(indent, resolved)
-	if err != nil {
-		return nil, nil, err
+	if changeDeps, serialization, err = computePlan(
+		indent, resolvedDepls, resolvedDeps, apps, parallel,
+	); err != nil {
+		return nil, nil, errors.Wrap(err, "couldn't compute plan for changes")
 	}
-	satisfiedDeps, missingDeps, err := checkDeplDeps(indent, resolved)
-	if err != nil {
-		return nil, nil, err
-	}
-	if len(conflicts) > 0 || len(missingDeps) > 0 {
-		return nil, nil, errors.New("pallet failed resource constraint checks")
-	}
-
-	IndentedPrintln(indent, "Resolving resource dependencies among package deployments...")
-	deps := resolveDeps(satisfiedDeps)
-	IndentedPrintln(indent, "Direct dependencies:")
-	printDigraph(indent+1, deps, "directly depends on")
-	IndentedPrintln(indent, "(In)direct dependencies:")
-	deps = computeTransitiveClosure(deps)
-	printDigraph(indent+1, deps, "(in)directly depends on")
-
-	// TODO: warn about any circular dependencies, until we can make a reconciliation plan where
-	// relevant resources (i.e. Docker networks) are created simultaneously so that circular
-	// dependencies don't prevent successful application. We can safely assume that clients of
-	// services can handle a transiently missing service (i.e. missing while only part of the circular
-	// dependency has been created so far).
-
-	fmt.Println()
-	IndentedPrintln(indent, "Determining package deployment changes...")
-	changes, err := planReconciliation(resolved, deps, apps)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "couldn't plan changes")
-	}
-	for _, change := range changes {
-		printReconciliationChange(indent, change)
-	}
-	return changes, dc, nil
+	return changeDeps, serialization, nil
 }
 
-// resolveDeps returns a map of sets, where each key is the name of a deployment and the
-// the value is the set of deployments providing its required resources.
-func resolveDeps(satisfiedDeps []forklift.SatisfiedDeplDeps) map[string]map[string]struct{} {
-	deps := make(map[string]map[string]struct{})
-	for _, satisfied := range satisfiedDeps {
-		providers := make(map[string]struct{})
-		for _, network := range satisfied.Networks {
-			provider := strings.TrimPrefix(network.Provided.Source[0], "deployment ")
-			if provider == satisfied.Depl.Name { // i.e. the deployment requires a resource it provides
-				continue
-			}
-			providers[provider] = struct{}{}
-		}
-		for _, service := range satisfied.Services {
-			provider := strings.TrimPrefix(service.Provided.Source[0], "deployment ")
-			if provider == satisfied.Depl.Name { // i.e. the deployment requires a resource it provides
-				continue
-			}
-			providers[provider] = struct{}{}
-		}
-		deps[satisfied.Depl.Name] = providers
-	}
-	return deps
-}
-
-func printDigraph(
-	indent int, digraph map[string]map[string]struct{}, edgeType string,
+func printDigraph[Node comparable, Digraph structures.MapDigraph[Node]](
+	indent int, digraph Digraph, edgeType string,
 ) {
-	sortedNodes := make([]string, 0, len(digraph))
+	sortedNodes := make([]Node, 0, len(digraph))
 	for node := range digraph {
 		sortedNodes = append(sortedNodes, node)
 	}
-	sort.Strings(sortedNodes)
+	sort.Slice(sortedNodes, func(i, j int) bool {
+		return fmt.Sprintf("%v", sortedNodes[i]) < fmt.Sprintf("%v", sortedNodes[j])
+	})
 	for _, node := range sortedNodes {
-		upstreamNodes := make([]string, 0, len(digraph[node]))
-		for dep := range digraph[node] {
-			upstreamNodes = append(upstreamNodes, dep)
-		}
-		sort.Strings(upstreamNodes)
-		if len(upstreamNodes) > 0 {
-			IndentedPrintf(indent, "%s %s: %+v\n", node, edgeType, upstreamNodes)
-		}
+		printNodeOutboundEdges(indent, digraph, node, edgeType)
 	}
 }
 
-// computeTransitiveClosure returns, given a set of direct dependencies for every deployment, a set
-// of all direct and indirect dependencies for every deployment. This is just the transitive closure
-// of the relation expressed by the digraph. Iff the digraph isn't a DAG (i.e. iff it has cycles),
-// then each node in the cycle will have an edge directed to itself.
-func computeTransitiveClosure(
-	digraph map[string]map[string]struct{},
-) map[string]map[string]struct{} {
-	// Seed the transitive closure with the initial digraph
-	closure := make(map[string]map[string]struct{})
-	prevChangedNodes := make(map[string]bool)
-	changedNodes := make(map[string]bool)
-	for node, upstreamNodes := range digraph {
-		closure[node] = make(map[string]struct{})
-		for upstreamNode := range upstreamNodes {
-			closure[node][upstreamNode] = struct{}{}
-		}
-		prevChangedNodes[node] = true
-		changedNodes[node] = true
+func printNodeOutboundEdges[Node comparable, Digraph structures.MapDigraph[Node]](
+	indent int, digraph Digraph, node Node, edgeType string,
+) {
+	upstreamNodes := make([]Node, 0, len(digraph[node]))
+	for dep := range digraph[node] {
+		upstreamNodes = append(upstreamNodes, dep)
 	}
-	// This algorithm is very asymptotically inefficient when long paths exist between nodes, but it's
-	// easy to understand, and performance is good enough for a typical use case in dependency
-	// resolution where dependency trees should be kept relatively shallow.
-	for {
-		converged := true
-		for node, upstreamNodes := range closure {
-			initial := len(upstreamNodes)
-			for upstreamNode := range upstreamNodes {
-				if !prevChangedNodes[upstreamNode] { // this is just a performance optimization
-					continue
-				}
-				// Add the dependency's own dependencies to the set of dependencies
-				transitiveNodes := closure[upstreamNode]
-				for transitiveNode := range transitiveNodes {
-					upstreamNodes[transitiveNode] = struct{}{}
-				}
-			}
-			final := len(upstreamNodes)
-			changedNodes[node] = initial != final
-			if changedNodes[node] {
-				converged = false
-			}
-		}
-		if converged {
-			return closure
-		}
-		prevChangedNodes = changedNodes
-		changedNodes = make(map[string]bool)
+	sort.Slice(upstreamNodes, func(i, j int) bool {
+		return fmt.Sprintf("%v", upstreamNodes[i]) < fmt.Sprintf("%v", upstreamNodes[j])
+	})
+	if len(upstreamNodes) == 0 {
+		IndentedPrintf(indent, "%v %s nothing", node, edgeType)
+	} else {
+		IndentedPrintf(indent, "%v %s: %+v", node, edgeType, upstreamNodes)
 	}
+	fmt.Println()
 }
 
-// invertDeps produces a map associating every deployment to the set of deployments
-// depending on it. In other words, it reverses the edges of the DAG of dependencies among
-// deployments.
-func invertDeps(deps map[string]map[string]struct{}) map[string]map[string]struct{} {
-	dependents := make(map[string]map[string]struct{})
-	for depl, deps := range deps {
-		for dependency := range deps {
-			if _, ok := dependents[dependency]; !ok {
-				dependents[dependency] = make(map[string]struct{})
-			}
-			dependents[dependency][depl] = struct{}{}
+// computePlan builds a dependency graph of changes to make to the Docker host (as a plan for
+// concurrent execution), for a given list of resolved package deployments, a precomputed graph of
+// direct dependency relationships between them, and a list of currently active Compose apps.
+func computePlan(
+	indent int, depls []*forklift.ResolvedDepl, deplDirectDeps structures.Digraph[string],
+	apps []api.Stack, parallel bool,
+) (
+	changeDirectDeps structures.Digraph[*ReconciliationChange], serialization []*ReconciliationChange,
+	err error,
+) {
+	// TODO: make a reconciliation plan where relevant resources (i.e. Docker networks) are created
+	// simultaneously/independently so that circular dependencies for those resouces won't prevent
+	// successful application.
+	changes, err := identifyReconciliationChanges(depls, apps)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "couldn't identify the changes to make")
+	}
+
+	changeDirectDeps = planReconciliation(changes, deplDirectDeps)
+	IndentedPrintln(indent, "Ordering relationships:")
+	printDigraph(indent+1, changeDirectDeps, "after")
+	changeIndirectDeps := changeDirectDeps.ComputeTransitiveClosure()
+	if cycles := changeIndirectDeps.IdentifyCycles(); len(cycles) > 0 {
+		IndentedPrintln(
+			indent, "WARNING: detected ordering cycles:",
+		)
+		for _, cycle := range cycles {
+			IndentedPrintf(indent+1, "cycle between: %s\n", cycle)
+		}
+		IndentedPrintln(
+			indent,
+			"To prevent deadlocks from cycles, changes must be applied serially, not concurrently.",
+		)
+		parallel = false
+	}
+
+	if !parallel {
+		fmt.Println()
+		IndentedPrintln(indent, "Serialized ordering of package deployment changes:")
+		serialization = planReconciliationSerial(changes, changeIndirectDeps)
+		for _, change := range serialization {
+			IndentedPrintf(indent+1, "%s\n", change.PlanString())
 		}
 	}
-	return dependents
+	return changeDirectDeps, serialization, nil
 }
 
-// planReconciliation produces a list of changes to make on the Docker host based on the desired
-// list of deployments, a transitive closure of dependencies among those deployments, a transitive
-// closure of the deployments depending on each deployment, and a list of
-// Docker Compose apps describing the current complete state of the Docker host.
+// planReconciliation produces a dependency graph of changes to make on the Docker host based on the
+// desired list of deployments, a graph of direct dependencies among those deployments, and a list
+// of Docker Compose apps describing the current complete state of the Docker host. The returned
+// dependency graph is a map between each reconciliation change and the respective set of other
+// reconciliation changes which must be completed first.
 func planReconciliation(
-	depls []*forklift.ResolvedDepl, deps map[string]map[string]struct{}, apps []api.Stack,
-) ([]reconciliationChange, error) {
-	deplSet := make(map[string]*forklift.ResolvedDepl)
-	composeAppDefinerSet := make(map[string]struct{})
+	changes []*ReconciliationChange, directDeps structures.Digraph[string],
+) structures.Digraph[*ReconciliationChange] {
+	removalChanges := make(map[string]*ReconciliationChange)    // keyed by app name
+	nonremovalChanges := make(map[string]*ReconciliationChange) // keyed by depl name
+	graph := make(structures.Digraph[*ReconciliationChange])
+	for _, change := range changes {
+		graph.AddNode(change)
+		if change.Type == removeReconciliationChange {
+			removalChanges[change.Name] = change
+			continue
+		}
+		nonremovalChanges[change.Depl.Name] = change
+	}
+	// FIXME: ideally we would order the removal changes based on dependency relationships between
+	// the Compose apps, e.g. with networks. With removals we don't have deployments which would
+	// tell us about Docker resource dependency relationships, so we'd need to determine this from
+	// Docker. If app r depends on a resource provided by app s, then app r must be removed first -
+	// so the removal of app s depends upon the removal of app r.
+	// Remove old resources first, in case additions/updates would add overlapping resources.
+	for _, change := range nonremovalChanges {
+		for _, removalChange := range removalChanges {
+			graph.AddEdge(change, removalChange)
+		}
+	}
+	for _, dependent := range nonremovalChanges {
+		for deplName := range directDeps[dependent.Depl.Name] {
+			if dependency, ok := nonremovalChanges[deplName]; ok {
+				graph.AddEdge(dependent, dependency)
+			}
+		}
+	}
+
+	return graph
+}
+
+// identifyReconciliationChanges builds an arbitrarily-ordered list of changes to carry out to
+// reconcile the desired list of deployments with the actual list of active Docker Compose apps.
+func identifyReconciliationChanges(
+	depls []*forklift.ResolvedDepl, apps []api.Stack,
+) ([]*ReconciliationChange, error) {
+	deplsByName := make(map[string]*forklift.ResolvedDepl)
 	for _, depl := range depls {
-		deplSet[depl.Name] = depl
+		deplsByName[depl.Name] = depl
+	}
+	appsByName := make(map[string]api.Stack)
+	for _, app := range apps {
+		appsByName[app.Name] = app
+	}
+	composeAppDefinerSet, err := identifyComposeAppDefiners(deplsByName)
+	if err != nil {
+		return nil, err
+	}
+
+	appDeplNames := make(map[string]string)
+	changes := make([]*ReconciliationChange, 0, len(depls)+len(apps))
+	for name, depl := range deplsByName {
+		appDeplNames[getAppName(name)] = name
+		app, ok := appsByName[getAppName(name)]
+		if !ok {
+			if composeAppDefinerSet.Has(name) {
+				changes = append(changes, newAddReconciliationChange(name, depl))
+			}
+			continue
+		}
+		if composeAppDefinerSet.Has(name) {
+			changes = append(changes, newUpdateReconciliationChange(name, depl, app))
+		}
+	}
+	for name, app := range appsByName {
+		if deplName, ok := appDeplNames[name]; ok {
+			if composeAppDefinerSet.Has(deplName) {
+				continue
+			}
+		}
+		changes = append(changes, newRemoveReconciliationChange(name, app))
+	}
+	return changes, nil
+}
+
+// identifyComposeAppDefiners builds a set of the names of deployments which define Compose apps.
+func identifyComposeAppDefiners(
+	depls map[string]*forklift.ResolvedDepl,
+) (structures.Set[string], error) {
+	composeAppDefinerSet := make(structures.Set[string])
+	for _, depl := range depls {
 		definesApp, err := depl.DefinesApp()
 		if err != nil {
 			return nil, errors.Wrapf(
@@ -609,112 +649,66 @@ func planReconciliation(
 			)
 		}
 		if definesApp {
-			composeAppDefinerSet[depl.Name] = struct{}{}
+			composeAppDefinerSet.Add(depl.Name)
 		}
 	}
-	appSet := make(map[string]api.Stack)
-	for _, app := range apps {
-		appSet[app.Name] = app
-	}
+	return composeAppDefinerSet, nil
+}
 
-	appDeplNames := make(map[string]string)
-	changes := make([]reconciliationChange, 0, len(deplSet)+len(appSet))
-	for name, depl := range deplSet {
-		appDeplNames[getAppName(name)] = name
-		app, ok := appSet[getAppName(name)]
-		if !ok {
-			if _, ok := composeAppDefinerSet[name]; ok {
-				changes = append(changes, newAddReconciliationChange(name, depl))
-			}
-			continue
-		}
-		if _, ok := composeAppDefinerSet[name]; ok {
-			changes = append(changes, newUpdateReconciliationChange(name, depl, app))
-		}
-	}
-	for name, app := range appSet {
-		if deplName, ok := appDeplNames[name]; ok {
-			if _, ok = composeAppDefinerSet[deplName]; ok {
-				continue
-			}
-		}
-		changes = append(changes, newRemoveReconciliationChange(name, app))
-	}
-
-	dependents := invertDeps(deps)
-	// Sequence the changes such that they can (hopefully) be carried out successfully
+// planReconciliationSerial produces a total ordering of the provided sequence of changes to make on
+// the Docker host, given a transitive closure of dependencies among changes.
+func planReconciliationSerial(
+	changes []*ReconciliationChange, deps structures.TransitiveClosure[*ReconciliationChange],
+) []*ReconciliationChange {
+	dependents := deps.Invert()
 	sort.Slice(changes, func(i, j int) bool {
-		return compareChanges(changes[i], changes[j], deps, dependents) == core.CompareLT
+		return compareChangesTotal(changes[i], changes[j], deps, dependents) == core.CompareLT
 	})
-	return changes, nil
+	return changes
 }
 
-// compareChanges returns a comparison for generating a total ordering of reconciliation changes
-// so that they are applied in a way that will (hopefully) succeed for all changes. Deps
-// should be a transitive closure of dependencies, and dependents should be a transitive closure of
-// dependents.
-func compareChanges(
-	r, s reconciliationChange, deps, dependents map[string]map[string]struct{},
+// compareChangesTotal returns a comparison for generating a total ordering of reconciliation
+// changes so that they are applied serially and sequentially in a way that will (hopefully) succeed
+// for all changes. deps should be a transitive closure of dependencies between changes, and
+// dependents should be the inverse of deps.
+// This function returns -1 if r should occur before s and 1 if s should occur before r.
+func compareChangesTotal(
+	r, s *ReconciliationChange, deps, dependents structures.TransitiveClosure[*ReconciliationChange],
 ) int {
-	// Remove old resources first, in case additions/updates would add overlapping resources.
-	if result := compareReconciliationChangesByType(r, s); result != core.CompareEQ {
+	// Apply the partial ordering from dependencies
+	if result := compareReconciliationChangesByDeps(r, s, deps); result != core.CompareEQ {
 		return result
-	}
-	// Now r.Depl and s.Depl are either both nil or both non-nil
-	if r.Depl == nil && s.Depl == nil {
-		return compareDeplNames(r.Name, s.Name)
 	}
 
-	// Now r and s are either both removals or both changes/additions
-	if result := compareReconciliationChangesByDeplDeps(r, s, deps); result != core.CompareEQ {
-		return result
-	}
 	// Now r and s either are in a circular dependency or have no dependency relationships
-	if result := compareDeplsByDepCounts(
-		r.Depl.Name, s.Depl.Name, deps, dependents,
-	); result != core.CompareEQ {
+	if result := compareDeplsByDepCounts(r, s, deps, dependents); result != core.CompareEQ {
 		return result
 	}
-	return compareDeplNames(r.Depl.Name, s.Depl.Name)
+
+	// Compare by names as a last resort
+	if r.Depl != nil && s.Depl != nil {
+		return compareDeplNames(r.Depl.Name, s.Depl.Name)
+	}
+	return compareDeplNames(r.Name, s.Name)
 }
 
-func compareReconciliationChangesByType(r, s reconciliationChange) int {
-	if r.Type == removeReconciliationChange && s.Type != removeReconciliationChange {
-		return core.CompareLT
-	}
-	if r.Type != removeReconciliationChange && s.Type == removeReconciliationChange {
+func compareReconciliationChangesByDeps(
+	r, s *ReconciliationChange, deps structures.TransitiveClosure[*ReconciliationChange],
+) int {
+	rDependsOnS := deps.HasEdge(r, s)
+	sDependsOnR := deps.HasEdge(s, r)
+	if rDependsOnS && !sDependsOnR {
 		return core.CompareGT
 	}
-	return core.CompareEQ
-}
-
-func compareReconciliationChangesByDeplDeps(
-	r, s reconciliationChange, deps map[string]map[string]struct{},
-) int {
-	rDependsOnS := false
-	if rDeps, ok := deps[r.Depl.Name]; ok {
-		_, rDependsOnS = rDeps[s.Depl.Name]
-	}
-	sDependsOnR := false
-	if sDeps, ok := deps[s.Depl.Name]; ok {
-		_, sDependsOnR = sDeps[r.Depl.Name]
-	}
-	if rDependsOnS && !sDependsOnR {
-		if r.Type == removeReconciliationChange { // i.e. r and s are both removals
-			return core.CompareLT // removal r goes before removal s
-		}
-		return core.CompareGT // addition/update r goes after addition/update s
-	}
 	if !rDependsOnS && sDependsOnR {
-		if s.Type == removeReconciliationChange { // i.e. r and s are both removals
-			return core.CompareGT // removal r goes after removal s
-		}
-		return core.CompareLT // addition/update r goes before addition/update s
+		return core.CompareLT
 	}
 	return core.CompareEQ
 }
 
-func compareDeplsByDepCounts(r, s string, deps, dependents map[string]map[string]struct{}) int {
+func compareDeplsByDepCounts(
+	r, s *ReconciliationChange, deps, dependents structures.TransitiveClosure[*ReconciliationChange],
+) int {
 	// Deployments with greater numbers of dependents go first (needed for correct ordering among
 	// unrelated deployments sorted by sort.Slice).
 	if len(dependents[r]) > len(dependents[s]) {
@@ -723,7 +717,7 @@ func compareDeplsByDepCounts(r, s string, deps, dependents map[string]map[string
 	if len(dependents[r]) < len(dependents[s]) {
 		return core.CompareGT
 	}
-	// Deployments with greater numbers of deps go first (for aesthetic reasons)
+	// Deployments with greater numbers of dependencies go first (for aesthetic reasons)
 	if len(deps[r]) > len(deps[s]) {
 		return core.CompareLT
 	}
@@ -743,30 +737,27 @@ func compareDeplNames(r, s string) int {
 	return core.CompareEQ
 }
 
-func printReconciliationChange(indent int, change reconciliationChange) {
-	if change.Depl == nil {
-		IndentedPrintf(
-			indent, "Will %s Compose app %s (from unknown deployment)\n",
-			strings.ToLower(change.Type), change.Name,
-		)
-		return
-	}
-	IndentedPrintf(
-		indent, "Will %s deployment %s as Compose app %s\n",
-		strings.ToLower(change.Type), change.Depl.Name, change.Name,
-	)
-}
-
 // Apply
 
-func ApplyPallet(indent int, pallet *forklift.FSPallet, loader forklift.FSPkgLoader) error {
-	changes, dc, err := computePlan(indent, pallet, loader)
+func ApplyPallet(
+	indent int, pallet *forklift.FSPallet, loader forklift.FSPkgLoader, parallel bool,
+) error {
+	_, serialization, err := PlanPallet(indent, pallet, loader, parallel)
 	if err != nil {
-		return errors.Wrap(err, "couldn't compute plan for changes")
+		return err
 	}
 
-	for _, change := range changes {
-		if err := applyReconciliationChange(0, change, dc); err != nil {
+	if parallel {
+		// TODO: implement, using partialOrder
+		return errors.New("parallel application not yet implemented!")
+	}
+
+	dc, err := docker.NewClient()
+	if err != nil {
+		return errors.Wrap(err, "couldn't make Docker API client")
+	}
+	for _, change := range serialization {
+		if err := applyReconciliationChange(0, *change, dc); err != nil {
 			return errors.Wrapf(
 				err, "couldn't apply '%s' change to Compose app %s", change.Type, change.Name,
 			)
@@ -776,7 +767,7 @@ func ApplyPallet(indent int, pallet *forklift.FSPallet, loader forklift.FSPkgLoa
 }
 
 func applyReconciliationChange(
-	indent int, change reconciliationChange, dc *docker.Client,
+	indent int, change ReconciliationChange, dc *docker.Client,
 ) error {
 	fmt.Println()
 	switch change.Type {

--- a/internal/clients/git/git.go
+++ b/internal/clients/git/git.go
@@ -52,11 +52,11 @@ func (r *Repo) makeCheckoutOptions(release string, remote string) git.CheckoutOp
 			Branch: plumbing.NewTagReferenceName(release),
 		}
 	}
-  if remote != "" {
-    return git.CheckoutOptions{
-      Branch: plumbing.NewRemoteReferenceName(remote, release),
-    }
-  }
+	if remote != "" {
+		return git.CheckoutOptions{
+			Branch: plumbing.NewRemoteReferenceName(remote, release),
+		}
+	}
 	return git.CheckoutOptions{
 		Branch: plumbing.NewBranchReferenceName(release),
 	}

--- a/internal/clients/git/git.go
+++ b/internal/clients/git/git.go
@@ -34,7 +34,7 @@ func (r *Repo) resolveCommit(commit string) (*plumbing.Hash, error) {
 	return nil, errors.Errorf("%s appears to be a non-commit revision name", commit)
 }
 
-func (r *Repo) makeCheckoutOptions(release string) git.CheckoutOptions {
+func (r *Repo) makeCheckoutOptions(release string, remote string) git.CheckoutOptions {
 	if plumbing.IsHash(release) {
 		return git.CheckoutOptions{
 			Hash: plumbing.NewHash(release),
@@ -52,17 +52,22 @@ func (r *Repo) makeCheckoutOptions(release string) git.CheckoutOptions {
 			Branch: plumbing.NewTagReferenceName(release),
 		}
 	}
+  if remote != "" {
+    return git.CheckoutOptions{
+      Branch: plumbing.NewRemoteReferenceName(remote, release),
+    }
+  }
 	return git.CheckoutOptions{
 		Branch: plumbing.NewBranchReferenceName(release),
 	}
 }
 
-func (r *Repo) Checkout(release string) error {
+func (r *Repo) Checkout(release string, remote string) error {
 	worktree, err := r.repository.Worktree()
 	if err != nil {
 		return err
 	}
-	checkoutOptions := r.makeCheckoutOptions(release)
+	checkoutOptions := r.makeCheckoutOptions(release, remote)
 	if err = worktree.Checkout(&checkoutOptions); err != nil {
 		return err
 	}

--- a/pkg/core/packages-models.go
+++ b/pkg/core/packages-models.go
@@ -156,4 +156,7 @@ type ServiceRes struct {
 	// Paths is a list of paths used for accessing the service. A path may also be a prefix, indicated
 	// by ending the path with an asterisk (`*`).
 	Paths []string `yaml:"paths,omitempty"`
+	// Nonblocking, when specified as a resource requirement, specifies that the client of the service
+	// does not need to wait for the resource to exist before the client can start.
+	Nonblocking bool `yaml:"nonblocking,omitempty"`
 }

--- a/pkg/structures/digraph.go
+++ b/pkg/structures/digraph.go
@@ -1,0 +1,167 @@
+package structures
+
+import (
+	"fmt"
+	"sort"
+)
+
+// MapDigraph
+
+type MapDigraph[Node comparable] interface {
+	~map[Node]Set[Node]
+}
+
+// Digraph
+
+type Digraph[Node comparable] map[Node]Set[Node]
+
+// AddNode adds the node to the graph. If the node was already in the graph, nothing changes.
+func (g Digraph[Node]) AddNode(n Node) {
+	if _, ok := g[n]; ok {
+		return
+	}
+	g[n] = make(Set[Node])
+}
+
+// AddEdge adds an edge from the first node to the second node. If the edge was already in the
+// graph, nothing changes.
+func (g Digraph[Node]) AddEdge(from, to Node) {
+	g.AddNode(from)
+	g.AddNode(to)
+	g[from].Add(to)
+}
+
+// HasEdge checks whether an edge exists from the first node to the second node.
+func (g Digraph[Node]) HasEdge(from, to Node) bool {
+	targetNodes, ok := g[from]
+	if !ok {
+		return false
+	}
+	return targetNodes.Has(to)
+}
+
+// ComputeTransitiveClosure adds edges between every pair of nodes which are transitively connected
+// by some path of directed edges. This is just the transitive closure of the relation expressed by
+// the digraph. Iff the digraph isn't a DAG (i.e. iff it has cycles), then each node in the cycle
+// will have an edge directed to itself.
+func (g Digraph[Node]) ComputeTransitiveClosure() TransitiveClosure[Node] {
+	// Seed the transitive closure with the initial digraph
+	closure := make(TransitiveClosure[Node])
+	prevChangedNodes := make(map[Node]bool)
+	changedNodes := make(map[Node]bool)
+	for node, upstreamNodes := range g {
+		closure[node] = make(Set[Node])
+		for upstreamNode := range upstreamNodes {
+			closure[node].Add(upstreamNode)
+		}
+		prevChangedNodes[node] = true
+		changedNodes[node] = true
+	}
+	// This algorithm is very asymptotically inefficient when long paths exist between nodes, but it's
+	// easy to understand, and performance is good enough for a typical use case in dependency
+	// resolution where dependency trees should be kept relatively shallow.
+	for {
+		converged := true
+		for node, upstreamNodes := range closure {
+			initial := len(upstreamNodes)
+			for upstreamNode := range upstreamNodes {
+				if !prevChangedNodes[upstreamNode] { // this is just a performance optimization
+					continue
+				}
+				// Add the dependency's own dependencies to the set of dependencies
+				transitiveNodes := closure[upstreamNode]
+				for transitiveNode := range transitiveNodes {
+					upstreamNodes.Add(transitiveNode)
+				}
+			}
+			final := len(upstreamNodes)
+			changedNodes[node] = initial != final
+			if changedNodes[node] {
+				converged = false
+			}
+		}
+		if converged {
+			return closure
+		}
+		prevChangedNodes = changedNodes
+		changedNodes = make(map[Node]bool)
+	}
+}
+
+// Invert converts a digraph of children pointing to parents into a new digraph of parents pointing
+// to children.
+func (g Digraph[Node]) Invert() Digraph[Node] {
+	inverted := make(Digraph[Node])
+	for child, parents := range g {
+		for parent := range parents {
+			inverted.AddNode(parent)
+			inverted[parent].Add(child)
+			inverted.AddNode(child)
+		}
+	}
+	return inverted
+}
+
+// Transitive closure
+
+type TransitiveClosure[Node comparable] Digraph[Node]
+
+// addNode adds the node to the graph. If the node was already in the graph, nothing changes.
+// This method is private because it should only be used to create a new TransitiveClosure, e.g. as
+// part of the Invert method; any other uses will corrupt the state of the transitive closure.
+func (g TransitiveClosure[Node]) addNode(n Node) {
+	if _, ok := g[n]; ok {
+		return
+	}
+	g[n] = make(Set[Node])
+}
+
+// HasEdge checks whether an edge exists from the first node to the second node.
+func (g TransitiveClosure[Node]) HasEdge(from, to Node) bool {
+	targetNodes, ok := g[from]
+	if !ok {
+		return false
+	}
+	return targetNodes.Has(to)
+}
+
+// IdentifyCycles builds a sorted list of cycles in the transitive closure, where each cycle is a
+// list of nodes sorted lexigoraphically by the node's string representation.
+func (g TransitiveClosure[Node]) IdentifyCycles() [][]Node {
+	cycles := make(map[string][]Node)
+	for node, parents := range g {
+		if parents.Has(node) { // this node is part of a cycle
+			cycle := make([]Node, 0, len(parents))
+			for parent := range parents {
+				cycle = append(cycle, parent)
+			}
+			sort.Slice(cycle, func(i, j int) bool {
+				return fmt.Sprintf("%v", cycle[i]) < fmt.Sprintf("%v", cycle[j])
+			})
+			cycles[fmt.Sprintf("%+v", cycle)] = cycle
+		}
+	}
+	// TODO: sort the cycle
+	orderedCycles := make([][]Node, 0, len(cycles))
+	for _, cycle := range cycles {
+		orderedCycles = append(orderedCycles, cycle)
+	}
+	sort.Slice(orderedCycles, func(i, j int) bool {
+		return fmt.Sprintf("%+v", orderedCycles[i]) < fmt.Sprintf("%+v", orderedCycles[j])
+	})
+	return orderedCycles
+}
+
+// Invert converts a digraph of children pointing to parents into a new digraph of parents pointing
+// to children.
+func (g TransitiveClosure[Node]) Invert() TransitiveClosure[Node] {
+	inverted := make(TransitiveClosure[Node])
+	for child, parents := range g {
+		for parent := range parents {
+			inverted.addNode(parent)
+			inverted[parent].Add(child)
+			inverted.addNode(child)
+		}
+	}
+	return inverted
+}

--- a/pkg/structures/set.go
+++ b/pkg/structures/set.go
@@ -1,0 +1,14 @@
+// Package structures provides a few generic data structures.
+package structures
+
+type Set[Node comparable] map[Node]struct{}
+
+// Add adds the node to the set. If the node was already in the set, nothing changes.
+func (s Set[Node]) Add(n Node) {
+	s[n] = struct{}{}
+}
+
+func (s Set[Node]) Has(n Node) bool {
+	_, ok := s[n]
+	return ok
+}


### PR DESCRIPTION
This PR makes progress on https://github.com/PlanktoScope/PlanktoScope/issues/219 and follows up on findings from https://github.com/PlanktoScope/PlanktoScope/pull/324 by allowing the various slow Docker-related operations to be run in parallel. Specifically, this PR enables parallelization of:
- `plt cache-img` and `dev plt cache-img` (only used in the setup script)
- `plt apply` and `dev plt apply`