### PR TITLE
Add `--no-cache-img` flag, fix issues with `--parallel` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 0.7.0-alpha.1 - 2024-04-13
+## 0.7.0-alpha.2 - 2024-04-13
+
+### Added
+
+- (cli) Added a `--no-cache-img` flag to all `plt switch`, `[dev] plt stage`, and `stage set-next` to enable non-root execution in setup scripts where the Docker socket can only be accessed with root permissions.
+
+### Fixed
+
+- (cli) Added missing a `--parallel` flag to `plt stage`.
+- (cli) Fixed incorrect usage descriptions for the `--parallel` flag for `[dev] plt plan`, `[dev] plt apply`, and `stage plan`.
 
 ### Added
 

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -56,7 +56,7 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "parallel",
-					Usage: "parallelize downloading of images",
+					Usage: "construct a plan for parallel updating of deployments",
 				},
 			},
 		},
@@ -67,8 +67,12 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 			Action:   stageAction(versions),
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
+					Name:  "no-cache-img",
+					Usage: "don't download container images",
+				},
+				&cli.BoolFlag{
 					Name:  "parallel",
-					Usage: "parallelize downloading of images",
+					Usage: "parallelize downloading of container images",
 				},
 			},
 		},
@@ -81,7 +85,7 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "parallel",
-					Usage: "parallelize downloading of images",
+					Usage: "parallelize updating of package deployments",
 				},
 			},
 		},
@@ -103,7 +107,7 @@ func makeUseCacheSubcmds(versions Versions) []*cli.Command {
 				},
 				&cli.BoolFlag{
 					Name:  "parallel",
-					Usage: "parallelize downloading of images",
+					Usage: "parallelize downloading of container images",
 				},
 			},
 		},
@@ -127,7 +131,7 @@ func makeUseCacheSubcmds(versions Versions) []*cli.Command {
 				},
 				&cli.BoolFlag{
 					Name:  "parallel",
-					Usage: "parallelize downloading of images",
+					Usage: "parallelize downloading of container images",
 				},
 			},
 		},

--- a/cmd/forklift/dev/plt/pallets.go
+++ b/cmd/forklift/dev/plt/pallets.go
@@ -221,7 +221,7 @@ func stageAction(versions Versions) cli.ActionFunc {
 		if _, err = fcli.StagePallet(
 			pallet, stageStore, cache, c.String("exports"),
 			versions.Tool, versions.MinSupportedBundle, versions.NewBundle,
-			c.Bool("parallel"), c.Bool("ignore-tool-version"),
+			c.Bool("no-cache-img"), c.Bool("parallel"), c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}
@@ -258,7 +258,7 @@ func applyAction(versions Versions) cli.ActionFunc {
 		index, err := fcli.StagePallet(
 			pallet, stageStore, repoCache, c.String("exports"),
 			versions.Tool, versions.MinSupportedBundle, versions.NewBundle,
-			c.Bool("parallel"), c.Bool("ignore-tool-version"),
+			false, c.Bool("parallel"), c.Bool("ignore-tool-version"),
 		)
 		if err != nil {
 			return errors.Wrap(err, "couldn't stage pallet to be applied immediately")

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -30,8 +30,12 @@ func MakeCmd(versions Versions) *cli.Command {
 					Action:    switchAction(versions),
 					Flags: []cli.Flag{
 						&cli.BoolFlag{
+							Name:  "no-cache-img",
+							Usage: "don't download container images (this flag is ignored if --apply is set)",
+						},
+						&cli.BoolFlag{
 							Name:  "parallel",
-							Usage: "parallelize updating of deployments",
+							Usage: "parallelize updating of package deployments",
 						},
 						&cli.BoolFlag{
 							Name:  "apply",
@@ -66,7 +70,7 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "parallel",
-					Usage: "parallelize downloading of images",
+					Usage: "construct a plan for parallel updating of deployments",
 				},
 			},
 		},
@@ -75,6 +79,16 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 			Category: category,
 			Usage:    "Builds and stages a bundle of the local pallet to be applied later",
 			Action:   stageAction(versions),
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "no-cache-img",
+					Usage: "don't download container images",
+				},
+				&cli.BoolFlag{
+					Name:  "parallel",
+					Usage: "parallelize downloading of container images",
+				},
+			},
 		},
 		&cli.Command{
 			Name:     "apply",
@@ -85,7 +99,7 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "parallel",
-					Usage: "parallelize updating of deployments",
+					Usage: "parallelize updating of package deployments",
 				},
 			},
 		},
@@ -107,7 +121,7 @@ func makeUseCacheSubcmds(versions Versions) []*cli.Command {
 				},
 				&cli.BoolFlag{
 					Name:  "parallel",
-					Usage: "parallelize downloading of images",
+					Usage: "parallelize downloading of container images",
 				},
 			},
 		},
