### PR TITLE
Make `stage` subcmds correctly handle undefined workspace path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.7.0-alpha.3 - 2024-04-13
+
+### Fixed
+
+- (cli) Subcommands under `stage` no longer require the workspace to be set via `--workspace` or `FORKLIFT_WORKSPACE` (which defaults to `$HOME`, which may be unset in systemd system services) if the path to the stage store is explicitly set via `--stage-store` or `FORKLIFT_STAGE_STORE`.
+
 ## 0.7.0-alpha.2 - 2024-04-13
 
 ### Added

--- a/cmd/forklift/stage/store.go
+++ b/cmd/forklift/stage/store.go
@@ -65,13 +65,20 @@ func loadNextBundle(
 	return bundle, store, nil
 }
 
-func getStageStore(wpath, sspath string, versions Versions) (*forklift.FSStageStore, error) {
-	workspace, err := forklift.LoadWorkspace(wpath)
-	if err != nil {
-		return nil, err
+func getStageStore(
+	wpath, sspath string, versions Versions,
+) (store *forklift.FSStageStore, err error) {
+	var workspace *forklift.FSWorkspace
+	if sspath == "" {
+		workspace, err = forklift.LoadWorkspace(wpath)
+		if err != nil {
+			return nil, errors.Wrap(
+				err, "couldn't load workspace to load the stage store, since no explicit path was "+
+					"provided for the stage store",
+			)
+		}
 	}
-	store, err := fcli.GetStageStore(workspace, sspath, versions.NewStageStore)
-	if err != nil {
+	if store, err = fcli.GetStageStore(workspace, sspath, versions.NewStageStore); err != nil {
 		return nil, err
 	}
 	return store, nil


### PR DESCRIPTION
This PR follows up on #179 to fix an issue where `stage` subcommands would error out if the workspace (via `--workspace` or `FORKLIFT_WORKSPACE`) was an empty path, even if the path of the stage store was explicitly set (via `--stage-store` or `FORKLIFT_STAGE_STORE`). Now this situation is correctly handled so that the empty workspace path is ignored when the stage store path is non-empty.