### PR TITLE
Add fileset resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### 0.5.1 - 2024-02-07
+### Added
+
+- (spec) Added a "fileset" resource type for files (which can include directories).
+
+## 0.5.1 - 2024-02-07
 
 - (cli) Added a `plt switch` subcommand which is the equivalent of running `plt clone --force` and then running `plt cache-repo` and then running `plt apply`. This allows a common task (switching the version of a pallet and applying it immediately) to be run with a single command, for a simpler user experience.
 

--- a/docs/specs/00-package.md
+++ b/docs/specs/00-package.md
@@ -2,11 +2,9 @@
 
 This specification defines Forklift packages and repositories.
 
-
 ## Introduction
 
 This specification's design is heavily inspired by the design of the Go programming language and its module system, and this reference document tries to echo the [reference document for Go modules](https://go.dev/ref/mod) for familiarity; certain aspects of packages are also inspired by the Rust programming language's [Cargo](https://doc.rust-lang.org/cargo/) package management system.
-
 
 ## Repositories, packages, and versions
 
@@ -21,11 +19,13 @@ A Forklift *package* is a configuration of a software application which can be d
 All of this information is declared in a `forklift-package.yml` file. The *package root directory* is the directory that contains the package's `forklift-package.yml` file.
 
 ### Repository paths
+
 A *repository path* is the canonical name for a Forklift repository, declared with the `path` field in the repository's `forklift-repository.yml` file. A repository's path is the prefix for the package paths of packages provided by the repository.
 
 A repository path should communicate both what the repository does and where to find it. A Forklift repository path is just the path of the Git repository which contains the Forklift repository. `github.com/PlanktoScope/device-pkgs` is an example of a repository path.
 
 ### Versions
+
 A *version* is a Git tag which identifies an immutable snapshot of a repository and all packages in the repository; thus, all packages in any single commit of a repository will have always have identical versions, and all packages in a repository will always have the same version for a given Git commit. A version may be either a release or a pre-release. Once a Git tag is created, it should not be deleted or changed to a different revision. Versions should be authenticated to ensure safe, repeatable deployments. If a tag is modified, clients may see a security error when downloading it.
 
 Each version starts with the letter `v`, followed by either a semantic version or a calendar version. The [Semantic Versioning 2.0.0 specification](https://semver.org/spec/v2.0.0.html) expains how semantic versions should be formatted, interpreted, and compared; the [Calendar Versioning reference](https://calver.org/) describes a variety of ways that calendar versions may be constructed, but any calendar versioning scheme used must meet the following requirements:
@@ -35,8 +35,8 @@ Each version starts with the letter `v`, followed by either a semantic version o
 - The calendar version must conform to the semantic versioning specifications for precedence, so that versions can be compared and sequentially ordered.
 
 ### Package paths
-The path of a package is the repository path joined with the subdirectory (relative to the repository root) which contains the package's `forklift-package.yml` file. That subdirectory is the *package root directory*. For example, the repository `github.com/PlanktoScope/device-pkgs` contains a Forklift package in the subdirectory `core/infra/caddy-ingress`. The `core/infra/caddy-ingress` directory contains a `forklift-package.yml` file and thus is the root directory of a package which has a package path of `github.com/PlanktoScope/device-pkgs/core/infra/caddy-ingress`. Note that the package path is not necessarily resolveable as a web page URL (so for example <https://github.com/PlanktoScope/device-pkgs/core/infra/caddy-ingress> gives a HTTP 404 Not Found error), because the package path is only resolvable in the context of a specific GitHub repository version.
 
+The path of a package is the repository path joined with the subdirectory (relative to the repository root) which contains the package's `forklift-package.yml` file. That subdirectory is the *package root directory*. For example, the repository `github.com/PlanktoScope/device-pkgs` contains a Forklift package in the subdirectory `core/infra/caddy-ingress`. The `core/infra/caddy-ingress` directory contains a `forklift-package.yml` file and thus is the root directory of a package which has a package path of `github.com/PlanktoScope/device-pkgs/core/infra/caddy-ingress`. Note that the package path is not necessarily resolveable as a web page URL (so for example <https://github.com/PlanktoScope/device-pkgs/core/infra/caddy-ingress> gives a HTTP 404 Not Found error), because the package path is only resolvable in the context of a specific GitHub repository version.
 
 ## Package deployments and constraints
 
@@ -51,10 +51,10 @@ Usually, multiple package deployments are simultaneously active on a Docker host
 Each such operation will modify the set of all active package deployments on the Docker host, and it will succeed if (and only if) all of the following constraints will be satisfied by the resulting set of all package deployments:
 
 - Package deployment name constraints:
-  - Uniqueness constraint: no package deployment will attempt to use the same name as another distinct package deployment; package deployments are distinct if they have different package paths and/or if they declare different sets of enabled features.
+   - Uniqueness constraint: no package deployment will attempt to use the same name as another distinct package deployment; package deployments are distinct if they have different package paths and/or if they declare different sets of enabled features.
 - Resource constraints:
-  - Dependency constraint (*resource requirements*): all of the resources required by all of the active package deployments will also be resources provided by some subset of the active package deployments.
-  - Uniqueness constraint (*provided resources*): none of the resources provided by any of the active package deployments will conflict with resources provided by any other active package deployments.
+   - Dependency constraint (*resource requirements*): all of the resources required by all of the active package deployments will also be resources provided by some subset of the active package deployments.
+   - Uniqueness constraint (*provided resources*): none of the resources provided by any of the active package deployments will conflict with resources provided by any other active package deployments.
 
 ### Package resource constraints
 
@@ -71,6 +71,7 @@ Resource requirements and provided resources are specified as a set of *identifi
 Because some Docker hosts may already have ambiently-available resources not provided by applications running in Docker (for example, an SSH server on port 22 installed using `apt-get`), a Forklift package may also include a list of resources already ambiently provided by the host; if such a resource is declared, it should be provided by the Docker host regardless of whether the package is deployed. Adding or removing a deployment of such a package will not affect the actual existence of such resources; it will only change a package manager's assumptions about what resources are ambiently provided by the host.
 
 ### Package features
+
 Forklift package *features* provide a mechanism to express optional resource constraints (both required resources and provided resources) and functionalities of a package. Each feature is identified by a name unique within the package. The design of Forklift package features is inspired by the design of the [features system](https://doc.rust-lang.org/cargo/reference/features.html) in the Rust Cargo package management system.
 
 A package defines a set of named features in its `forklift-package.yml` metadata file, and each feature can be either enabled or disabled by a package manager. Each package feature specifies any resources it requires from the Docker host, as well as any resources it provides on the Docker host, and the names of any additional Docker Compose files which should be merged together into the Docker Compose application defined by the package when the feature is enabled.
@@ -81,31 +82,31 @@ Usually, the following changes to a package are backwards-incompatible, in which
 
 - Changing the name to use for deploying the package
 - Making changes which may introduce conflicts between provided resources, for certain combinations of package deployments:
-  - In the host specification or the deployment specification:
-    - Adding a provided resource
-    - Modifying the identification criteria of a provided resource
-  - In any optional feature:
-    - Adding a new provided resource
-    - Modifying the identification criteria of a provided resource
+   - In the host specification or the deployment specification:
+      - Adding a provided resource
+      - Modifying the identification criteria of a provided resource
+   - In any optional feature:
+      - Adding a new provided resource
+      - Modifying the identification criteria of a provided resource
 - Making changes which may make dependencies between provided and required resources unresolvable, for certain combinations of package deployments:
-  - In the host specification or the deployment specification:
-    - Removing a provided resource
-    - Modifying the identification criteria of a provided resource
-  - In the deployment specification:
-    - Adding a resource requirement
-    - Modifying the identification criteria of a resource requirement
-  - In any optional feature:
-    - Adding a new resource requirement
-    - Removing a provided resource
-    - Modifying the identification criteria of a provided resource
-    - Modifying the identification criteria of a resource requirement
+   - In the host specification or the deployment specification:
+      - Removing a provided resource
+      - Modifying the identification criteria of a provided resource
+   - In the deployment specification:
+      - Adding a resource requirement
+      - Modifying the identification criteria of a resource requirement
+   - In any optional feature:
+      - Adding a new resource requirement
+      - Removing a provided resource
+      - Modifying the identification criteria of a provided resource
+      - Modifying the identification criteria of a resource requirement
 - Making changes which may make a package deployment declaration invalid:
-  - In the list of optional features offered by the package:
-    - Removing any feature
-    - Renaming any feature
+   - In the list of optional features offered by the package:
+      - Removing any feature
+      - Renaming any feature
 - Making a backwards-incompatible change to any external technical interfaces (protocols, APIs, schemas, data formats, etc.) provided or required by that package: this may break compatibility with other deployed packages which interact with those interfaces. Backwards-incompatible changes include:
-  - Adding a new requirement as part of the interface
-  - Removing a previously-provided functionality from the interface
+   - Adding a new requirement as part of the interface
+   - Removing a previously-provided functionality from the interface
 - Making a change to any user interfaces provided or by that package which would probably break users' existing mental models of how to use the interface.
 
 The following changes to a package are usually backwards-compatible, in which case they would only require incrementing the minor component of the semantic version of the repository providing that package, if the repository follows semantic versioning:
@@ -113,11 +114,10 @@ The following changes to a package are usually backwards-compatible, in which ca
 - Adding a new optional feature
 - Removing a resource requirement from any optional feature
 - Making a backwards-compatible change to any external technical or user interfaces provided or required by that package. Backwards-compatible changes in an interface include:
-  - Removing a requirement from the interface
-  - Adding new optional functionality to the interface
+   - Removing a requirement from the interface
+   - Adding new optional functionality to the interface
 
 It is the reponsibility of the package maintainer to document the package's external interfaces, to increment the relevant components of a repository's semantic or calendar version as needed, and to help users migrate smoothly across version upgrades and downgrades.
-
 
 ## Repository definition
 
@@ -133,11 +133,14 @@ repository:
 ```
 
 ### `forklift-version` field
+
 This field of the `forklift-repository.yml` file declares that the repository was written assuming the semantics of a given version of Forklift.
+
 - This field is required.
 - The version must be a valid version of the Forklift tool or the Forklift specification.
 - The version sets the minimum version of the Forklift tool required to use the repository. The Forklift tool refuses to use repositories declaring newer Forklift versions (or excessively old Forklift versions) for any operations beyond printing information.
 - Example:
+  
   ```yaml
   forklift-version: v0.4.0
   ```
@@ -156,32 +159,40 @@ repository:
 ```
 
 #### `path` field
+
 This field of the `repository` section is the repository path.
+
 - This field is required.
 - Example:
+  
   ```yaml
   path: github.com/PlanktoScope/device-pkgs
   ```
 
 #### `description` field
+
 This field of the `repository` section is a short (one-sentence) description of the repository to be shown to users.
+
 - This field is required.
 - Example:
+  
   ```yaml
   description: Packages for the PlanktoScope software distribution
   ```
 
 #### `readme-file` field
+
 This field of the `repository` section is the filename of a readme file to be shown to users.
+
 - This field is required.
 - The file must be located in the same directory as the `forklift-repository.yml` file.
 - The file must be a text file.
 - It is recommended for this file to be named `README.md` and to be formatted in [GitHub-flavored Markdown](https://github.github.com/gfm/).
 - Example:
+  
   ```yaml
   readme-file: README.md
   ```
-
 
 ## Package definition
 
@@ -249,18 +260,24 @@ package:
 ```
 
 #### `description` field
+
 This field of the `package` section is a short (one-sentence) description of the package to be shown to users.
+
 - This field is required.
 - Example:
+  
   ```yaml
   description: Web GUI for operating the PlanktoScope
   ```
 
 #### `maintainers` field
+
 This field of the `package` section is an array of maintainer objects listing the people who maintain the Forklift package.
+
 - This field is optional.
 - In most cases, the maintainers of the Forklift package will be different from the maintainers of the original software applications provided by the package. The maintainers of the package are specifically the people responsible for maintaining the software configurations specified by the package.
 - Example:
+  
   ```yaml
   maintainers:
     - name: Ethan Li
@@ -269,44 +286,58 @@ This field of the `package` section is an array of maintainer objects listing th
   ```
 
 A maintainer object consists of the following fields:
+
 - `name` is a string with the maintainer's name.
-  - This field is optional.
-  - Example:
-    ```yaml
-    name: Ethan Li
-    ```
+  
+   - This field is optional.
+   - Example:
+     
+     ```yaml
+     name: Ethan Li
+     ```
 
 - `email` is a string with an email address for contacting the maintainer.
-  - This field is optional.
-  - Example:
-    ```yaml
-    email: lietk12@gmail.com
-    ```
+  
+   - This field is optional.
+   - Example:
+     
+     ```yaml
+     email: lietk12@gmail.com
+     ```
 
 #### `license` field
+
 This field of the `package` section is an [SPDX 2.1 license expression](https://spdx.github.io/spdx-spec/v2-draft/SPDX-license-expressions/) specifying the licensing terms of the software provided by the Forklift package.
+
 - This field is optional.
 - Usually, an SPDX license name will be sufficient; however, some software applications are released under multiple licenses, in which case a more complex SPDX license expression (such as `MIT OR Apache-2.0`) is needed.
 - If a package is using a nonstandard license, then the `license-file` field may be specified in lieu of the `license` field.
 - Example:
+  
   ```yaml
   license: GPL-3.0
   ```
 
 #### `license-file` field
+
 This field of the `package` section is the filename of a license file describing the licensing terms of the software provided by the Forklift package.
+
 - This field is optional.
 - The file must be a text file.
 - The file must be located in the same directory as the `forklift-package.yml` file.
 - Example:
+  
   ```yaml
   license-file: LICENSE-ZeroTier-BSL
   ```
 
 #### `sources` field
+
 This field of the `package` section is an array of URLs which can be opened to access the source code for the software provided by the Forklift package.
+
 - This field is optional.
 - Example:
+  
   ```yaml
   sources:
     - https://github.com/zerotier/ZeroTierOne
@@ -339,9 +370,12 @@ host:
 ```
 
 #### `tags` field
+
 This field of the `host` section is an array of strings to associate with the host or with resources provided by the host. These tags have no semantic meaning within the Forklift package specification, but can be used by other applications for arbitrary purposes.
+
 - This field is optional.
 - Example:
+  
   ```yaml
   tags:
     - device-portal-name=SSH server
@@ -375,11 +409,13 @@ provides:
 ##### `listeners` field
 
 This field of the `provides` subsection is an array of host port listener objects listing the network port/protocol pairs which are already bound to host processes which are running on the Docker host and listening for incoming traffic on those port/protocol pairs, on any/all IP addresses.
+
 - This field is optional.
 - Each host port listener object describes a host port listener resource which may or may not be in conflict with other host port listener resources; this is because multiple processes are not allowed to simultaneously bind to the same port/protocol pair on all IP addresses.
 - If a set of package deployments contains two or more host port listener resources for the same port/protocol pair from different package deployments, the package deployments declaring those respective host port listeners will be reported as conflicting with each other. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for uniqueness of host port listener resources will not be satisfied.
 - Currently, this specification does not allow multiple host port listeners to bind to the same port/protocol pair on different IP addresses; instead for simplicity, processes are assumed to be listening for that port/protocol pair on *all* IP addresses on the host.
 - Example:
+  
   ```yaml
   listeners:
     - description: ZeroTier traffic to the rest of the world
@@ -391,35 +427,44 @@ This field of the `provides` subsection is an array of host port listener object
   ```
 
 A host port listener object consists of the following fields:
+
 - `description` is a short (one-sentence) description of the host port listener resource to be shown to users.
-  - This field is required.
-  - Example:
-    ```yaml
-    description: Web server for the Cockpit dashboard
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     description: Web server for the Cockpit dashboard
+     ```
 
 - `port` is a number specifying the [network port](https://en.wikipedia.org/wiki/Port_(computer_networking)) bound by a process running on the host.
-  - This field is required.
-  - Example:
-    ```yaml
-    port: 9090
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     port: 9090
+     ```
 
 - `protocol` is a string specifying whether the bound network port is for the TCP transport protocol or for the UDP transport protocol.
-  - This field is required.
-  - The value of this field must be either `tcp` or `udp`.
-  - Example:
-    ```yaml
-    protocol: tcp
-    ```
+  
+   - This field is required.
+   - The value of this field must be either `tcp` or `udp`.
+   - Example:
+     
+     ```yaml
+     protocol: tcp
+     ```
 
 ##### `networks` field
 
 This field of the `provides` subsection is an array of host Docker network objects listing the Docker networks which are already available on the Docker host.
+
 - This field is optional.
 - Each host Docker network object describes a Docker network resource which may or may not be in conflict with other Docker network resources; this is because multiple Docker networks are not allowed to have the same name.
 - If a set of package deployments contains two or more Docker network resources for networks with the same name from different package deployments, the package deployments declaring those respective Docker networks will be reported as conflicting with each other. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for uniqueness of host Docker network names will not be satisfied.
 - Example:
+  
   ```yaml
   networks:
     - description: Default bridge to the host
@@ -427,28 +472,35 @@ This field of the `provides` subsection is an array of host Docker network objec
   ```
 
 A Docker network object consists of the following fields:
+
 - `description` is a short (one-sentence) description of the Docker network resource to be shown to users.
-  - This field is required.
-  - Example:
-    ```yaml
-    description: Default host network
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     description: Default host network
+     ```
 
 - `name` is a string specifying the name of the Docker network.
-  - This field is required.
-  - Example:
-    ```yaml
-    name: host
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     name: host
+     ```
 
 ##### `services` field
 
 This field of the `provides` subsection is an array of network service objects listing the network services which are already available on the Docker host.
+
 - This field is optional.
 - The route of a network service can be defined either as a port/protocol pair or as a combination of port, protocol, and one or more paths. A network service whose route is defined only as a port/protocol pair will overlap with another network service if and only if the other network service whose route is also defined only as a port/protocol pair. A network service whose route is defined with one or more paths will overlap with another network service if and only if both network services have the same port, the same protocol, and at least one overlapping path (for a definition of overlapping paths, refer below to description of the `path` field of the network service object).
 - Each network service object describes a network service resource which may or may not be in conflict with other network service resources; this is because multiple networks are not allowed to have overlapping routes.
 - If a set of package deployments contains two or more network service resources for services with overlapping routes from different package deployments, then the package deployments declaring those respective network services will be reported as conflicting with each other. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for uniqueness of network services will not be satisfied.
 - Example:
+  
   ```yaml
   services:
     - description: SSH server
@@ -457,48 +509,59 @@ This field of the `provides` subsection is an array of network service objects l
   ```
 
 A network service object consists of the following fields:
+
 - `description` is a short (one-sentence) description of the network service resource to be shown to users.
-  - This field is required.
-  - Example:
-    ```yaml
-    description: The Cockpit system administration dashboard
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     description: The Cockpit system administration dashboard
+     ```
 
 - `port` is a number specifying the network port used for accessing the service.
-  - This field is required.
-  - Example:
-    ```yaml
-    port: 9090
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     port: 9090
+     ```
 
 - `protocol` is a string specifying the application-level protocol used for accessing the service.
-  - This field is required.
-  - Example:
-    ```yaml
-    protocol: https
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     protocol: https
+     ```
 
 - `tags` is an array of strings which constrain resolution of network service resource dependencies among package deployments. These tags are ignored in determining whether network services conflict with each other, since they are not part of the network service's route.
-  - This field is optional.
-  - These tags have no semantic meaning within the Forklift package specification, but tag requirements can be used for arbitrary purposes. For example, tags can be used to annotate a network service with information about API versions, subprotocols, etc. If a package deployment specifies that it requires a network service with one or more tags, then another package deployment will only be considered to satisfy the network service dependency if it provides a network service matching both the required route and all required tags. This is useful in ensuring that a network service provided by one package deployment is compatible with the API version required by a service client from another package deployment, for example.
-  - Example:
-    ```yaml
-    tags:
-      - https-only
-      - tls-client-certs-required
-    ```
+  
+   - This field is optional.
+   - These tags have no semantic meaning within the Forklift package specification, but tag requirements can be used for arbitrary purposes. For example, tags can be used to annotate a network service with information about API versions, subprotocols, etc. If a package deployment specifies that it requires a network service with one or more tags, then another package deployment will only be considered to satisfy the network service dependency if it provides a network service matching both the required route and all required tags. This is useful in ensuring that a network service provided by one package deployment is compatible with the API version required by a service client from another package deployment, for example.
+   - Example:
+     
+     ```yaml
+     tags:
+       - https-only
+       - tls-client-certs-required
+     ```
 
 - `paths` is an array of strings which are paths used for accessing the service.
-  - This field is optional.
-  - A path may optionally have an asterisk (`*`) at the end, in which case it is a prefix path - so the network service covers all paths beginning with that prefix (i.e. the string before the asterisk).
-  - If a network service specifies a port and protocol but no paths, it will conflict with another network service which also specifies the same port and protocol but no paths; it will not conflict with another network service which specifies the same port and protocol and also specifies some paths. In other words, not listing any paths in a network service is equivalent to not having any conflicts with other services available at specific paths on the same port and protocol. This is useful for describing systems involving HTTP reverse-proxies or involving message brokers, where one package deployment may provide a network service which routes specific messages to network services from other package deployments on specific paths; then the reverse-proxy or message broker would be specified on some port and protocol with no paths, while the network services behind it would be specified on the same port and protocol but with a set of specific paths.
-  - If a package deployment has a dependency on a network service with a specific path which matches a prefix path in a network service from another package deployment, that dependency will be satisfied. For example, a dependency on a network service requiring a path `/admin/cockpit/system` would be met by a network service provided with the path prefix `/admin/cockpit/*`, assuming they have the same port and protocol.
-  - If a package deployment provides a network service with a specific path which matches a prefix path in a network service provided by another package deployment, those two package deployments will be in conflict with each other. For example, a network service providing a path `/admin/cockpit/system` would conflict with a network service providing the path prefix `/admin/cockpit/*`, assuming they have the same port and protocol. This is because those overlapping paths would cause the network services to overlap with each other, which is not allowed.
-  - Example:
-    ```yaml
-    paths:
-      - /admin/cockpit/*
-    ```
+  
+   - This field is optional.
+   - A path may optionally have an asterisk (`*`) at the end, in which case it is a prefix path - so the network service covers all paths beginning with that prefix (i.e. the string before the asterisk).
+   - If a network service specifies a port and protocol but no paths, it will conflict with another network service which also specifies the same port and protocol but no paths; it will not conflict with another network service which specifies the same port and protocol and also specifies some paths. In other words, not listing any paths in a network service is equivalent to not having any conflicts with other services available at specific paths on the same port and protocol. This is useful for describing systems involving HTTP reverse-proxies or involving message brokers, where one package deployment may provide a network service which routes specific messages to network services from other package deployments on specific paths; then the reverse-proxy or message broker would be specified on some port and protocol with no paths, while the network services behind it would be specified on the same port and protocol but with a set of specific paths.
+   - If a package deployment has a dependency on a network service with a specific path which matches a prefix path in a network service from another package deployment, that dependency will be satisfied. For example, a dependency on a network service requiring a path `/admin/cockpit/system` would be met by a network service provided with the path prefix `/admin/cockpit/*`, assuming they have the same port and protocol.
+   - If a package deployment provides a network service with a specific path which matches a prefix path in a network service provided by another package deployment, those two package deployments will be in conflict with each other. For example, a network service providing a path `/admin/cockpit/system` would conflict with a network service providing the path prefix `/admin/cockpit/*`, assuming they have the same port and protocol. This is because those overlapping paths would cause the network services to overlap with each other, which is not allowed.
+   - Example:
+     
+     ```yaml
+     paths:
+       - /admin/cockpit/*
+     ```
 
 ### `deployment` section
 
@@ -515,21 +578,27 @@ deployment:
 ```
 
 #### `compose-files` field
+
 This field of the `deployment` section is an array of the string filenames of one or more Docker Compose files specifying the Docker Compose application which will be deployed when the package is deployed.
+
 - This field is optional.
 - The filenames must be for YAML files following the [Docker Compose file specification](https://docs.docker.com/compose/compose-file/).
 - The files must be located in the same directory as the `forklift-package.yml` file, or in subdirectories.
 - It only makes sense to omit the Docker Compose file from a package if the package also specifies some host resources in the `host` section of the `forklift-package.yml` file, or if the package defines some features with associated Compose files; otherwise, the package would do nothing and have no effect.
 - Example:
+  
   ```yaml
   compose-files:
     - compose.yml
   ```
 
 #### `tags` field
+
 This field of the `deployment` section is an array of strings to associate with the package deployment or with resources required or provided by the package deployment. These tags have no semantic meaning within the Forklift package specification, but can be used by other applications for arbitrary purposes.
+
 - This field is optional.
 - Example:
+  
   ```yaml
   tags:
     - remote-access
@@ -562,9 +631,11 @@ requires:
 ##### `networks` field
 
 This optional field of the `requires` subsection is an array of Docker network objects listing the Docker networks which must be available on the Docker host in order for a deployment of the package to successfully become active.
+
 - This field is optional.
 - The Docker network object describes a Docker network which must be provided by either the Docker host itself or by another package deployment. If the Docker network does not exist and won't be created, then the package deployment will not be allowed because its [package resource constraints](#package-resource-constraints) for dependencies on Docker networks will not be satisfied.
 - Example:
+  
   ```yaml
   networks:
     - description: Overlay network for Caddy to connect to upstream services
@@ -572,27 +643,34 @@ This optional field of the `requires` subsection is an array of Docker network o
   ```
 
 A Docker network object consists of the following fields:
+
 - `description` is a short (one-sentence) description of the required Docker network resource to be shown to users.
-  - This field is required.
-  - Example:
-    ```yaml
-    description: Overlay network for the Portainer server to connect to Portainer agents
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     description: Overlay network for the Portainer server to connect to Portainer agents
+     ```
 
 - `name` is a string specifying the name of the required Docker network.
-  - This field is required.
-  - Example:
-    ```yaml
-    name: portainer-agent
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     name: portainer-agent
+     ```
 
 ##### `services` field
 
 This optional field of the `requires` subsection is an array of network service objects listing the network services which must be available on the Docker host in order for a deployment of the package to successfully become active.
+
 - This field is optional.
 - The route of a network service requirement can be defined either as a port/protocol pair or as a combination of port, protocol, and one or more paths. A network service requirement whose route is defined only as a port/protocol pair can be satisfied by a network service defined with or without paths. A network service requirement whose route is defined with one or more paths will be satisfied by one or more network services if and only if all of those network services have the same port/protocol pair as the network service requirement, *and* the set union of the paths of the network services overlaps with every path listed in the network service requirement (for a definition of overlapping paths, refer below to description of the `path` field of the network service object). Thus, in any particular set of package deployments, one network service from one package deployment may be sufficient to satisfy a network service requirement from some other package deployment, or multiple network services from multiple packages may be necessary to fully satisfy that network service requirement.
 - If a set of package deployments contains a network service resource requirement with a route which does not overlap with the routes of any network services provided by other package deployments, then the package deployment declaring that network service requirement will be reported as having an unmet dependency. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for resource dependencies will not be satisfied.
 - Example:
+  
   ```yaml
   services:
     - tags: [caddy-docker-proxy]
@@ -601,55 +679,68 @@ This optional field of the `requires` subsection is an array of network service 
   ```
 
 A network service object consists of the following fields:
+
 - `description` is a short (one-sentence) description of the network service resource requirement to be shown to users.
-  - This field is required.
-  - Example:
-    ```yaml
-    description: An MJPEG stream from the Raspberry Pi's camera
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     description: An MJPEG stream from the Raspberry Pi's camera
+     ```
 
 - `port` is a number specifying the network port which must be usable for accessing the required service.
-  - This field is required.
-  - Example:
-    ```yaml
-    port: 8000
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     port: 8000
+     ```
 
 - `protocol` is a string specifying the application-level protocol which must be usable for accessing the required service.
-  - This field is required.
-  - Example:
-    ```yaml
-    protocol: http
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     protocol: http
+     ```
 
 - `tags` is an array of strings specifying labels which must be associated with the required service.
-  - This field is optional.
-  - These tags have no semantic meaning within the Forklift package specification, but tag requirements can be used for arbitrary purposes. For example, tags can be used to require a network service annotated with information about specific API versions, subprotocols, etc. If a package deployment specifies that it requires a network service with one or more tags, then another package deployment will only be considered to satisfy the network service dependency if it provides a network service matching both the required route and all required tags. This is useful in ensuring that a network service provided by one package deployment is compatible with the API version required by a service client from another package deployment, for example.
-  - Example:
-    ```yaml
-    tags:
-      - mjpeg-stream
-    ```
+  
+   - This field is optional.
+   - These tags have no semantic meaning within the Forklift package specification, but tag requirements can be used for arbitrary purposes. For example, tags can be used to require a network service annotated with information about specific API versions, subprotocols, etc. If a package deployment specifies that it requires a network service with one or more tags, then another package deployment will only be considered to satisfy the network service dependency if it provides a network service matching both the required route and all required tags. This is useful in ensuring that a network service provided by one package deployment is compatible with the API version required by a service client from another package deployment, for example.
+   - Example:
+     
+     ```yaml
+     tags:
+       - mjpeg-stream
+     ```
 
 - `paths` is an array of strings which are paths which must be accessible on the required service.
-  - This field is optional.
-  - A path may optionally have an asterisk (`*`) at the end, in which case it is a prefix path - so the required network service must declare that it can be used with any path beginning with that prefix (i.e. the string before the asterisk).
-  - If a network service requirement specifies a port and protocol but no paths, that requirement will be satisfied by any network service which also specifies the same port and protocol and has the required tags (if any), regardless of whether the service specifies any paths. In other words, not listing any paths in a network service requirement is equivalent to not having any requirements about the paths exposed by a network service.
-  - If a package deployment has a requirement for a network service with a specific path which matches the prefix path of a network service provided by another package deployment, the network service requirement will be met. For example, a requirement for a network service with a path `/stream.mjpg` would be met by a network service provided with the path prefix `/*`, assuming they have the same port and protocol.
-  - Example:
-    ```yaml
-    paths:
-      - /stream.mjpg
-    ```
+  
+   - This field is optional.
+   - A path may optionally have an asterisk (`*`) at the end, in which case it is a prefix path - so the required network service must declare that it can be used with any path beginning with that prefix (i.e. the string before the asterisk).
+   - If a network service requirement specifies a port and protocol but no paths, that requirement will be satisfied by any network service which also specifies the same port and protocol and has the required tags (if any), regardless of whether the service specifies any paths. In other words, not listing any paths in a network service requirement is equivalent to not having any requirements about the paths exposed by a network service.
+   - If a package deployment has a requirement for a network service with a specific path which matches the prefix path of a network service provided by another package deployment, the network service requirement will be met. For example, a requirement for a network service with a path `/stream.mjpg` would be met by a network service provided with the path prefix `/*`, assuming they have the same port and protocol.
+   - Example:
+     
+     ```yaml
+     paths:
+       - /stream.mjpg
+     ```
 
 - `nonblocking` is a boolean flag specifying whether the package deployment providing the required service is allowed to start after starting the package deployment with the service requirement.
-  - This field is optional.
-  - This is a performance optimization hint which may be ignored; it's only meaningful if package deployments can be started concurrently. However, it can help to reduce the startup time needed for the critical path of a chain of dependencies between package deployments.
-  - This field can be set to true if the service client can gracefully handle the temporary absence of the service while package deployments are being applied; otherwise, this field should not be set to true.
-  - Example:
-    ```yaml
-    nonblocking: true
-    ```
+  
+   - This field is optional.
+   - This is a performance optimization hint which may be ignored; it's only meaningful if package deployments can be started concurrently. However, it can help to reduce the startup time needed for the critical path of a chain of dependencies between package deployments.
+   - This field can be set to true if the service client can gracefully handle the temporary absence of the service while package deployments are being applied; otherwise, this field should not be set to true.
+   - Example:
+     
+     ```yaml
+     nonblocking: true
+     ```
 
 #### `provides` subsection
 
@@ -671,12 +762,14 @@ provides:
 ##### `listeners` field
 
 This field of the `provides` subsection is an array of host port listener objects listing the network port/protocol pairs which will be bound to processes running in an active deployment of the package and listening for incoming traffic on those port/protocol pairs, on any/all IP addresses.
+
 - This field is optional.
 - Generally, a host port listener object should correspond to a [published port](https://docs.docker.com/network/#published-ports) of a Docker container.
 - Each host port listener object describes a host port listener resource which may or may not be in conflict with other host port listener resources; this is because multiple processes are not allowed to simultaneously bind to the same port/protocol pair on all IP addresses.
 - If a set of package deployments contains two or more host port listener resources for the same port/protocol pair from different package deployments, the package deployments declaring those respective host port listeners will be reported as conflicting with each other. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for uniqueness of host port listener resources will not be satisfied.
 - Currently, this specification does not allow multiple host port listeners to bind to the same port/protocol pair on different IP addresses; instead for simplicity, processes are assumed to be listening for that port/protocol pair on *all* IP addresses on the host.
 - Example:
+  
   ```yaml
   listeners:
     - description: MQTT broker
@@ -685,35 +778,44 @@ This field of the `provides` subsection is an array of host port listener object
   ```
 
 A host port listener object consists of the following fields:
+
 - `description` is a short (one-sentence) description of the host port listener resource to be shown to users.
-  - This field is required.
-  - Example:
-    ```yaml
-    description: Web server for all HTTP requests
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     description: Web server for all HTTP requests
+     ```
 
 - `port` is a number specifying the [network port](https://en.wikipedia.org/wiki/Port_(computer_networking)) bound by a process running on the host.
-  - This field is required.
-  - Example:
-    ```yaml
-    port: 80
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     port: 80
+     ```
 
 - `protocol` is a string specifying whether the bound network port is for the TCP transport protocol or for the UDP transport protocol.
-  - This field is required.
-  - The value of this field must be either `tcp` or `udp`.
-  - Example:
-    ```yaml
-    protocol: tcp
-    ```
+  
+   - This field is required.
+   - The value of this field must be either `tcp` or `udp`.
+   - Example:
+     
+     ```yaml
+     protocol: tcp
+     ```
 
 ##### `networks` field
 
 This field of the `provides` subsection is an array of Docker network objects listing the Docker networks which are created when a deployment of the package becomes active.
+
 - This field is optional.
 - Each host Docker network object describes a Docker network resource which may or may not be in conflict with other Docker network resources; this is because multiple Docker networks are not allowed to have the same name.
 - If a set of package deployments contains two or more Docker network resources for networks with the same name from different package deployments, the package deployments declaring those respective Docker networks will be reported as conflicting with each other. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for uniqueness of host Docker network names will not be satisfied.
 - Example:
+  
   ```yaml
   networks:
     - description: Overlay network for Caddy to connect to upstream services
@@ -721,28 +823,35 @@ This field of the `provides` subsection is an array of Docker network objects li
   ```
 
 A Docker network object consists of the following fields:
+
 - `description` is a short (one-sentence) description of the Docker network resource to be shown to users.
-  - This field is required.
-  - Example:
-    ```yaml
-    description: Overlay network for the Portainer server to connect to Portainer agents
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     description: Overlay network for the Portainer server to connect to Portainer agents
+     ```
 
 - `name` is a string specifying the name of the Docker network.
-  - This field is required.
-  - Example:
-    ```yaml
-    name: portainer-agent
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     name: portainer-agent
+     ```
 
 ##### `services` field
 
 This field of the `provides` subsection is an array of network service objects listing the network services which are created when a deployment of the package becomes active.
+
 - This field is optional.
 - The route of a network service can be defined either as a port/protocol pair or as a combination of port, protocol, and one or more paths. A network service whose route is defined only as a port/protocol pair will overlap with another network service if and only if the other network service whose route is also defined only as a port/protocol pair. A network service whose route is defined with one or more paths will overlap with another network service if and only if both network services have the same port, the same protocol, and at least one overlapping path (for a definition of overlapping paths, refer below to description of the `path` field of the network service object).
 - Each network service object describes a network service resource which may or may not be in conflict with other network service resources; this is because multiple networks are not allowed to have overlapping routes.
 - If a set of package deployments contains two or more network service resources for services with overlapping routes from different package deployments, then the package deployments declaring those respective network services will be reported as conflicting with each other. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for uniqueness of network services will not be satisfied.
 - Example:
+  
   ```yaml
   services:
     - description: MJPEG stream of last segmented object from the PlanktoScope object segmenter
@@ -765,48 +874,59 @@ This field of the `provides` subsection is an array of network service objects l
   ```
 
 A network service object consists of the following fields:
+
 - `description` is a short (one-sentence) description of the network service resource to be shown to users.
-  - This field is required.
-  - Example:
-    ```yaml
-    description: PlanktoScope documentation site
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     description: PlanktoScope documentation site
+     ```
 
 - `port` is a number specifying the network port used for accessing the service.
-  - This field is required.
-  - Example:
-    ```yaml
-    port: 80
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     port: 80
+     ```
 
 - `protocol` is a string specifying the application-level protocol used for accessing the service.
-  - This field is required.
-  - Example:
-    ```yaml
-    protocol: http
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     protocol: http
+     ```
 
 - `tags` is an array of strings which constrain resolution of network service resource dependencies among package deployments. These tags are ignored in determining whether network services conflict with each other, since they are not part of the network service's route.
-  - This field is optional.
-  - These tags have no semantic meaning within the Forklift package specification, but tag requirements can be used for arbitrary purposes. For example, tags can be used to annotate a network service with information about API versions, subprotocols, etc. If a package deployment specifies that it requires a network service with one or more tags, then another package deployment will only be considered to satisfy the network service dependency if it provides a network service matching both the required route and all required tags. This is useful in ensuring that a network service provided by one package deployment is compatible with the API version required by a service client from another package deployment, for example.
-  - Example:
-    ```yaml
-    tags:
-      - website
-    ```
+  
+   - This field is optional.
+   - These tags have no semantic meaning within the Forklift package specification, but tag requirements can be used for arbitrary purposes. For example, tags can be used to annotate a network service with information about API versions, subprotocols, etc. If a package deployment specifies that it requires a network service with one or more tags, then another package deployment will only be considered to satisfy the network service dependency if it provides a network service matching both the required route and all required tags. This is useful in ensuring that a network service provided by one package deployment is compatible with the API version required by a service client from another package deployment, for example.
+   - Example:
+     
+     ```yaml
+     tags:
+       - website
+     ```
 
 - `paths` is an array of strings which are paths used for accessing the service.
-  - This field is optional.
-  - A path may optionally have an asterisk (`*`) at the end, in which case it is a prefix path - so the network service covers all paths beginning with that prefix (i.e. the string before the asterisk).
-  - If a network service specifies a port and protocol but no paths, it will conflict with another network service which also specifies the same port and protocol but no paths; it will not conflict with another network service which specifies the same port and protocol and also specifies some paths. In other words, not listing any paths in a network service is equivalent to not having any conflicts with other services available at specific paths on the same port and protocol. This is useful for describing systems involving HTTP reverse-proxies or involving message brokers, where one package deployment may provide a network service which routes specific messages to network services from other package deployments on specific paths; then the reverse-proxy or message broker would be specified on some port and protocol with no paths, while the network services behind it would be specified on the same port and protocol but with a set of specific paths.
-  - If a package deployment has a dependency on a network service with a specific path which matches a prefix path in a network service from another package deployment, that dependency will be satisfied. For example, a dependency on a network service requiring a path `/ps/docs/hardware` would be met by a network service provided with the path prefix `/ps/docs/*`, assuming they have the same port and protocol.
-  - If a package deployment provides a network service with a specific path which matches a prefix path in a network service provided by another package deployment, those two package deployments will be in conflict with each other. For example, a network service providing a path `/ps/docs/hardware` would conflict with a network service providing the path prefix `/ps/docs/*`, assuming they have the same port and protocol. This is because those overlapping paths would cause the network services to overlap with each other, which is not allowed.
-  - Example:
-    ```yaml
-    paths:
-      - /ps/docs
-      - /ps/docs/*
-    ```
+  
+   - This field is optional.
+   - A path may optionally have an asterisk (`*`) at the end, in which case it is a prefix path - so the network service covers all paths beginning with that prefix (i.e. the string before the asterisk).
+   - If a network service specifies a port and protocol but no paths, it will conflict with another network service which also specifies the same port and protocol but no paths; it will not conflict with another network service which specifies the same port and protocol and also specifies some paths. In other words, not listing any paths in a network service is equivalent to not having any conflicts with other services available at specific paths on the same port and protocol. This is useful for describing systems involving HTTP reverse-proxies or involving message brokers, where one package deployment may provide a network service which routes specific messages to network services from other package deployments on specific paths; then the reverse-proxy or message broker would be specified on some port and protocol with no paths, while the network services behind it would be specified on the same port and protocol but with a set of specific paths.
+   - If a package deployment has a dependency on a network service with a specific path which matches a prefix path in a network service from another package deployment, that dependency will be satisfied. For example, a dependency on a network service requiring a path `/ps/docs/hardware` would be met by a network service provided with the path prefix `/ps/docs/*`, assuming they have the same port and protocol.
+   - If a package deployment provides a network service with a specific path which matches a prefix path in a network service provided by another package deployment, those two package deployments will be in conflict with each other. For example, a network service providing a path `/ps/docs/hardware` would conflict with a network service providing the path prefix `/ps/docs/*`, assuming they have the same port and protocol. This is because those overlapping paths would cause the network services to overlap with each other, which is not allowed.
+   - Example:
+     
+     ```yaml
+     paths:
+       - /ps/docs
+       - /ps/docs/*
+     ```
 
 ### `features` section
 
@@ -934,61 +1054,71 @@ features:
 A feature specification object consists of the following fields:
 
 - `description` is a short (one-sentence) description of the network service resource requirement to be shown to users.
-  - This field is required.
-  - Example:
-    ```yaml
-    description: Provides access to the GUI
-    ```
+  
+   - This field is required.
+   - Example:
+     
+     ```yaml
+     description: Provides access to the GUI
+     ```
 
 - `compose-files` is an array of the string filenames of one or more Docker Compose files specifying modifications to the Docker Compose application which will be applied if the feature is enabled.
-  - This field is optional.
-  - The filenames must be for YAML files which are fragments of a [Docker Compose file specification](https://docs.docker.com/compose/compose-file/). These files will be merged together with any other Compose files specified in the [`deployment` section](#deployment-section) of the `forklift-package.yml` file and in any other enabled features according to Docker Compose's [compose file merging mechanism](https://docs.docker.com/compose/multiple-compose-files/merge/).
-  - The files must be located in the same directory as the `forklift-package.yml` file, or in subdirectories.
-  - For clarity, it is strongly recommended that the order in which the files for different feature flags are merged should not affect the final result of merging.
-  - Example:
-    ```yaml
-    compose-files: [compose-frontend.yml]
-    ```
+  
+   - This field is optional.
+   - The filenames must be for YAML files which are fragments of a [Docker Compose file specification](https://docs.docker.com/compose/compose-file/). These files will be merged together with any other Compose files specified in the [`deployment` section](#deployment-section) of the `forklift-package.yml` file and in any other enabled features according to Docker Compose's [compose file merging mechanism](https://docs.docker.com/compose/multiple-compose-files/merge/).
+   - The files must be located in the same directory as the `forklift-package.yml` file, or in subdirectories.
+   - For clarity, it is strongly recommended that the order in which the files for different feature flags are merged should not affect the final result of merging.
+   - Example:
+     
+     ```yaml
+     compose-files: [compose-frontend.yml]
+     ```
 
 - `tags` is an array of strings to associate with the feature or with resources required or provided by the feature.
-  - This field is optional.
-  - These tags have no semantic meaning within the Forklift package specification, but can be used by other applictions for arbitrary purposes.
-  - Example:
-    ```yaml
-    tags:
-      - device-portal-name=Portainer
-      - device-portal-description=Provides a Docker administration dashboard
-      - device-portal-type=Browser applications
-      - device-portal-purpose=System administration and troubleshooting
-      - device-portal-entrypoint=/admin/portainer/
-    ```
+  
+   - This field is optional.
+   - These tags have no semantic meaning within the Forklift package specification, but can be used by other applictions for arbitrary purposes.
+   - Example:
+     
+     ```yaml
+     tags:
+       - device-portal-name=Portainer
+       - device-portal-description=Provides a Docker administration dashboard
+       - device-portal-type=Browser applications
+       - device-portal-purpose=System administration and troubleshooting
+       - device-portal-entrypoint=/admin/portainer/
+     ```
 
 - `requires` is a specification of resources required for a deployment of the package, with the feature enabled, to successfully become active.
-  - This field is optional.
-  - The contents of this field have the same syntax and semantics as the contents of the [`requires` subsection](#requires-subsection) of the `deployment` section of the Forklift package specification, except that resource requirements are only evaluated for features configured as "enabled" for each deployment of each package; resource requirements for disabled features will be ignored.
-  - Example:
-    ```yaml
-    requires:
-      networks:
-        - description: Overlay network for Caddy to connect to upstream services
-          name: caddy-ingress
-      services:
-        - tags: [caddy-docker-proxy]
-          port: 80
-          protocol: http
-    ```
+  
+   - This field is optional.
+   - The contents of this field have the same syntax and semantics as the contents of the [`requires` subsection](#requires-subsection) of the `deployment` section of the Forklift package specification, except that resource requirements are only evaluated for features configured as "enabled" for each deployment of each package; resource requirements for disabled features will be ignored.
+   - Example:
+     
+     ```yaml
+     requires:
+       networks:
+         - description: Overlay network for Caddy to connect to upstream services
+           name: caddy-ingress
+       services:
+         - tags: [caddy-docker-proxy]
+           port: 80
+           protocol: http
+     ```
 
 - `provides` is a specification of resources provided by a deployment of the package, if the feature is enabled for that deployment.
-  - This field is optional.
-  - The contents of this field have the same syntax and semantics as the contents of the [`provides` subsection](#provides-subsection) of the `deployment` section of the Forklift package specification, except that provided resources are only considered for features configured as "enabled" for each deployment of each package; provided resources for disabled features will be ignored.
-  - Example:
-    ```yaml
-    provides:
-      services:
-        - description: The Portainer Docker management dashboard
-          port: 80
-          protocol: http
-          paths:
-            - /admin/portainer
-            - /admin/portainer/*
-    ```
+  
+   - This field is optional.
+   - The contents of this field have the same syntax and semantics as the contents of the [`provides` subsection](#provides-subsection) of the `deployment` section of the Forklift package specification, except that provided resources are only considered for features configured as "enabled" for each deployment of each package; provided resources for disabled features will be ignored.
+   - Example:
+     
+     ```yaml
+     provides:
+       services:
+         - description: The Portainer Docker management dashboard
+           port: 80
+           protocol: http
+           paths:
+             - /admin/portainer
+             - /admin/portainer/*
+     ```

--- a/docs/specs/00-package.md
+++ b/docs/specs/00-package.md
@@ -138,8 +138,11 @@ repository:
 This field of the `forklift-repository.yml` file declares that the repository was written assuming the semantics of a given version of Forklift.
 
 - This field is required.
+
 - The version must be a valid version of the Forklift tool or the Forklift specification.
+
 - The version sets the minimum version of the Forklift tool required to use the repository. The Forklift tool refuses to use repositories declaring newer Forklift versions (or excessively old Forklift versions) for any operations beyond printing information.
+
 - Example:
   
   ```yaml
@@ -164,6 +167,7 @@ repository:
 This field of the `repository` section is the repository path.
 
 - This field is required.
+
 - Example:
   
   ```yaml
@@ -175,6 +179,7 @@ This field of the `repository` section is the repository path.
 This field of the `repository` section is a short (one-sentence) description of the repository to be shown to users.
 
 - This field is required.
+
 - Example:
   
   ```yaml
@@ -186,9 +191,13 @@ This field of the `repository` section is a short (one-sentence) description of 
 This field of the `repository` section is the filename of a readme file to be shown to users.
 
 - This field is required.
+
 - The file must be located in the same directory as the `forklift-repository.yml` file.
+
 - The file must be a text file.
+
 - It is recommended for this file to be named `README.md` and to be formatted in [GitHub-flavored Markdown](https://github.github.com/gfm/).
+
 - Example:
   
   ```yaml
@@ -265,6 +274,7 @@ package:
 This field of the `package` section is a short (one-sentence) description of the package to be shown to users.
 
 - This field is required.
+
 - Example:
   
   ```yaml
@@ -276,7 +286,9 @@ This field of the `package` section is a short (one-sentence) description of the
 This field of the `package` section is an array of maintainer objects listing the people who maintain the Forklift package.
 
 - This field is optional.
+
 - In most cases, the maintainers of the Forklift package will be different from the maintainers of the original software applications provided by the package. The maintainers of the package are specifically the people responsible for maintaining the software configurations specified by the package.
+
 - Example:
   
   ```yaml
@@ -291,6 +303,7 @@ A maintainer object consists of the following fields:
 - `name` is a string with the maintainer's name.
   
    - This field is optional.
+  
    - Example:
      
      ```yaml
@@ -300,6 +313,7 @@ A maintainer object consists of the following fields:
 - `email` is a string with an email address for contacting the maintainer.
   
    - This field is optional.
+  
    - Example:
      
      ```yaml
@@ -311,8 +325,11 @@ A maintainer object consists of the following fields:
 This field of the `package` section is an [SPDX 2.1 license expression](https://spdx.github.io/spdx-spec/v2-draft/SPDX-license-expressions/) specifying the licensing terms of the software provided by the Forklift package.
 
 - This field is optional.
+
 - Usually, an SPDX license name will be sufficient; however, some software applications are released under multiple licenses, in which case a more complex SPDX license expression (such as `MIT OR Apache-2.0`) is needed.
+
 - If a package is using a nonstandard license, then the `license-file` field may be specified in lieu of the `license` field.
+
 - Example:
   
   ```yaml
@@ -324,8 +341,11 @@ This field of the `package` section is an [SPDX 2.1 license expression](https://
 This field of the `package` section is the filename of a license file describing the licensing terms of the software provided by the Forklift package.
 
 - This field is optional.
+
 - The file must be a text file.
+
 - The file must be located in the same directory as the `forklift-package.yml` file.
+
 - Example:
   
   ```yaml
@@ -337,6 +357,7 @@ This field of the `package` section is the filename of a license file describing
 This field of the `package` section is an array of URLs which can be opened to access the source code for the software provided by the Forklift package.
 
 - This field is optional.
+
 - Example:
   
   ```yaml
@@ -375,6 +396,7 @@ host:
 This field of the `host` section is an array of strings to associate with the host or with resources provided by the host. These tags have no semantic meaning within the Forklift package specification, but can be used by other applications for arbitrary purposes.
 
 - This field is optional.
+
 - Example:
   
   ```yaml
@@ -412,9 +434,13 @@ provides:
 This field of the `provides` subsection is an array of host port listener objects listing the network port/protocol pairs which are already bound to host processes which are running on the Docker host and listening for incoming traffic on those port/protocol pairs, on any/all IP addresses.
 
 - This field is optional.
+
 - Each host port listener object describes a host port listener resource which may or may not be in conflict with other host port listener resources; this is because multiple processes are not allowed to simultaneously bind to the same port/protocol pair on all IP addresses.
+
 - If a set of package deployments contains two or more host port listener resources for the same port/protocol pair from different package deployments, the package deployments declaring those respective host port listeners will be reported as conflicting with each other. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for uniqueness of host port listener resources will not be satisfied.
+
 - Currently, this specification does not allow multiple host port listeners to bind to the same port/protocol pair on different IP addresses; instead for simplicity, processes are assumed to be listening for that port/protocol pair on *all* IP addresses on the host.
+
 - Example:
   
   ```yaml
@@ -432,6 +458,7 @@ A host port listener object consists of the following fields:
 - `description` is a short (one-sentence) description of the host port listener resource to be shown to users.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -441,6 +468,7 @@ A host port listener object consists of the following fields:
 - `port` is a number specifying the [network port](https://en.wikipedia.org/wiki/Port_(computer_networking)) bound by a process running on the host.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -450,7 +478,9 @@ A host port listener object consists of the following fields:
 - `protocol` is a string specifying whether the bound network port is for the TCP transport protocol or for the UDP transport protocol.
   
    - This field is required.
+  
    - The value of this field must be either `tcp` or `udp`.
+  
    - Example:
      
      ```yaml
@@ -462,8 +492,11 @@ A host port listener object consists of the following fields:
 This field of the `provides` subsection is an array of host Docker network objects listing the Docker networks which are already available on the Docker host.
 
 - This field is optional.
+
 - Each host Docker network object describes a Docker network resource which may or may not be in conflict with other Docker network resources; this is because multiple Docker networks are not allowed to have the same name.
+
 - If a set of package deployments contains two or more Docker network resources for networks with the same name from different package deployments, the package deployments declaring those respective Docker networks will be reported as conflicting with each other. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for uniqueness of host Docker network names will not be satisfied.
+
 - Example:
   
   ```yaml
@@ -477,6 +510,7 @@ A Docker network object consists of the following fields:
 - `description` is a short (one-sentence) description of the Docker network resource to be shown to users.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -486,6 +520,7 @@ A Docker network object consists of the following fields:
 - `name` is a string specifying the name of the Docker network.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -497,9 +532,13 @@ A Docker network object consists of the following fields:
 This field of the `provides` subsection is an array of network service objects listing the network services which are already available on the Docker host.
 
 - This field is optional.
+
 - The route of a network service can be defined either as a port/protocol pair or as a combination of port, protocol, and one or more paths. A network service whose route is defined only as a port/protocol pair will overlap with another network service if and only if the other network service whose route is also defined only as a port/protocol pair. A network service whose route is defined with one or more paths will overlap with another network service if and only if both network services have the same port, the same protocol, and at least one overlapping path (for a definition of overlapping paths, refer below to description of the `path` field of the network service object).
+
 - Each network service object describes a network service resource which may or may not be in conflict with other network service resources; this is because multiple network services are not allowed to have overlapping routes.
+
 - If a set of package deployments contains two or more network service resources for services with overlapping routes from different package deployments, then the package deployments declaring those respective network services will be reported as conflicting with each other. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for uniqueness of network services will not be satisfied.
+
 - Example:
   
   ```yaml
@@ -514,6 +553,7 @@ A network service object consists of the following fields:
 - `description` is a short (one-sentence) description of the network service resource to be shown to users.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -523,6 +563,7 @@ A network service object consists of the following fields:
 - `port` is a number specifying the network port used for accessing the service.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -532,6 +573,7 @@ A network service object consists of the following fields:
 - `protocol` is a string specifying the application-level protocol used for accessing the service.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -541,11 +583,16 @@ A network service object consists of the following fields:
 - `paths` is an array of strings which are paths used for accessing the service.
   
    - This field is optional.
+  
    - A path may optionally have an asterisk (`*`) at the end, in which case it is a prefix path - so the network service covers all paths beginning with that prefix (i.e. the string before the asterisk).
+  
    - If a network service specifies a port and protocol but no paths, it will conflict with another network service which also specifies the same port and protocol but no paths; it will not conflict with another network service which specifies the same port and protocol and also specifies some paths. In other words, not listing any paths in a network service is equivalent to not having any conflicts with other services available at specific paths on the same port and protocol.
      This is useful for describing systems involving HTTP reverse-proxies or involving message brokers, where one package deployment may provide a network service which routes specific messages to network services from other package deployments on specific paths; then the reverse-proxy or message broker would be specified on some port and protocol with no paths, while the network services behind it would be specified on the same port and protocol but with a set of specific paths.
+  
    - If a package deployment has a dependency on a network service with a specific path which matches a prefix path in a network service from another package deployment, that dependency will be satisfied. For example, a dependency on a network service requiring a path `/admin/cockpit/system` would be met by a network service provided with the path prefix `/admin/cockpit/*`, assuming they have the same port and protocol.
+  
    - If a package deployment provides a network service with a specific path which matches a prefix path in a network service provided by another package deployment, those two package deployments will be in conflict with each other. For example, a network service providing a path `/admin/cockpit/system` would conflict with a network service providing the path prefix `/admin/cockpit/*`, assuming they have the same port and protocol. This is because those overlapping paths would cause the network services to overlap with each other, which is not allowed.
+  
    - Example:
      
      ```yaml
@@ -653,8 +700,11 @@ deployment:
 This field of the `deployment` section is an array of the string filenames of one or more Docker Compose files specifying the Docker Compose application which will be deployed when the package is deployed.
 
 - This field is optional.
+
 - The filenames must be for YAML files following the [Docker Compose file specification](https://docs.docker.com/compose/compose-file/).
+
 - The files must be located in the same directory as the `forklift-package.yml` file, or in subdirectories.
+
 - Example:
   
   ```yaml
@@ -667,6 +717,7 @@ This field of the `deployment` section is an array of the string filenames of on
 This field of the `deployment` section is an array of strings to associate with the package deployment or with resources required or provided by the package deployment. These tags have no semantic meaning within the Forklift package specification, but can be used by other applications for arbitrary purposes.
 
 - This field is optional.
+
 - Example:
   
   ```yaml
@@ -703,7 +754,9 @@ requires:
 This optional field of the `requires` subsection is an array of Docker network objects listing the Docker networks which must be available on the Docker host in order for a deployment of the package to successfully become active.
 
 - This field is optional.
+
 - The Docker network object describes a Docker network which must be provided by either the Docker host itself or by another package deployment. If the Docker network does not exist and won't be created, then the package deployment will not be allowed because its [package resource constraints](#package-resource-constraints) for dependencies on Docker networks will not be satisfied.
+
 - Example:
   
   ```yaml
@@ -717,6 +770,7 @@ A Docker network object consists of the following fields:
 - `description` is a short (one-sentence) description of the required Docker network resource to be shown to users.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -726,6 +780,7 @@ A Docker network object consists of the following fields:
 - `name` is a string specifying the name of the required Docker network.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -737,9 +792,12 @@ A Docker network object consists of the following fields:
 This optional field of the `requires` subsection is an array of network service objects listing the network services which must be available on the Docker host in order for a deployment of the package to successfully become active.
 
 - This field is optional.
+
 - The route of a network service requirement can be defined either as a port/protocol pair or as a combination of port, protocol, and one or more paths. A network service requirement whose route is defined only as a port/protocol pair can be satisfied by a network service defined with or without paths. A network service requirement whose route is defined with one or more paths will be satisfied by one or more network services if and only if all of those network services have the same port/protocol pair as the network service requirement, *and* the set union of the paths of the network services overlaps with every path listed in the network service requirement (for a definition of overlapping paths, refer below to description of the `path` field of the network service object).
   Thus, in any particular set of package deployments, one network service from one package deployment may be sufficient to satisfy a network service requirement from some other package deployment, or multiple network services from multiple packages may be necessary to fully satisfy that network service requirement.
+
 - If a set of package deployments contains a network service resource requirement with a route which does not overlap with the routes of any network services provided by other package deployments, then the package deployment declaring that network service requirement will be reported as having an unmet dependency. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for resource dependencies will not be satisfied.
+
 - Example:
   
   ```yaml
@@ -755,6 +813,7 @@ A network service object consists of the following fields:
 - `description` is a short (one-sentence) description of the network service resource requirement to be shown to users.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -764,6 +823,7 @@ A network service object consists of the following fields:
 - `port` is a number specifying the network port which must be usable for accessing the required service.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -773,6 +833,7 @@ A network service object consists of the following fields:
 - `protocol` is a string specifying the application-level protocol which must be usable for accessing the required service.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -782,9 +843,13 @@ A network service object consists of the following fields:
 - `paths` is an array of strings which are paths which must be accessible on the required service.
   
    - This field is optional.
+  
    - A path may optionally have an asterisk (`*`) at the end, in which case it is a prefix path - so the required network service must declare that it can be used with any path beginning with that prefix (i.e. the string before the asterisk).
+  
    - If a network service requirement specifies a port and protocol but no paths, that requirement will be satisfied by any network service which also specifies the same port and protocol and has the required tags (if any), regardless of whether the service specifies any paths. In other words, not listing any paths in a network service requirement is equivalent to not having any requirements about the paths exposed by a network service.
+  
    - If a package deployment has a requirement for a network service with a specific path which matches the prefix path of a network service provided by another package deployment, the network service requirement will be met. For example, a requirement for a network service with a path `/stream.mjpg` would be met by a network service provided with the path prefix `/*`, assuming they have the same port and protocol.
+  
    - Example:
      
      ```yaml
@@ -883,6 +948,20 @@ A filesystem object consists of the following fields:
        - plain-text
      ```
 
+- `nonblocking` is a boolean flag specifying whether the package deployment providing the required filesystem entity is allowed to start after starting the package deployment with the filesystem requirement.
+  
+   - This field is optional.
+  
+   - This is a performance optimization hint which may be ignored; it's only meaningful if package deployments can be started concurrently. However, it can help to reduce the startup time needed for the critical path of a chain of dependencies between package deployments.
+  
+   - This field can be set to true if the program requiring the filesystem entity can gracefully handle the temporary absence of the filesystem entity while package deployments are being applied; otherwise, this field should not be set to true.
+  
+   - Example:
+     
+     ```yaml
+     nonblocking: true
+     ```
+
 #### `provides` subsection
 
 This optional subsection of the `deployment` section specifies the resources provided by an active deployment of the package. This is the same as the `provides` subsection of the `host` section, except that here the resources only exist when a package deployment is active. Here is an example of a `provides` section:
@@ -905,10 +984,15 @@ provides:
 This optional field of the `provides` subsection is an array of host port listener objects listing the network port/protocol pairs which will be bound to processes running in an active deployment of the package and listening for incoming traffic on those port/protocol pairs, on any/all IP addresses.
 
 - This field is optional.
+
 - Generally, a host port listener object should correspond to a [published port](https://docs.docker.com/network/#published-ports) of a Docker container.
+
 - Each host port listener object describes a host port listener resource which may or may not be in conflict with other host port listener resources; this is because multiple processes are not allowed to simultaneously bind to the same port/protocol pair on all IP addresses.
+
 - If a set of package deployments contains two or more host port listener resources for the same port/protocol pair from different package deployments, the package deployments declaring those respective host port listeners will be reported as conflicting with each other. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for uniqueness of host port listener resources will not be satisfied.
+
 - Currently, this specification does not allow multiple host port listeners to bind to the same port/protocol pair on different IP addresses; instead for simplicity, processes are assumed to be listening for that port/protocol pair on *all* IP addresses on the host.
+
 - Example:
   
   ```yaml
@@ -923,6 +1007,7 @@ A host port listener object consists of the following fields:
 - `description` is a short (one-sentence) description of the host port listener resource to be shown to users.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -932,6 +1017,7 @@ A host port listener object consists of the following fields:
 - `port` is a number specifying the [network port](https://en.wikipedia.org/wiki/Port_(computer_networking)) bound by a process running on the host.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -941,7 +1027,9 @@ A host port listener object consists of the following fields:
 - `protocol` is a string specifying whether the bound network port is for the TCP transport protocol or for the UDP transport protocol.
   
    - This field is required.
+  
    - The value of this field must be either `tcp` or `udp`.
+  
    - Example:
      
      ```yaml
@@ -953,8 +1041,11 @@ A host port listener object consists of the following fields:
 This optional field of the `provides` subsection is an array of Docker network objects listing the Docker networks which are created when a deployment of the package becomes active.
 
 - This field is optional.
+
 - Each host Docker network object describes a Docker network resource which may or may not be in conflict with other Docker network resources; this is because multiple Docker networks are not allowed to have the same name.
+
 - If a set of package deployments contains two or more Docker network resources for networks with the same name from different package deployments, the package deployments declaring those respective Docker networks will be reported as conflicting with each other. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for uniqueness of host Docker network names will not be satisfied.
+
 - Example:
   
   ```yaml
@@ -968,6 +1059,7 @@ A Docker network object consists of the following fields:
 - `description` is a short (one-sentence) description of the Docker network resource to be shown to users.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -977,6 +1069,7 @@ A Docker network object consists of the following fields:
 - `name` is a string specifying the name of the Docker network.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -988,9 +1081,13 @@ A Docker network object consists of the following fields:
 This optional field of the `provides` subsection is an array of network service objects listing the network services which are created when a deployment of the package becomes active.
 
 - This field is optional.
+
 - The route of a network service can be defined either as a port/protocol pair or as a combination of port, protocol, and one or more paths. A network service whose route is defined only as a port/protocol pair will overlap with another network service if and only if the other network service whose route is also defined only as a port/protocol pair. A network service whose route is defined with one or more paths will overlap with another network service if and only if both network services have the same port, the same protocol, and at least one overlapping path (for a definition of overlapping paths, refer below to description of the `path` field of the network service object).
+
 - Each network service object describes a network service resource which may or may not be in conflict with other network service resources; this is because multiple network services are not allowed to have overlapping routes.
+
 - If a set of package deployments contains two or more network service resources for services with overlapping routes from different package deployments, then the package deployments declaring those respective network services will be reported as conflicting with each other. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for uniqueness of network services will not be satisfied.
+
 - Example:
   
   ```yaml
@@ -1019,6 +1116,7 @@ A network service object consists of the following fields:
 - `description` is a short (one-sentence) description of the network service resource to be shown to users.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -1028,6 +1126,7 @@ A network service object consists of the following fields:
 - `port` is a number specifying the network port used for accessing the service.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -1037,6 +1136,7 @@ A network service object consists of the following fields:
 - `protocol` is a string specifying the application-level protocol used for accessing the service.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -1046,11 +1146,16 @@ A network service object consists of the following fields:
 - `paths` is an array of strings which are paths used for accessing the service.
   
    - This field is optional.
+  
    - A path may optionally have an asterisk (`*`) at the end, in which case it is a prefix path - so the network service covers all paths beginning with that prefix (i.e. the string before the asterisk).
+  
    - If a network service specifies a port and protocol but no paths, it will conflict with another network service which also specifies the same port and protocol but no paths; it will not conflict with another network service which specifies the same port and protocol and also specifies some paths. In other words, not listing any paths in a network service is equivalent to not having any conflicts with other services available at specific paths on the same port and protocol.
      This is useful for describing systems involving HTTP reverse-proxies or involving message brokers, where one package deployment may provide a network service which routes specific messages to network services from other package deployments on specific paths; then the reverse-proxy or message broker would be specified on some port and protocol with no paths, while the network services behind it would be specified on the same port and protocol but with a set of specific paths.
+  
    - If a package deployment has a dependency on a network service with a specific path which matches a prefix path in a network service from another package deployment, that dependency will be satisfied. For example, a dependency on a network service requiring a path `/ps/docs/hardware` would be met by a network service provided with the path prefix `/ps/docs/*`, assuming they have the same port and protocol.
+  
    - If a package deployment provides a network service with a specific path which matches a prefix path in a network service provided by another package deployment, those two package deployments will be in conflict with each other. For example, a network service providing a path `/ps/docs/hardware` would conflict with a network service providing the path prefix `/ps/docs/*`, assuming they have the same port and protocol. This is because those overlapping paths would cause the network services to overlap with each other, which is not allowed.
+  
    - Example:
      
      ```yaml
@@ -1219,6 +1324,7 @@ A feature specification object consists of the following fields:
 - `description` is a short (one-sentence) description of the network service resource requirement to be shown to users.
   
    - This field is required.
+  
    - Example:
      
      ```yaml
@@ -1228,9 +1334,13 @@ A feature specification object consists of the following fields:
 - `compose-files` is an array of the string filenames of one or more Docker Compose files specifying modifications to the Docker Compose application which will be applied if the feature is enabled.
   
    - This field is optional.
+  
    - The filenames must be for YAML files which are fragments of a [Docker Compose file specification](https://docs.docker.com/compose/compose-file/). These files will be merged together with any other Compose files specified in the [`deployment` section](#deployment-section) of the `forklift-package.yml` file and in any other enabled features according to Docker Compose's [compose file merging mechanism](https://docs.docker.com/compose/multiple-compose-files/merge/).
+  
    - The files must be located in the same directory as the `forklift-package.yml` file, or in subdirectories.
+  
    - For clarity, it is strongly recommended that the order in which the files for different feature flags are merged should not affect the final result of merging.
+  
    - Example:
      
      ```yaml
@@ -1240,7 +1350,9 @@ A feature specification object consists of the following fields:
 - `tags` is an array of strings to associate with the feature or with resources required or provided by the feature.
   
    - This field is optional.
+  
    - These tags have no semantic meaning within the Forklift package specification, but can be used by other applictions for arbitrary purposes.
+  
    - Example:
      
      ```yaml
@@ -1255,7 +1367,9 @@ A feature specification object consists of the following fields:
 - `requires` is a specification of resources required for a deployment of the package, with the feature enabled, to successfully become active.
   
    - This field is optional.
+  
    - The contents of this field have the same syntax and semantics as the contents of the [`requires` subsection](#requires-subsection) of the `deployment` section of the Forklift package specification, except that resource requirements are only evaluated for features configured as "enabled" for each deployment of each package; resource requirements for disabled features will be ignored.
+  
    - Example:
      
      ```yaml
@@ -1272,7 +1386,9 @@ A feature specification object consists of the following fields:
 - `provides` is a specification of resources provided by a deployment of the package, if the feature is enabled for that deployment.
   
    - This field is optional.
+  
    - The contents of this field have the same syntax and semantics as the contents of the [`provides` subsection](#provides-subsection) of the `deployment` section of the Forklift package specification, except that provided resources are only considered for features configured as "enabled" for each deployment of each package; provided resources for disabled features will be ignored.
+  
    - Example:
      
      ```yaml

--- a/docs/specs/00-package.md
+++ b/docs/specs/00-package.md
@@ -614,30 +614,30 @@ A network service object consists of the following fields:
        - tls-client-certs-required
      ```
 
-##### `filesystem` field
+##### `filesets` field
 
-This field of the `provides` subsection is an array of filesystem objects listing the filesystem entities (e.g. files and/or directories) which are already available on the Docker host.
+This field of the `provides` subsection is an array of fileset objects listing the files (which can include directories) which are already available on the Docker host.
 
 - This field is optional.
 
-- A filesystem entity is defined as a list of one or more paths. A filesystem entity will overlap with another filesystem entity if and only if both filesystem entities have at least one overlapping path (for a definition of overlapping paths, refer below to description of the `path` field of the filesystem object).
+- A fileset is defined as a list of one or more paths to files. A fileset will overlap with another fileset if and only if both filesets have at least one overlapping path (for a definition of overlapping paths, refer below to description of the `path` field of the fileset object).
 
-- Each filesystem object describes a filesystem resource which may or may not be in conflict with other filesystem resources; this is because multiple filesystem entities are not allowed to have overlapping paths.
+- Each fileset object describes a fileset resource which may or may not be in conflict with other fileset resources; this is because multiple filesets are not allowed to have overlapping paths.
 
-- If a set of package deployments contains two or more filesystem resources for filesystem entities with overlapping paths from different package deployments, then the package deployments declaring those respective filesystem entities will be reported as conflicting with each other. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for uniqueness of filesystem entities will not be satisfied.
+- If a set of package deployments contains two or more fileset resources for filesets with overlapping paths from different package deployments, then the package deployments declaring those respective filesets will be reported as conflicting with each other. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for uniqueness of filesets will not be satisfied.
 
 - Example:
   
   ```yaml
-  filesystem:
+  filesets:
     - description: File containing the device's machine name
       paths:
       - /var/lib/planktoscope/machine-name
   ```
 
-A filesystem object consists of the following fields:
+A fileset object consists of the following fields:
 
-- `description` is a short (one-sentence) description of the filesystem resource to be shown to users.
+- `description` is a short (one-sentence) description of the fileset resource to be shown to users.
   
    - This field is required.
   
@@ -647,15 +647,15 @@ A filesystem object consists of the following fields:
      description: Directory tree containing PlanktoScope datasets
      ```
 
-- `paths` is an array of strings which are paths where the filesystem entity exists.
+- `paths` is an array of strings which are paths where the fileset exists.
   
    - This field is required.
   
-   - A path may optionally have an asterisk (`*`) at the end, in which case it is a prefix path - so the filesystem entity covers all paths beginning with that prefix (i.e. the string before the asterisk).
+   - A path may optionally have an asterisk (`*`) at the end, in which case it is a prefix path - so the fileset covers all paths beginning with that prefix (i.e. the string before the asterisk).
   
-   - If a package deployment has a dependency on a filesystem entity with a specific path which matches a prefix path in a filesystem entity from another package deployment, that dependency will be satisfied. For example, a dependency on a filesystem entity requiring a path `/home/pi/data/img` would be met by a filesystem entity provided with the path prefix `/home/pi/data/*`.
+   - If a package deployment has a dependency on a fileset with a specific path which matches a prefix path in a fileset from another package deployment, that dependency will be satisfied. For example, a dependency on a fileset requiring a path `/home/pi/data/img` would be met by a fileset provided with the path prefix `/home/pi/data/*`.
   
-   - If a package deployment provides a filesystem entity with a specific path which matches a prefix path in a filesystem entity provided by another package deployment, those two package deployments will be in conflict with each other. For example, a filesystem entity providing a path `/home/pi/data/img` would conflict with a network service providing the path prefix `/home/pi/*`. This is because those overlapping paths would cause the filesystem entities to overlap with each other, which is not allowed.
+   - If a package deployment provides a fileset with a specific path which matches a prefix path in a fileset provided by another package deployment, those two package deployments will be in conflict with each other. For example, a fileset providing a path `/home/pi/data/img` would conflict with a network service providing the path prefix `/home/pi/*`. This is because those overlapping paths would cause the filesets to overlap with each other, which is not allowed.
   
    - Example:
      
@@ -666,11 +666,11 @@ A filesystem object consists of the following fields:
        - /home/pi/data/export
      ```
 
-- `tags` is an array of strings which constrain resolution of filesystem resource dependencies among package deployments. These tags are ignored in determining whether filesystem entities conflict with each other, since they are not part of the filesystem entity's location.
+- `tags` is an array of strings which constrain resolution of fileset resource dependencies among package deployments. These tags are ignored in determining whether filesets conflict with each other, since they are not part of the fileset's location.
   
    - This field is optional.
   
-   - These tags have no semantic meaning within the Forklift package specification, but tag requirements can be used for arbitrary purposes. For example, tags can be used to annotate a file with information about file type, file permissions, schema versions, etc. If a package deployment specifies that it requires a filesystem entity with one or more tags, then another package deployment will only be considered to satisfy the filesystem entity dependency if it provides a filesystem entity matching both the required path(s) and all required tags. This is useful in ensuring that a filesystem entity provided by one package deployment is compatible with the schema version required by another package deployment, for example.
+   - These tags have no semantic meaning within the Forklift package specification, but tag requirements can be used for arbitrary purposes. For example, tags can be used to annotate a file with information about file type, file permissions, schema versions, etc. If a package deployment specifies that it requires a fileset with one or more tags, then another package deployment will only be considered to satisfy the fileset dependency if it provides a fileset matching both the required path(s) and all required tags. This is useful in ensuring that a fileset provided by one package deployment is compatible with the schema version required by another package deployment, for example.
   
    - Example:
      
@@ -884,20 +884,20 @@ A network service object consists of the following fields:
      nonblocking: true
      ```
 
-##### `filesystem` field
+##### `filesets` field
 
-This optional field of the `requires` subsection is an array of filesystem objects listing the filesystem entities (e.g. files and/or directories) which must be available on the Docker host in order for a deployment of the package to successfully become active.
+This optional field of the `requires` subsection is an array of fileset objects listing the files (which can include directories) which must be available on the Docker host in order for a deployment of the package to successfully become active.
 
 - This field is optional.
 
-- A filesystem requirement is defined a list of one or more paths. A filesystem requirement will be satisfied by one or more filesystem entities if and only if the set union of the paths of the filesystem entities overlaps with every path listed in the filesystem requirement (for a definition of overlapping paths, refer below to description of the `path` field of the network service object). Thus, in any particular set of package deployments, one filesystem entity from one package deployment may be sufficient to satisfy a filesystem requirement from some other package deployment, or multiple filesystem entities from multiple packages may be necessary to fully satisfy that filesystem requirement.
+- A fileset requirement is defined a list of one or more paths. A fileset requirement will be satisfied by one or more filesets if and only if the set union of the paths of the filesets overlaps with every path listed in the fileset requirement (for a definition of overlapping paths, refer below to description of the `path` field of the network service object). Thus, in any particular set of package deployments, one fileset from one package deployment may be sufficient to satisfy a fileset requirement from some other package deployment, or multiple filesets from multiple packages may be necessary to fully satisfy that fileset requirement.
 
-- If a set of package deployments contains a filesystem resource requirement with a path which does not overlap with the paths of any filesystem entities provided by other package deployments, then the package deployment declaring that filesystem requirement will be reported as having an unmet dependency. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for resource dependencies will not be satisfied.
+- If a set of package deployments contains a fileset resource requirement with a path which does not overlap with the paths of any filesets provided by other package deployments, then the package deployment declaring that fileset requirement will be reported as having an unmet dependency. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for resource dependencies will not be satisfied.
 
 - Example:
   
   ```yaml
-  filesystem:
+  filesets:
     - description: The directory where logs will be saved
       tags:
         - directory
@@ -907,9 +907,9 @@ This optional field of the `requires` subsection is an array of filesystem objec
         - /home/pi/device-backend-logs/processing/segmenter
   ```
 
-A filesystem object consists of the following fields:
+A fileset object consists of the following fields:
 
-- `description` is a short (one-sentence) description of the filesystem resource requirement to be shown to users.
+- `description` is a short (one-sentence) description of the fileset resource requirement to be shown to users.
   
    - This field is required.
   
@@ -919,13 +919,13 @@ A filesystem object consists of the following fields:
      description: A file containing the device's machine name
      ```
 
-- `paths` is an array of strings which are paths which must be accessible on the filesystem.
+- `paths` is an array of strings which are paths of files which must exist.
   
    - This field is required.
   
-   - A path may optionally have an asterisk (`*`) at the end, in which case it is a prefix path - so the required filesystem entity must declare that it can be used with any path beginning with that prefix (i.e. the string before the asterisk).
+   - A path may optionally have an asterisk (`*`) at the end, in which case it is a prefix path - so the required fileset must declare that it can be used with any path beginning with that prefix (i.e. the string before the asterisk).
   
-   - If a package deployment has a requirement for a filesystem entity with a specific path which matches the prefix path of a filesystem entity provided by another package deployment, the filesystem requirement will be met. For example, a requirement for a filesystem entity with a path `/var/lib/planktoscope/machine-name` would be met by a filesystem entity provided with the path prefix `/var/lib/planktoscope/*`.
+   - If a package deployment has a requirement for a fileset with a specific path which matches the prefix path of a fileset provided by another package deployment, the fileset requirement will be met. For example, a requirement for a fileset with a path `/var/lib/planktoscope/machine-name` would be met by a fileset provided with the path prefix `/var/lib/planktoscope/*`.
   
    - Example:
      
@@ -934,11 +934,11 @@ A filesystem object consists of the following fields:
        - /var/lib/planktoscope/machine-name
      ```
 
-- `tags` is an array of strings specifying labels which must be associated with the required filesystem entity.
+- `tags` is an array of strings specifying labels which must be associated with the required fileset.
   
    - This field is optional.
   
-   - These tags have no semantic meaning within the Forklift package specification, but tag requirements can be used for arbitrary purposes. For example, tags can be used to require a filesystem entity annotated with information about file types, file permissions, schema versions, etc. If a package deployment specifies that it requires a filesystem entity with one or more tags, then another package deployment will only be considered to satisfy the filesystem entity dependency if it provides a filesystem entity matching both the required path(s) and all required tags. This is useful in ensuring that a filesystem entity provided by one package deployment is compatible with the schema version required by another package deployment, for example.
+   - These tags have no semantic meaning within the Forklift package specification, but tag requirements can be used for arbitrary purposes. For example, tags can be used to require a fileset annotated with information about file types, file permissions, schema versions, etc. If a package deployment specifies that it requires a fileset with one or more tags, then another package deployment will only be considered to satisfy the fileset dependency if it provides a fileset matching both the required path(s) and all required tags. This is useful in ensuring that a fileset provided by one package deployment is compatible with the schema version required by another package deployment, for example.
   
    - Example:
      
@@ -948,13 +948,13 @@ A filesystem object consists of the following fields:
        - plain-text
      ```
 
-- `nonblocking` is a boolean flag specifying whether the package deployment providing the required filesystem entity is allowed to start after starting the package deployment with the filesystem requirement.
+- `nonblocking` is a boolean flag specifying whether the package deployment providing the required fileset is allowed to start after starting the package deployment with the fileset requirement.
   
    - This field is optional.
   
    - This is a performance optimization hint which may be ignored; it's only meaningful if package deployments can be started concurrently. However, it can help to reduce the startup time needed for the critical path of a chain of dependencies between package deployments.
   
-   - This field can be set to true if the program requiring the filesystem entity can gracefully handle the temporary absence of the filesystem entity while package deployments are being applied; otherwise, this field should not be set to true.
+   - This field can be set to true if the program requiring the fileset can gracefully handle the temporary absence of the fileset while package deployments are being applied; otherwise, this field should not be set to true.
   
    - Example:
      
@@ -1177,17 +1177,17 @@ A network service object consists of the following fields:
        - website
      ```
 
-##### `filesystem` field
+##### `filesets` field
 
-This optional field of the `provides` subsection is an array of filesystem objects listing the filesystem entities (e.g. files and/or directories) which are created when a deployment of the package becomes active.
+This optional field of the `provides` subsection is an array of fileset objects listing the files (which can include directories) which are created when a deployment of the package becomes active.
 
 - This field is optional.
 
-- A filesystem entity is defined as a list of one or more paths. A filesystem entity will overlap with another filesystem entity if and only if both filesystem entities have at least one overlapping path (for a definition of overlapping paths, refer below to description of the `path` field of the filesystem object).
+- A fileset is defined as a list of one or more paths. A fileset will overlap with another fileset if and only if both filesets have at least one overlapping path (for a definition of overlapping paths, refer below to description of the `path` field of the fileset object).
 
-- Each filesystem object describes a filesystem resource which may or may not be in conflict with other filesystem resources; this is because multiple filesystem entities are not allowed to have overlapping paths.
+- Each fileset object describes a fileset resource which may or may not be in conflict with other fileset resources; this is because multiple filesets are not allowed to have overlapping paths.
 
-- If a set of package deployments contains two or more filesystem resources for filesystem entities with overlapping paths from different package deployments, then the package deployments declaring those respective filesystem entities will be reported as conflicting with each other. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for uniqueness of filesystem entities will not be satisfied.
+- If a set of package deployments contains two or more fileset resources for filesets with overlapping paths from different package deployments, then the package deployments declaring those respective filesets will be reported as conflicting with each other. Therefore, the overall set of package deployments will not be allowed because its [package resource constraints](#package-resource-constraints) for uniqueness of filesets will not be satisfied.
 
 - Example:
   
@@ -1201,9 +1201,9 @@ This optional field of the `provides` subsection is an array of filesystem objec
         - /var/lib/planktoscope/machine-name
   ```
 
-A filesystem object consists of the following fields:
+A fileset object consists of the following fields:
 
-- `description` is a short (one-sentence) description of the filesystem resource to be shown to users.
+- `description` is a short (one-sentence) description of the fileset resource to be shown to users.
   
    - This field is required.
   
@@ -1213,15 +1213,15 @@ A filesystem object consists of the following fields:
      description: Directory of EcoTaxa export archives
      ```
 
-- `paths` is an array of strings which are paths where the filesystem entity exists.
+- `paths` is an array of strings which are paths of files in the fileset.
   
    - This field is required.
   
-   - A path may optionally have an asterisk (`*`) at the end, in which case it is a prefix path - so the filesystem entity covers all paths beginning with that prefix (i.e. the string before the asterisk).
+   - A path may optionally have an asterisk (`*`) at the end, in which case it is a prefix path - so the fileset covers all paths beginning with that prefix (i.e. the string before the asterisk).
   
-   - If a package deployment has a dependency on a filesystem entity with a specific path which matches a prefix path in a filesystem entity from another package deployment, that dependency will be satisfied. For example, a dependency on a filesystem entity requiring a path `/home/pi/device-logs/controller` would be met by a network service provided with the path prefix `/home/pi/device-logs/*`.
+   - If a package deployment has a dependency on a fileset with a specific path which matches a prefix path in a fileset from another package deployment, that dependency will be satisfied. For example, a dependency on a fileset requiring a path `/home/pi/device-logs/controller` would be met by a network service provided with the path prefix `/home/pi/device-logs/*`.
   
-   - If a package deployment provides a filesystem entity with a specific path which matches a prefix path in a filesystem entity provided by another package deployment, those two package deployments will be in conflict with each other. For example, a filesystem entity providing a path `/home/pi/data/export/ecotaxa` would conflict with a network service providing the path prefix `/home/pi/data/export/*`. This is because those overlapping paths would cause the filesystem entities to overlap with each other, which is not allowed.
+   - If a package deployment provides a fileset with a specific path which matches a prefix path in a fileset provided by another package deployment, those two package deployments will be in conflict with each other. For example, a fileset providing a path `/home/pi/data/export/ecotaxa` would conflict with a network service providing the path prefix `/home/pi/data/export/*`. This is because those overlapping paths would cause the filesets to overlap with each other, which is not allowed.
   
    - Example:
      
@@ -1230,11 +1230,11 @@ A filesystem object consists of the following fields:
        - /home/pi/data/export/ecotaxa
      ```
 
-- `tags` is an array of strings which constrain resolution of filesystem resource dependencies among package deployments. These tags are ignored in determining whether filesystem entities conflict with each other, since they are not part of the filesystem entity's location.
+- `tags` is an array of strings which constrain resolution of fileset resource dependencies among package deployments. These tags are ignored in determining whether filesets conflict with each other, since they are not part of the fileset's location.
   
    - This field is optional.
   
-   - These tags have no semantic meaning within the Forklift package specification, but tag requirements can be used for arbitrary purposes. For example, tags can be used to annotate a file with information about file type, file permissions, schema versions, etc. If a package deployment specifies that it requires a filesystem entity with one or more tags, then another package deployment will only be considered to satisfy the filesystem entity dependency if it provides a filesystem entity matching both the required path(s) and all required tags. This is useful in ensuring that a filesystem entity provided by one package deployment is compatible with the schema version required by another package deployment, for example.
+   - These tags have no semantic meaning within the Forklift package specification, but tag requirements can be used for arbitrary purposes. For example, tags can be used to annotate a file with information about file type, file permissions, schema versions, etc. If a package deployment specifies that it requires a fileset with one or more tags, then another package deployment will only be considered to satisfy the fileset dependency if it provides a fileset matching both the required path(s) and all required tags. This is useful in ensuring that a fileset provided by one package deployment is compatible with the schema version required by another package deployment, for example.
   
    - Example:
      

--- a/internal/app/forklift/cli/pallets.go
+++ b/internal/app/forklift/cli/pallets.go
@@ -239,6 +239,12 @@ func printDeplConflict(indent int, conflict forklift.DeplConflict) error {
 			return errors.Wrap(err, "couldn't print conflicting network services")
 		}
 	}
+	if conflict.HasFilesetConflict() {
+		IndentedPrintln(indent, "Conflicting filesets:")
+		if err := printResConflicts(indent+1, conflict.Filesets); err != nil {
+			return errors.Wrap(err, "couldn't print conflicting filesets")
+		}
+	}
 	return nil
 }
 
@@ -322,6 +328,14 @@ func printMissingDeplDep(indent int, deps forklift.MissingDeplDeps) error {
 		if err := printMissingDeps(indent+1, deps.Services); err != nil {
 			return errors.Wrapf(
 				err, "couldn't print unmet network service dependencies of deployment %s", deps.Depl.Name,
+			)
+		}
+	}
+	if deps.HasMissingFilesetDep() {
+		IndentedPrintln(indent, "Missing filesets:")
+		if err := printMissingDeps(indent+1, deps.Filesets); err != nil {
+			return errors.Wrapf(
+				err, "couldn't print unmet fileset dependencies of deployment %s", deps.Depl.Name,
 			)
 		}
 	}

--- a/internal/app/forklift/constraints-models.go
+++ b/internal/app/forklift/constraints-models.go
@@ -13,6 +13,7 @@ type DeplConflict struct {
 	Listeners []core.ResConflict[core.ListenerRes]
 	Networks  []core.ResConflict[core.NetworkRes]
 	Services  []core.ResConflict[core.ServiceRes]
+	Filesets  []core.ResConflict[core.FilesetRes]
 }
 
 type SatisfiedDeplDeps struct {
@@ -20,6 +21,7 @@ type SatisfiedDeplDeps struct {
 
 	Networks []core.SatisfiedResDep[core.NetworkRes]
 	Services []core.SatisfiedResDep[core.ServiceRes]
+	Filesets []core.SatisfiedResDep[core.FilesetRes]
 }
 
 type MissingDeplDeps struct {
@@ -27,4 +29,5 @@ type MissingDeplDeps struct {
 
 	Networks []core.MissingResDep[core.NetworkRes]
 	Services []core.MissingResDep[core.ServiceRes]
+	Filesets []core.MissingResDep[core.FilesetRes]
 }

--- a/internal/app/forklift/constraints.go
+++ b/internal/app/forklift/constraints.go
@@ -18,9 +18,14 @@ func (c DeplConflict) HasServiceConflict() bool {
 	return len(c.Services) > 0
 }
 
+func (c DeplConflict) HasFilesetConflict() bool {
+	return len(c.Filesets) > 0
+}
+
 func (c DeplConflict) HasConflict() bool {
 	return c.HasNameConflict() ||
-		c.HasListenerConflict() || c.HasNetworkConflict() || c.HasServiceConflict()
+		c.HasListenerConflict() || c.HasNetworkConflict() || c.HasServiceConflict() ||
+		c.HasFilesetConflict()
 }
 
 // SatisfiedDeplDeps
@@ -33,8 +38,12 @@ func (d SatisfiedDeplDeps) HasSatisfiedServiceDep() bool {
 	return len(d.Services) > 0
 }
 
+func (d SatisfiedDeplDeps) HasSatisfiedFilesetDep() bool {
+	return len(d.Filesets) > 0
+}
+
 func (d SatisfiedDeplDeps) HasSatisfiedDep() bool {
-	return d.HasSatisfiedNetworkDep() || d.HasSatisfiedServiceDep()
+	return d.HasSatisfiedNetworkDep() || d.HasSatisfiedServiceDep() || d.HasSatisfiedFilesetDep()
 }
 
 // MissingDeplDeps
@@ -47,6 +56,10 @@ func (d MissingDeplDeps) HasMissingServiceDep() bool {
 	return len(d.Services) > 0
 }
 
+func (d MissingDeplDeps) HasMissingFilesetDep() bool {
+	return len(d.Filesets) > 0
+}
+
 func (d MissingDeplDeps) HasMissingDep() bool {
-	return d.HasMissingNetworkDep() || d.HasMissingServiceDep()
+	return d.HasMissingNetworkDep() || d.HasMissingServiceDep() || d.HasMissingFilesetDep()
 }

--- a/pkg/core/packages-models.go
+++ b/pkg/core/packages-models.go
@@ -111,6 +111,8 @@ type RequiredRes struct {
 	Networks []NetworkRes `yaml:"networks,omitempty"`
 	// Services is a list of requirements for network services.
 	Services []ServiceRes `yaml:"services,omitempty"`
+	// Filesets is a list of requirements for files/directories.
+	Filesets []FilesetRes `yaml:"fileset,omitempty"`
 }
 
 // ProvidedRes describes a set of resources provided by some aspect of a package.
@@ -121,6 +123,8 @@ type ProvidedRes struct {
 	Networks []NetworkRes `yaml:"networks,omitempty"`
 	// Services is a list of network services.
 	Services []ServiceRes `yaml:"services,omitempty"`
+	// Filesets is a list of files/directories.
+	Filesets []FilesetRes `yaml:"fileset,omitempty"`
 }
 
 // ListenerRes describes a host port listener.
@@ -158,5 +162,20 @@ type ServiceRes struct {
 	Paths []string `yaml:"paths,omitempty"`
 	// Nonblocking, when specified as a resource requirement, specifies that the client of the service
 	// does not need to wait for the resource to exist before the client can start.
+	Nonblocking bool `yaml:"nonblocking,omitempty"`
+}
+
+// FilesetRes describes a set of files/directories.
+type FilesetRes struct {
+	// Description is a short description of the fileset to be shown to users.
+	Description string `yaml:"description,omitempty"`
+	// Tags is a list of strings associated with the fileset. Tags are considered in determining which
+	// fileset resources meet fileset resource requirements.
+	Tags []string `yaml:"tags,omitempty"`
+	// Paths is a list of paths where the fileset exists. A path may also be a prefix, indicated
+	// by ending the path with an asterisk (`*`).
+	Paths []string `yaml:"paths,omitempty"`
+	// Nonblocking, when specified as a resource requirement, specifies that the program requiring the
+	// fileset does not need to wait for the fileset to exist before the program can start.
 	Nonblocking bool `yaml:"nonblocking,omitempty"`
 }

--- a/pkg/core/packages-models.go
+++ b/pkg/core/packages-models.go
@@ -112,7 +112,7 @@ type RequiredRes struct {
 	// Services is a list of requirements for network services.
 	Services []ServiceRes `yaml:"services,omitempty"`
 	// Filesets is a list of requirements for files/directories.
-	Filesets []FilesetRes `yaml:"fileset,omitempty"`
+	Filesets []FilesetRes `yaml:"filesets,omitempty"`
 }
 
 // ProvidedRes describes a set of resources provided by some aspect of a package.
@@ -124,7 +124,7 @@ type ProvidedRes struct {
 	// Services is a list of network services.
 	Services []ServiceRes `yaml:"services,omitempty"`
 	// Filesets is a list of files/directories.
-	Filesets []FilesetRes `yaml:"fileset,omitempty"`
+	Filesets []FilesetRes `yaml:"filesets,omitempty"`
 }
 
 // ListenerRes describes a host port listener.


### PR DESCRIPTION
This PR adds a new "fileset" resource type, so that packages can specify what files they provide on the host filesystem (useful to prevent packages from managing files at conflicting filenames) and what files they require on the host filesystem (useful to avoid missing file dependencies).