### PR TITLE
Update Makefile for macOS cross-compilation with goreleaser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          docker-images: false
+          swap-storage: false
+
       - name: Setup Golang with cache
         uses: magnetikonline/action-golang-cache@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          docker-images: false
+          swap-storage: false
+
       - name: Set up Golang with cache
         uses: magnetikonline/action-golang-cache@v4
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
     - linux_arm_7
     - darwin_amd64_v1
     - darwin_arm64
-    - windows_amd64_v1
+    # - windows_amd64_v1
   overrides:
     - goos: darwin
       goarch: amd64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
     - linux_arm_7
     - darwin_amd64_v1
     - darwin_arm64
-    # - windows_amd64_v1
+    - windows_amd64_v1
   overrides:
     - goos: darwin
       goarch: amd64

--- a/Makefile
+++ b/Makefile
@@ -69,28 +69,28 @@ diff: ## git diff
 build: ## Use goreleaser-cross (due to macOS CGo requirement) to run goreleaser --snapshot --skip=publish --clean
 build: install
 	$(call print-target)
-	goreleaser --snapshot --skip=publish --clean
-	# docker run \
-	# 	--rm \
-	# 	-v /var/run/docker.sock:/var/run/docker.sock \
-	# 	-v `pwd`:/go/src/$(PACKAGE_NAME) \
-	# 	-w /go/src/$(PACKAGE_NAME) \
-	# 	ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-	# 	--snapshot --skip=publish --clean
+	# goreleaser --snapshot --skip=publish --clean
+	docker run \
+		--rm \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/$(PACKAGE_NAME) \
+		-w /go/src/$(PACKAGE_NAME) \
+		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
+		--snapshot --skip=publish --clean
 
 .PHONY: release
 release: ## Use goreleaser-cross (due to macOS CGo requirement) to run goreleaser --clean
 release: install
 	$(call print-target)
-	goreleaser --clean
-	# docker run \
-	# 	--rm \
-	# 	-e GITHUB_TOKEN=${GITHUB_TOKEN} \
-	# 	-v /var/run/docker.sock:/var/run/docker.sock \
-	# 	-v `pwd`:/go/src/$(PACKAGE_NAME) \
-	# 	-w /go/src/$(PACKAGE_NAME) \
-	# 	ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-	# 	--clean
+	# goreleaser --clean
+	docker run \
+		--rm \
+		-e GITHUB_TOKEN=${GITHUB_TOKEN} \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/$(PACKAGE_NAME) \
+		-w /go/src/$(PACKAGE_NAME) \
+		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
+		--clean
 
 .PHONY: run
 run: ## go run

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKAGE_NAME := github.com/PlanktoScope/forklift
-GOLANG_CROSS_VERSION ?= v1.21.0
+GOLANG_CROSS_VERSION ?= v1.22.0
 
 .DEFAULT_GOAL := dev
 
@@ -76,7 +76,7 @@ build: install
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		--snapshot --skip=publish --clean
+		release --snapshot --skip publish --clean
 
 .PHONY: release
 release: ## Use goreleaser-cross (due to macOS CGo requirement) to run goreleaser --clean
@@ -90,7 +90,7 @@ release: install
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		--clean
+		release --clean
 
 .PHONY: run
 run: ## go run


### PR DESCRIPTION
This PR follows up on the work started by [08dc467](https://github.com/PlanktoScope/forklift/commit/08dc4671304a181c0e85505516b2cea7ff262749) to bring back builds of binaries targeting macOS and Windows for releases.