@@ -131,7 +145,7 @@ func makeUseCacheSubcmds(versions Versions) []*cli.Command {
 				},
 				&cli.BoolFlag{
 					Name:  "parallel",
-					Usage: "parallelize downloading of images",
+					Usage: "parallelize downloading of container images",
 				},
 			},
 		},

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -91,7 +91,7 @@ func switchAction(versions Versions) cli.ActionFunc {
 		index, err := fcli.StagePallet(
 			pallet, stageStore, repoCache, c.String("exports"),
 			versions.Tool, versions.MinSupportedBundle, versions.NewBundle,
-			c.Bool("parallel"), c.Bool("ignore-tool-version"),
+			c.Bool("no-cache-img") || c.Bool("apply"), c.Bool("parallel"), c.Bool("ignore-tool-version"),
 		)
 		if err != nil {
 			return err
@@ -339,7 +339,7 @@ func stageAction(versions Versions) cli.ActionFunc {
 		if _, err = fcli.StagePallet(
 			pallet, stageStore, cache, c.String("exports"),
 			versions.Tool, versions.MinSupportedBundle, versions.NewBundle,
-			c.Bool("parallel"), c.Bool("ignore-tool-version"),
+			c.Bool("no-cache-img"), c.Bool("parallel"), c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}
@@ -376,7 +376,7 @@ func applyAction(versions Versions) cli.ActionFunc {
 		index, err := fcli.StagePallet(
 			pallet, stageStore, repoCache, c.String("exports"),
 			versions.Tool, versions.MinSupportedBundle, versions.NewBundle,
-			c.Bool("parallel"), c.Bool("ignore-tool-version"),
+			false, c.Bool("parallel"), c.Bool("ignore-tool-version"),
 		)
 		if err != nil {
 			return errors.Wrap(err, "couldn't stage pallet to be applied immediately")

--- a/cmd/forklift/stage/cli.go
+++ b/cmd/forklift/stage/cli.go
@@ -37,7 +37,7 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "parallel",
-					Usage: "parallelize downloading of images",
+					Usage: "parallelize downloading of container images",
 				},
 			},
 		},
@@ -55,7 +55,7 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "parallel",
-					Usage: "parallelize downloading of images",
+					Usage: "construct a plan for parallel updating of deployments",
 				},
 			},
 		},
@@ -154,15 +154,20 @@ func makeModifySubcmds(versions Versions) []*cli.Command {
 	category := "Modify the stage store"
 	return []*cli.Command{
 		{
-			Name:      "set-next",
-			Category:  category,
-			Usage:     "Sets the specified staged pallet bundle as the next one to be applied.",
+			Name:     "set-next",
+			Category: category,
+			Usage: "Sets the specified staged pallet bundle as the next one to be applied, then " +
+				"caches required images",
 			ArgsUsage: "bundle_index_or_name",
 			Action:    setNextAction(versions),
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
+					Name:  "no-cache-img",
+					Usage: "don't download container images",
+				},
+				&cli.BoolFlag{
 					Name:  "parallel",
-					Usage: "parallelize downloading of images",
+					Usage: "parallelize downloading of container images",
 				},
 			},
 		},

--- a/cmd/forklift/stage/store.go
+++ b/cmd/forklift/stage/store.go
@@ -257,8 +257,8 @@ func setNextAction(versions Versions) cli.ActionFunc {
 		}
 
 		if err = fcli.SetNextStagedBundle(
-			store, newNext, c.String("exports"),
-			versions.Tool, versions.MinSupportedBundle, c.Bool("parallel"), c.Bool("ignore-tool-version"),
+			store, newNext, c.String("exports"), versions.Tool, versions.MinSupportedBundle,
+			c.Bool("no-cache-img"), c.Bool("parallel"), c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}

--- a/internal/app/forklift/cli/pallets.go
+++ b/internal/app/forklift/cli/pallets.go
@@ -883,7 +883,7 @@ func compareDeplNames(r, s string) int {
 func StagePallet(
 	pallet *forklift.FSPallet, stageStore *forklift.FSStageStore, repoCache forklift.PathedRepoCache,
 	exportPath, toolVersion, bundleMinVersion, newBundleForkliftVersion string,
-	parallel, ignoreToolVersion bool,
+	skipImageCaching, parallel, ignoreToolVersion bool,
 ) (index int, err error) {
 	index, err = stageStore.AllocateNew()
 	if err != nil {
@@ -897,7 +897,8 @@ func StagePallet(
 		return index, errors.Wrapf(err, "couldn't bundle pallet %s as stage %d", pallet.Path(), index)
 	}
 	if err = SetNextStagedBundle(
-		stageStore, index, exportPath, toolVersion, bundleMinVersion, parallel, ignoreToolVersion,
+		stageStore, index, exportPath, toolVersion, bundleMinVersion,
+		skipImageCaching, parallel, ignoreToolVersion,
 	); err != nil {
 		return index, errors.Wrapf(
 			err, "couldn't prepare staged pallet bundle %d to be applied next", index,

--- a/internal/app/forklift/cli/store.go
+++ b/internal/app/forklift/cli/store.go
@@ -26,7 +26,7 @@ func GetStageStore(
 
 func SetNextStagedBundle(
 	store *forklift.FSStageStore, index int, exportPath, toolVersion, bundleMinVersion string,
-	parallel, ignoreToolVersion bool,
+	skipImageCaching, parallel, ignoreToolVersion bool,
 ) error {
 	store.SetNext(index)
 	fmt.Printf(
@@ -34,6 +34,10 @@ func SetNextStagedBundle(
 	)
 	if err := store.CommitState(); err != nil {
 		return errors.Wrap(err, "couldn't commit updated stage store state")
+	}
+
+	if skipImageCaching {
+		return nil
 	}
 
 	if err := DownloadImagesForStoreApply(


### PR DESCRIPTION
This PR follows up on #178 by:
- Fixing a regression introduced by that PR (which made `[dev] plt stage` require root privileges in the PlanktoScope OS setup scripts by adding image-caching functionality to that subcommand)
- Fixing incorrect usage instructions for the `--parallel` flag in various places
- Adding a missing `--parallel` flag to `stage cache-img`