### PR TITLE
Allow a pallet to deploy packages defined by that same pallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.5.2 - 2024-02-10
+
 ### Added
 
 - (spec) Added a "fileset" resource type for files (which can include directories).
+- (cli) Added support to for a pallet to deploy packages defined in that same pallet, by referring to the package as an absolute path (rooted at the root of the pallet), if the pallet declares itself as a Forklift repo with the same path.
 
 ## 0.5.1 - 2024-02-07
 

--- a/cmd/forklift/dev/plt/deployments.go
+++ b/cmd/forklift/dev/plt/deployments.go
@@ -9,11 +9,8 @@ import (
 // ls-depl
 
 func lsDeplAction(c *cli.Context) error {
-	pallet, cache, overrideCache, err := processFullBaseArgs(c, true)
+	pallet, cache, err := processFullBaseArgs(c, true, true)
 	if err != nil {
-		return err
-	}
-	if err = setOverrideCacheVersions(pallet, overrideCache); err != nil {
 		return err
 	}
 
@@ -23,11 +20,8 @@ func lsDeplAction(c *cli.Context) error {
 // show-depl
 
 func showDeplAction(c *cli.Context) error {
-	pallet, cache, overrideCache, err := processFullBaseArgs(c, true)
+	pallet, cache, err := processFullBaseArgs(c, true, true)
 	if err != nil {
-		return err
-	}
-	if err = setOverrideCacheVersions(pallet, overrideCache); err != nil {
 		return err
 	}
 
@@ -38,11 +32,8 @@ func showDeplAction(c *cli.Context) error {
 // locate-depl-pkg
 
 func locateDeplPkgAction(c *cli.Context) error {
-	pallet, cache, overrideCache, err := processFullBaseArgs(c, true)
+	pallet, cache, err := processFullBaseArgs(c, true, true)
 	if err != nil {
-		return err
-	}
-	if err = setOverrideCacheVersions(pallet, overrideCache); err != nil {
 		return err
 	}
 

--- a/cmd/forklift/dev/plt/images.go
+++ b/cmd/forklift/dev/plt/images.go
@@ -12,11 +12,8 @@ import (
 
 func cacheImgAction(toolVersion, repoMinVersion, palletMinVersion string) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		pallet, cache, overrideCache, err := processFullBaseArgs(c, true)
+		pallet, cache, err := processFullBaseArgs(c, true, true)
 		if err != nil {
-			return err
-		}
-		if err = setOverrideCacheVersions(pallet, overrideCache); err != nil {
 			return err
 		}
 		if err = fcli.CheckCompatibility(

--- a/cmd/forklift/dev/plt/packages.go
+++ b/cmd/forklift/dev/plt/packages.go
@@ -9,11 +9,8 @@ import (
 // ls-pkg
 
 func lsPkgAction(c *cli.Context) error {
-	pallet, cache, overrideCache, err := processFullBaseArgs(c, true)
+	pallet, cache, err := processFullBaseArgs(c, true, true)
 	if err != nil {
-		return err
-	}
-	if err = setOverrideCacheVersions(pallet, overrideCache); err != nil {
 		return err
 	}
 
@@ -23,11 +20,8 @@ func lsPkgAction(c *cli.Context) error {
 // show-pkg
 
 func showPkgAction(c *cli.Context) error {
-	pallet, cache, overrideCache, err := processFullBaseArgs(c, true)
+	pallet, cache, err := processFullBaseArgs(c, true, true)
 	if err != nil {
-		return err
-	}
-	if err = setOverrideCacheVersions(pallet, overrideCache); err != nil {
 		return err
 	}
 

--- a/cmd/forklift/dev/plt/repositories.go
+++ b/cmd/forklift/dev/plt/repositories.go
@@ -22,7 +22,7 @@ import (
 
 func cacheRepoAction(toolVersion, repoMinVersion, palletMinVersion string) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		pallet, cache, _, err := processFullBaseArgs(c, false)
+		pallet, cache, err := processFullBaseArgs(c, false, false)
 		if err != nil {
 			return err
 		}
@@ -62,11 +62,8 @@ func lsRepoAction(c *cli.Context) error {
 // show-repo
 
 func showRepoAction(c *cli.Context) error {
-	pallet, cache, overrideCache, err := processFullBaseArgs(c, true)
+	pallet, cache, err := processFullBaseArgs(c, true, true)
 	if err != nil {
-		return err
-	}
-	if err = setOverrideCacheVersions(pallet, overrideCache); err != nil {
 		return err
 	}
 
@@ -78,7 +75,7 @@ func showRepoAction(c *cli.Context) error {
 
 func addRepoAction(toolVersion, repoMinVersion, palletMinVersion string) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		pallet, cache, _, err := processFullBaseArgs(c, false)
+		pallet, cache, err := processFullBaseArgs(c, false, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -14,21 +14,12 @@ import (
 
 func processFullBaseArgs(
 	c *cli.Context, ensureCache bool,
-) (pallet *forklift.FSPallet, cache *forklift.FSRepoCache, err error) {
-	workspace, err := forklift.LoadWorkspace(c.String("workspace"))
-	if err != nil {
-		return nil, nil, err
-	}
+) (pallet *forklift.FSPallet, cache forklift.PathedRepoCache, err error) {
 	if pallet, err = getPallet(c.String("workspace")); err != nil {
 		return nil, nil, err
 	}
-	if cache, err = workspace.GetRepoCache(); err != nil {
+	if cache, _, err = fcli.GetCache(c.String("workspace"), pallet, ensureCache); err != nil {
 		return nil, nil, err
-	}
-	if ensureCache && !cache.Exists() {
-		return nil, nil, errors.New(
-			"you first need to cache the repos specified by your pallet with `forklift plt cache-repo`",
-		)
 	}
 	return pallet, cache, nil
 }

--- a/internal/app/forklift/caching.go
+++ b/internal/app/forklift/caching.go
@@ -214,6 +214,7 @@ func (c *LayeredRepoCache) LoadFSPkg(pkgPath string, version string) (*core.FSPk
 		pkg, err := c.Overlay.LoadFSPkg(pkgPath, version)
 		return pkg, errors.Wrap(err, "couldn't load package from overlay")
 	}
+
 	pkg, err := c.Underlay.LoadFSPkg(pkgPath, version)
 	return pkg, errors.Wrap(err, "couldn't load package from underlay")
 }
@@ -305,6 +306,9 @@ func (c *RepoOverrideCache) SetVersions(repoPath string, versions map[string]str
 // IncludesFSRepo reports whether the RepoOverrideCache instance has a repo with the
 // specified path and version.
 func (c *RepoOverrideCache) IncludesFSRepo(repoPath string, version string) bool {
+	if c == nil {
+		return false
+	}
 	if _, ok := c.repos[repoPath]; !ok {
 		return false
 	}
@@ -364,6 +368,9 @@ func (c *RepoOverrideCache) LoadFSRepos(searchPattern string) ([]*core.FSRepo, e
 // IncludesFSPkg reports whether the RepoOverrideCache instance has a repo with the specified
 // version which covers the specified package path.
 func (c *RepoOverrideCache) IncludesFSPkg(pkgPath string, version string) bool {
+	if c == nil {
+		return false
+	}
 	// Beyond a certain number of repos, it's probably faster to just recurse down via the subdirs.
 	// But we probably don't need to worry about this for now.
 	for _, repo := range c.repos {

--- a/internal/app/forklift/cli/packages.go
+++ b/internal/app/forklift/cli/packages.go
@@ -18,7 +18,7 @@ func PrintPkg(indent int, cache forklift.PathedRepoCache, pkg *core.FSPkg) {
 	if core.CoversPath(cache, pkg.FS.Path()) {
 		IndentedPrintf(indent, "Path in cache: %s\n", core.GetSubdirPath(cache, pkg.FS.Path()))
 	} else {
-		IndentedPrintf(indent, "External path (replacing cached package): %s\n", pkg.FS.Path())
+		IndentedPrintf(indent, "Absolute path (replacing any cached copy): %s\n", pkg.FS.Path())
 	}
 
 	PrintPkgSpec(indent, pkg.Def.Package)
@@ -36,7 +36,7 @@ func printPkgRepo(indent int, cache forklift.PathedRepoCache, pkg *core.FSPkg) {
 		IndentedPrintf(indent, "Version: %s\n", pkg.Repo.Version)
 	} else {
 		IndentedPrintf(
-			indent, "External path (replacing cached repository): %s\n", pkg.Repo.FS.Path(),
+			indent, "Absolute path (replacing any cached copy): %s\n", pkg.Repo.FS.Path(),
 		)
 	}
 

--- a/internal/app/forklift/pallets-deployments.go
+++ b/internal/app/forklift/pallets-deployments.go
@@ -29,7 +29,7 @@ func ResolveDepl(
 		pkgReqLoader, pkgLoader, pkgPath,
 	); err != nil {
 		return nil, errors.Wrapf(
-			err, "couldn't load package %s to resolved from package deployment %s", pkgPath, depl.Name,
+			err, "couldn't load package %s to resolve from package deployment %s", pkgPath, depl.Name,
 		)
 	}
 	return resolved, nil

--- a/internal/app/forklift/pallets.go
+++ b/internal/app/forklift/pallets.go
@@ -3,7 +3,9 @@ package forklift
 import (
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
@@ -131,6 +133,15 @@ func (p *FSPallet) LoadPkgReq(pkgPath string) (r PkgReq, err error) {
 	if err != nil {
 		return PkgReq{}, errors.Wrap(err, "couldn't open directory for repo requirements from pallet")
 	}
+	if path.IsAbs(pkgPath) { // special case: package should be provided by the pallet itself
+		return PkgReq{
+			PkgSubdir: strings.TrimLeft(pkgPath, "/"),
+			Repo: RepoReq{
+				RepoPath: p.Def.Pallet.Path,
+			},
+		}, nil
+	}
+
 	fsRepoReq, err := loadFSRepoReqContaining(reposFS, pkgPath)
 	if err != nil {
 		return PkgReq{}, errors.Wrapf(err, "couldn't find repo providing package %s in pallet", pkgPath)


### PR DESCRIPTION
This PR adds support for a pallet act as its own package repository by defining its own packages and deploying those packages, without having to deal with version locking. This functionality is demonstrated by https://github.com/ethanjli/pallet-example-minimal . This functionality can be used by carrying out the following steps:

- Add a `forklift-repository.yml` file next to the existing `forklift-pallet.yml` file at the root of the pallet, and ensure that the declared path in the repository file matches the declared path in the pallet file.
- For deployments of packages defined by the same pallet, use an absolute path to refer to the path, where the root of the absolute path is the root of the pallet. For example, if a pallet `github.com/ethanjli/pallet-example-minimal` defines a package in the subdirectory `packages/foobar`, then a deployment of that package should identify the package as `/packages/foobar`.

Note that:

- As with regular Forklift repositories, packages may be defined anywhere.
- No `forklift-version-lock.yml` file should be created for the pallet-which-is-also-a-repository; if such a file is created, it will be silently ignored.