### PR TITLE
Don't require `plt cache-repo` for pallets without repo reqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.5.3 - 2024-02-10
+
+### Fixed
+
+- (cli) When performing operations on a pallet without any external repo requirements, forklift no longer complains if you haven't cached any repos.
+
 ## 0.5.2 - 2024-02-10
 
 ### Added

--- a/cmd/forklift/main.go
+++ b/cmd/forklift/main.go
@@ -55,7 +55,7 @@ var app = &cli.App{
 const (
 	repoMinVersion   = "v0.4.0"     // minimum supported Forklift version among repos
 	palletMinVersion = "v0.4.0"     // minimum supported Forklift version among pallets
-	fallbackVersion  = "v0.5.0-dev" // version reported by Forklift tool if actual version is unknown
+	fallbackVersion  = "v0.5.3-dev" // version reported by Forklift tool if actual version is unknown
 )
 
 var (

--- a/internal/app/forklift/cli/pallets-repositories.go
+++ b/internal/app/forklift/cli/pallets-repositories.go
@@ -35,7 +35,13 @@ func GetCache(
 	cache.Underlay = fsCache
 
 	if ensureCache && !fsCache.Exists() {
-		return nil, nil, errors.New("you first need to cache the repos specified by your pallet")
+		repoReqs, err := pallet.LoadFSRepoReqs("**")
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "couldn't check whether the pallet requires any repos")
+		}
+		if len(repoReqs) > 0 {
+			return nil, nil, errors.New("you first need to cache the repos specified by your pallet")
+		}
 	}
 	return cache, override, nil
 }


### PR DESCRIPTION
This PR follows up on #130 by only erroring out on the lack of a repo cache for pallets which specify external repo requirements; thus, now pallets which only deploy their own packages can be used without running `plt cache-repo`.