### PR TITLE
Make `[dev] plt cache-all` work on pallets with local pkgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (cli) Added a `[dev] plt cache-all` subcommand which just does everything in `[dev] plt cache-repo` and `[dev] plt cache-img` in a single command.
 
 ### Changed
+
 - (cli) The `plt clone` and `plt switch` subcommands now update the local pallet cache, and they initialize the local pallet from the local pallet cache. This way, version queries can still be resolved (for re-cloning or switching pallets) even without internet access, as long as the local pallet cache is up-to-date.
 - (cli) The `plt clone` and `plt switch` subcommands now create local branches tracking all remote branches, and providing a branch name as the version query causes the corresponding local branch to be checked out (instead of checking out the remote branch). This makes it easier to add local commits and push/pull between the local repository and the remote repository when a branch is checked out on the local repository.
 - (cli) The `[dev] plt add-repo` subcommand now updates the local pallet cache, and it runs version queries on the local pallet cache. This way, version queries can still be resolved (for re-cloning or switching pallets) even without internet access, as long as the local pallet cache is up-to-date.

--- a/cmd/forklift/dev/plt/pallets.go
+++ b/cmd/forklift/dev/plt/pallets.go
@@ -124,7 +124,7 @@ func cacheAllAction(toolVersion, repoMinVersion, palletMinVersion string) cli.Ac
 		}
 
 		changed, err := fcli.CacheAllRequirements(
-			pallet, cache.Underlay, c.Bool("include-disabled"), c.Bool("parallel"),
+			pallet, cache.Underlay.Path(), cache, c.Bool("include-disabled"), c.Bool("parallel"),
 		)
 		if err != nil {
 			return err

--- a/cmd/forklift/dev/plt/repositories.go
+++ b/cmd/forklift/dev/plt/repositories.go
@@ -29,7 +29,7 @@ func cacheRepoAction(toolVersion, repoMinVersion, palletMinVersion string) cli.A
 		}
 
 		fmt.Printf("Downloading repos specified by the development pallet...\n")
-		changed, err := fcli.DownloadRequiredRepos(0, pallet, cache.Underlay)
+		changed, err := fcli.DownloadRequiredRepos(0, pallet, cache.Underlay.Path())
 		if err != nil {
 			return err
 		}

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -53,7 +53,7 @@ func cacheAllAction(toolVersion, repoMinVersion, palletMinVersion string) cli.Ac
 		}
 
 		changed, err := fcli.CacheAllRequirements(
-			pallet, cache, c.Bool("include-disabled"), c.Bool("parallel"),
+			pallet, cache.Path(), cache, c.Bool("include-disabled"), c.Bool("parallel"),
 		)
 		if err != nil {
 			return err
@@ -110,7 +110,7 @@ func switchAction(toolVersion, repoMinVersion, palletMinVersion string) cli.Acti
 			return err
 		}
 		if _, err = fcli.CacheAllRequirements(
-			pallet, cache, c.Bool("include-disabled"), c.Bool("parallel"),
+			pallet, cache.Path(), cache, c.Bool("include-disabled"), c.Bool("parallel"),
 		); err != nil {
 			return err
 		}

--- a/cmd/forklift/plt/repositories.go
+++ b/cmd/forklift/plt/repositories.go
@@ -23,7 +23,7 @@ func cacheRepoAction(toolVersion, repoMinVersion, palletMinVersion string) cli.A
 		}
 
 		fmt.Println("Downloading repos specified by the local pallet...")
-		changed, err := fcli.DownloadRequiredRepos(0, pallet, cache)
+		changed, err := fcli.DownloadRequiredRepos(0, pallet, cache.Path())
 		if err != nil {
 			return err
 		}

--- a/internal/app/forklift/cli/pallets-repositories.go
+++ b/internal/app/forklift/cli/pallets-repositories.go
@@ -131,7 +131,7 @@ func printRepoReq(indent int, req forklift.RepoReq) {
 // Download
 
 func DownloadRequiredRepos(
-	indent int, pallet *forklift.FSPallet, cache forklift.PathedRepoCache,
+	indent int, pallet *forklift.FSPallet, cachePath string,
 ) (changed bool, err error) {
 	loadedRepoReqs, err := pallet.LoadFSRepoReqs("**")
 	if err != nil {
@@ -140,7 +140,7 @@ func DownloadRequiredRepos(
 	changed = false
 	for _, req := range loadedRepoReqs {
 		downloaded, err := DownloadLockedGitRepoUsingLocalMirror(
-			indent, cache.Path(), req.Path(), req.VersionLock,
+			indent, cachePath, req.Path(), req.VersionLock,
 		)
 		changed = changed || downloaded
 		if err != nil {

--- a/internal/app/forklift/cli/pallets.go
+++ b/internal/app/forklift/cli/pallets.go
@@ -213,7 +213,7 @@ func printRemoteInfo(indent int, remote *ggit.Remote) {
 // Download
 
 func DownloadRequiredPallets(
-	indent int, pallet *forklift.FSPallet, cache forklift.PathedPalletCache,
+	indent int, pallet *forklift.FSPallet, cachePath string,
 ) (changed bool, err error) {
 	loadedPalletReqs, err := pallet.LoadFSPalletReqs("**")
 	if err != nil {
@@ -222,7 +222,7 @@ func DownloadRequiredPallets(
 	changed = false
 	for _, req := range loadedPalletReqs {
 		downloaded, err := DownloadLockedGitRepoUsingLocalMirror(
-			indent, cache.Path(), req.Path(), req.VersionLock,
+			indent, cachePath, req.Path(), req.VersionLock,
 		)
 		changed = changed || downloaded
 		if err != nil {
@@ -237,10 +237,11 @@ func DownloadRequiredPallets(
 // Cache
 
 func CacheAllRequirements(
-	pallet *forklift.FSPallet, repoCache forklift.PathedRepoCache, includeDisabled, parallel bool,
+	pallet *forklift.FSPallet, repoCachePath string, loader forklift.FSPkgLoader,
+	includeDisabled, parallel bool,
 ) (changed bool, err error) {
 	fmt.Println("Downloading repos specified by the local pallet...")
-	changed, err = DownloadRequiredRepos(0, pallet, repoCache)
+	changed, err = DownloadRequiredRepos(0, pallet, repoCachePath)
 	if err != nil {
 		return false, err
 	}
@@ -249,7 +250,7 @@ func CacheAllRequirements(
 	// forklift version is incompatible or ahead of the pallet version
 
 	fmt.Println("Downloading Docker container images specified by the local pallet...")
-	if err := DownloadImages(0, pallet, repoCache, includeDisabled, parallel); err != nil {
+	if err := DownloadImages(0, pallet, loader, includeDisabled, parallel); err != nil {
 		return false, err
 	}
 	return changed, nil


### PR DESCRIPTION
This PR fixes a bug with the `[dev] plt cache-all` subcommand added by #138, where that subcommand would fail if run on a pallet which deployed a package locally defined in that pallet (i.e. a package whose path didn't include a hostname, but rather started with a `/`, support for which was added by #130), error'ing out with a message about the inability to resolve the locally-defined package.