### PR TITLE
Make various UX improvements to the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (cli) Added a `plt add-repo` subcommand which is just like `dev plt add-repo` (including its new `require-repo` and `require-repositories` aliases).
 - (cli) By default, now the `[dev] plt add-repo` subcommand will also cache all repos required by the pallet after adding/updating a repo requirement (or multiple repo requirements). This added behavior can be disabled with a new `--no-cache-req` flag.
 - (cli) By default, now the `plt clone` and `plt pull` subcommands will also cache all required repos after cloning/pulling the pallet. This added behavior can be disabled with a new `--no-cache-req` flag.
+- (cli) Added a `stage unset-next` subcommand which will update the stage store so that no staged pallet bundle will be applied next.
+- (cli) Now the `stage set-next` subcommand will accept an index of 0, which will update the stage store so that no staged pallet bundle will be applied next.
+- (cli) Added a `stage set-next-result` subcommand which can be used on non-Docker systems (where `forklift stage apply` doesn't work) to record whether the next staged pallet bundle to be applied has been successfully applied or has failed to be applied (or to reset its state from "failed" to "pending", representing that we don't know whether it has been applied successfully or unsuccessfully). This is intended to be used by systems which need to use the files exported by the next staged pallet bundle but might encounter unrecoverable errors.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- (Breaking change; cli) The `--parallel` flag for various subcommands has now been consolidated and moved to the top level (e.g. `forklift --parallel plt cache-img` instead of `forklift plt cache-img --parallel`). Additionally, now the flag is enabled by default (because sequential downloading of images and bringup of Docker containers is so much slower than parallel downloading/bringup); to avoid parallel execution, use `--parallel=false` (e.g. `forklift --parallel=false plt cache-img`).
+
 ## 0.7.0-alpha.3 - 2024-04-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - (cli) The `dev plt add-repo` subcommand now has additional aliases with clearer names: `require-repo` and `require-repositories`.
 - (cli) Added a `plt add-repo` subcommand which is just like `dev plt add-repo` (including its new `require-repo` and `require-repositories` aliases).
+- (cli) By default, now the `plt clone` subcommand will also cache all required repos after cloning the pallet. This added behavior can be disabled with a new `--no-cache-req` flag.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - (cli) The `dev plt add-repo` subcommand now has additional aliases with clearer names: `require-repo` and `require-repositories`.
 - (cli) Added a `plt add-repo` subcommand which is just like `dev plt add-repo` (including its new `require-repo` and `require-repositories` aliases).
-- (cli) By default, now the `plt clone` subcommand will also cache all required repos after cloning the pallet. This added behavior can be disabled with a new `--no-cache-req` flag.
+- (cli) By default, now the `[dev] plt add-repo` subcommand will also cache all repos required by the pallet after adding/updating a repo requirement (or multiple repo requirements). This added behavior can be disabled with a new `--no-cache-req` flag.
+- (cli) By default, now the `plt clone` and `plt pull` subcommands will also cache all required repos after cloning/pulling the pallet. This added behavior can be disabled with a new `--no-cache-req` flag.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- (cli) The `dev plt add-repo` subcommand now has additional aliases with clearer names: `require-repo` and `require-repositories`.
+- (cli) Added a `plt add-repo` subcommand which is just like `dev plt add-repo` (including its new `require-repo` and `require-repositories` aliases).
+
 ### Changed
 
 - (Breaking change; cli) The `--parallel` flag for various subcommands has now been consolidated and moved to the top level (e.g. `forklift --parallel plt cache-img` instead of `forklift plt cache-img --parallel`). Additionally, now the flag is enabled by default (because sequential downloading of images and bringup of Docker containers is so much slower than parallel downloading/bringup); to avoid parallel execution, use `--parallel=false` (e.g. `forklift --parallel=false plt cache-img`).
+- (Breaking change; cli) `plt clone` no longer deletes the `.git` directory after cloning a pallet, because the new pallet staging functionality makes it feasible to keep a long-running local pallet which can change independently of what is actually applied on a computer.
 
 ## 0.7.0-alpha.3 - 2024-04-13
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If you aren't running Docker in rootless mode and your user isn't in a `docker` 
 
   ```
   # Run now:
-  forklift pallet switch github.com/ethanjli/pallet-example-minimal@main
+  forklift pallet switch --no-cache-img github.com/ethanjli/pallet-example-minimal@main
   sudo -E forklift stage cache-img
   # Run when you want to apply the pallet:
   sudo -E forklift stage apply
@@ -126,21 +126,21 @@ cd /home/pi/
 
 The following projects solve related problems with containers for application software, though they make different trade-offs compared to Forklift:
 
-- poco enables Git-based management of Docker Compose projects and collections (*catalogs*) of projects and repositories and provides some similar functionalities to forklift: <https://github.com/shiwaforce/poco>
-- Terraform (an inspiration for this project) has a Docker Provider which enables declarative management of Docker hosts and Docker Swarms from a Terraform configuration: <https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs>
-- swarm-pack (an inspiration for this project) uses collections of packages from user-specified Git repositories and enables templated configuration of Docker Compose files, with imperative deployments of packages to a Docker Swarm: <https://github.com/swarm-pack/swarm-pack>
-- SwarmManagement uses a single YAML file for declarative configuration of an entire Docker Swarm: <https://github.com/hansehe/SwarmManagement>
-- Podman Quadlets enable management of containers, volumes, and networks using declarative systemd units: <https://github.com/containers/podlet> & <https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html>
-- FetchIt enables Git-based management of containers in Podman: <https://github.com/containers/fetchit>
-- Projects developing GitOps tools such as ArgoCD, Flux, etc., store container environment configurations as Git repositories but are generally designed for Kubernetes: <https://www.gitops.tech/>
+- [poco](https://github.com/shiwaforce/poco) enables Git-based management of Docker Compose projects and collections (*catalogs*) of projects and repositories and provides some similar functionalities to forklift
+- [Terraform](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs) (an early inspiration for this project) has a Docker Provider which enables declarative management of Docker hosts and Docker Swarms from a Terraform configuration
+- [swarm-pack](https://github.com/swarm-pack/swarm-pack) (an early inspiration for this project) uses collections of packages from user-specified Git repositories and enables templated configuration of Docker Compose files, with imperative deployments of packages to a Docker Swarm
+- [SwarmManagement](https://github.com/hansehe/SwarmManagement) uses a single YAML file for declarative configuration of an entire Docker Swarm
+- Podman [Quadlets](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html) enable management of containers, volumes, and networks using declarative systemd units
+- [FetchIt](https://github.com/containers/fetchit) enables Git-based management of containers in Podman
+- Projects developing [GitOps](https://www.gitops.tech/) tools such as ArgoCD, Flux, etc., store container environment configurations as Git repositories but are generally designed for Kubernetes
 
 The following projects solve related problems in the base OS, though they make different trade-offs compared to Forklift (especially because of the PlanktoScope project's legacy software):
 
-- systemd-sysext and systemd-confext provide a more structured/constrained way (compared to Forklift) to atomically overlay system files onto the base OS; however, Forklift can also be used as a way to deploy sysexts/confexts onto an OS (see [this demo](https://github.com/ethanjli/ublue-forklift-sysext-demo?tab=readme-ov-file#explanation)): <https://www.freedesktop.org/software/systemd/man/latest/systemd-sysext.html>
-- systemd's Portable Services pattern and `portablectl` tool provide a more structured/constrained/sandboxed way (compared to Forklift) to atomically add system services: <https://systemd.io/PORTABLE_SERVICES/>
-- ostree enables atomic updates of the base OS, but [it is not supported by Raspberry Pi OS](https://github.com/ostreedev/ostree/issues/2223): <https://ostreedev.github.io/ostree/>
-- The bootc project enables the entire operating system to be delivered as a bootable OCI container image, but currently it relies on bootupd, which [currently only works on RPM-based distros](https://github.com/coreos/bootupd/issues/468): <https://containers.github.io/bootc/>
-- gokrazy enables atomic deployment of Go programs (and also of software containers!), but it has a very different architecture compared to traditional Linux distros: <https://gokrazy.org/>
+- [systemd-sysext and systemd-confext](https://www.freedesktop.org/software/systemd/man/latest/systemd-sysext.html) provide a more structured/constrained way (compared to Forklift) to atomically overlay system files onto the base OS; however, Forklift can also be used as a way to deploy sysexts/confexts onto an OS (see [this demo](https://github.com/ethanjli/ublue-forklift-sysext-demo?tab=readme-ov-file#explanation))
+- systemd's [Portable Services](https://systemd.io/PORTABLE_SERVICES/) pattern and `portablectl` tool provide a more structured/constrained/sandboxed way (compared to Forklift) to atomically add system services
+- [ostree](https://ostreedev.github.io/ostree/) enables atomic updates of the base OS, but [it is not supported by Raspberry Pi OS](https://github.com/ostreedev/ostree/issues/2223)
+- The [bootc](https://containers.github.io/bootc/) project enables the entire operating system to be delivered as a bootable OCI container image, but currently it relies on bootupd, which [currently only works on RPM-based distros](https://github.com/coreos/bootupd/issues/468)
+- [gokrazy](https://gokrazy.org/) enables atomic deployment of Go programs (and also of software containers!), but it has a very different architecture compared to traditional Linux distros
 
 Other related OS-level projects can be found at [github.com/castrojo/awesome-immutable](https://github.com/castrojo/awesome-immutable).
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ cd /etc/
 /home/pi/forklift dev --cwd /home/pi/dev/pallet-example-minimal plt show
 ```
 
-You can also use the `forklift dev plt add-repo` command to add additional Forklift repositories to your development pallet, and/or to change the versions of Forklift repositories already added to your development pallet.
+You can also use the `forklift dev plt require-repo` command to require additional Forklift repositories for use in your development pallet, and/or to change the versions of Forklift repositories already required by your development pallet.
 
 You can also run commands like `forklift dev plt cache-all` and `forklift dev plt stage --no-cache-img` (with appropriate values in the `--cwd` flag if necessary) to download the Forklift repositories specified by your development pallet into your local cache and stage your development pallet to be applied with `sudo -E forklift stage apply`. This is useful if, for example, you want to make some experimental changes to your development pallet and test them on your local machine before committing and pushing those changes onto GitHub.
 

--- a/cmd/forklift/cache/git-repositories.go
+++ b/cmd/forklift/cache/git-repositories.go
@@ -94,7 +94,7 @@ func rmGitRepoAction[Cache remover](
 			return err
 		}
 
-		fmt.Printf("Clearing %s cache...", gitRepoType)
+		fmt.Printf("Clearing %s cache...\n", gitRepoType)
 		if err = cache.Remove(); err != nil {
 			return errors.Wrapf(err, "couldn't clear %s cache", gitRepoType)
 		}

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -197,15 +197,19 @@ func makeModifySubcmds(versions Versions) []*cli.Command {
 	const category = "Modify the pallet"
 	return []*cli.Command{
 		{
-			Name:      "add-repo",
-			Aliases:   []string{"add-repositories"},
-			Category:  category,
-			Usage:     "Adds repos to the pallet, tracking specified versions or branches",
+			Name:     "add-repo",
+			Aliases:  []string{"add-repositories", "require-repo", "require-repositories"},
+			Category: category,
+			Usage: "Adds (or re-adds) repo requirements to the pallet, tracking specified versions " +
+				"or branches",
 			ArgsUsage: "[repo_path@version_query]...",
 			Action:    addRepoAction(versions),
 		},
-		// TODO: add an rm-repo action
-		// TODO: add an add-depl action
+		// TODO: add an rm-repo action with alias "drop-repo"; it should ensure no depls depend on it
+		// or delete those depls if `--force` is set
+		// TODO: add an add-depl --features=... depl_path package_path action
 		// TODO: add an rm-depl action
+		// TODO: add an add-depl-feat depl_path [feature]... action
+		// TODO: add an rm-depl-feat depl_path [feature]... action
 	}
 }

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -62,7 +62,7 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "no-cache-img",
-					Usage: "don't download container images",
+					Usage: "Don't download container images",
 				},
 			},
 		},
@@ -87,7 +87,7 @@ func makeUseCacheSubcmds(versions Versions) []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "include-disabled",
-					Usage: "also cache things needed for disabled package deployments",
+					Usage: "Also cache things needed for disabled package deployments",
 				},
 			},
 		},
@@ -107,7 +107,7 @@ func makeUseCacheSubcmds(versions Versions) []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "include-disabled",
-					Usage: "also download images for disabled package deployments",
+					Usage: "Also download images for disabled package deployments",
 				},
 			},
 		},
@@ -186,7 +186,7 @@ func makeQueryDeplSubcmds(category string) []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "allow-disabled",
-					Usage: "locates the package even if the specified deployment is disabled",
+					Usage: "Locates the package even if the specified deployment is disabled",
 				},
 			},
 		},

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -203,7 +203,14 @@ func makeModifySubcmds(versions Versions) []*cli.Command {
 			Usage: "Adds (or re-adds) repo requirements to the pallet, tracking specified versions " +
 				"or branches",
 			ArgsUsage: "[repo_path@version_query]...",
-			Action:    addRepoAction(versions),
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name: "no-cache-req",
+					Usage: "Don't download repositories and pallets required by this pallet after adding " +
+						"the repo",
+				},
+			},
+			Action: addRepoAction(versions),
 		},
 		// TODO: add an rm-repo action with alias "drop-repo"; it should ensure no depls depend on it
 		// or delete those depls if `--force` is set

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -53,12 +53,6 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 			Usage: "Determines the changes needed to update the host to match the deployments " +
 				"specified by the local pallet",
 			Action: planAction(versions),
-			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name:  "parallel",
-					Usage: "construct a plan for parallel updating of deployments",
-				},
-			},
 		},
 		&cli.Command{
 			Name:     "stage",
@@ -70,10 +64,6 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 					Name:  "no-cache-img",
 					Usage: "don't download container images",
 				},
-				&cli.BoolFlag{
-					Name:  "parallel",
-					Usage: "parallelize downloading of container images",
-				},
 			},
 		},
 		&cli.Command{
@@ -82,12 +72,6 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 			Usage: "Builds, stages, and immediately applies a bundle of the development pallet to " +
 				"update the host to match the deployments specified by the development pallet",
 			Action: applyAction(versions),
-			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name:  "parallel",
-					Usage: "parallelize updating of package deployments",
-				},
-			},
 		},
 	)
 }
@@ -104,10 +88,6 @@ func makeUseCacheSubcmds(versions Versions) []*cli.Command {
 				&cli.BoolFlag{
 					Name:  "include-disabled",
 					Usage: "also cache things needed for disabled package deployments",
-				},
-				&cli.BoolFlag{
-					Name:  "parallel",
-					Usage: "parallelize downloading of container images",
 				},
 			},
 		},
@@ -128,10 +108,6 @@ func makeUseCacheSubcmds(versions Versions) []*cli.Command {
 				&cli.BoolFlag{
 					Name:  "include-disabled",
 					Usage: "also download images for disabled package deployments",
-				},
-				&cli.BoolFlag{
-					Name:  "parallel",
-					Usage: "parallelize downloading of container images",
 				},
 			},
 		},

--- a/cmd/forklift/dev/plt/images.go
+++ b/cmd/forklift/dev/plt/images.go
@@ -30,7 +30,7 @@ func cacheImgAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 		fmt.Println()
-		fmt.Println("Done! Next, you'll probably want to run `sudo -E forklift dev plt apply`.")
+		fmt.Println("Done!")
 		return nil
 	}
 }

--- a/cmd/forklift/dev/plt/pallets.go
+++ b/cmd/forklift/dev/plt/pallets.go
@@ -134,7 +134,7 @@ func cacheAllAction(versions Versions) cli.ActionFunc {
 			fmt.Println("Done! No further actions are needed at this time.")
 			return nil
 		}
-		fmt.Println("Done! Next, you might want to run `forklift dev plt stage`.")
+		fmt.Println("Done!")
 		return nil
 	}
 }
@@ -225,7 +225,10 @@ func stageAction(versions Versions) cli.ActionFunc {
 		); err != nil {
 			return err
 		}
-		fmt.Println("Done! To apply the staged pallet immediately, run `sudo -E forklift stage apply`.")
+		fmt.Println(
+      "Done! To apply the staged pallet, you may need to reboot or run " +
+      "`forklift stage apply` (or `sudo -E forklift stage apply` if you need sudo for Docker).",
+    )
 		return nil
 	}
 }

--- a/cmd/forklift/dev/plt/pallets.go
+++ b/cmd/forklift/dev/plt/pallets.go
@@ -226,9 +226,9 @@ func stageAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 		fmt.Println(
-      "Done! To apply the staged pallet, you may need to reboot or run " +
-      "`forklift stage apply` (or `sudo -E forklift stage apply` if you need sudo for Docker).",
-    )
+			"Done! To apply the staged pallet, you may need to reboot or run " +
+				"`forklift stage apply` (or `sudo -E forklift stage apply` if you need sudo for Docker).",
+		)
 		return nil
 	}
 }

--- a/cmd/forklift/dev/plt/repositories.go
+++ b/cmd/forklift/dev/plt/repositories.go
@@ -35,7 +35,7 @@ func cacheRepoAction(versions Versions) cli.ActionFunc {
 
 		// TODO: warn if any downloaded repo doesn't appear to be an actual repo, or if any repo's
 		// forklift version is incompatible or ahead of the pallet version
-		fmt.Println("Done! Next, you might want to run `sudo -E forklift dev plt apply`.")
+		fmt.Println("Done!")
 		return nil
 	}
 }
@@ -65,21 +65,27 @@ func showRepoAction(c *cli.Context) error {
 
 func addRepoAction(versions Versions) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		pallet, cache, err := processFullBaseArgs(c, false, false)
+		pallet, repoCache, err := processFullBaseArgs(c, false, false)
 		if err != nil {
 			return err
 		}
 		if err = fcli.CheckShallowCompatibility(
-			pallet, cache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}
 
 		if err = fcli.AddRepoRequirements(
-			0, pallet, cache.Underlay.Path(), c.Args().Slice(),
+			0, pallet, repoCache.Underlay.Path(), c.Args().Slice(),
 		); err != nil {
 			return err
+		}
+
+		if !c.Bool("no-cache-req") {
+			if _, err = fcli.CacheStagingRequirements(pallet, repoCache.Path()); err != nil {
+				return err
+			}
 		}
 		fmt.Println("Done!")
 		return nil

--- a/cmd/forklift/main.go
+++ b/cmd/forklift/main.go
@@ -73,6 +73,13 @@ var app = &cli.App{
 			Usage:   "Ignore the version of the forklift tool in version compatibility checks",
 			EnvVars: []string{"FORKLIFT_IGNORE_TOOL_VERSION"},
 		},
+		&cli.BoolFlag{
+			Name:  "parallel",
+			Value: true,
+			Usage: "Allow parallel execution of I/O-bound tasks, such as downloading container images " +
+				"or starting containers",
+			EnvVars: []string{"FORKLIFT_PARALLEL"},
+		},
 	},
 	Suggest: true,
 }

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -42,7 +42,7 @@ func MakeCmd(versions Versions) *cli.Command {
 			},
 			makeUseSubcmds(versions),
 			makeQuerySubcmds(),
-			makeModifySubcmds(),
+			makeModifySubcmds(versions),
 		),
 	}
 }
@@ -203,7 +203,36 @@ func makeQueryDeplSubcmds(category string) []*cli.Command {
 	}
 }
 
-func makeModifySubcmds() []*cli.Command {
+func makeModifySubcmds(versions Versions) []*cli.Command {
+	const category = "Modify the pallet"
+	return append(
+		makeModifyGitSubcmds(),
+		&cli.Command{
+			Name:     "rm",
+			Aliases:  []string{"remove"},
+			Category: category,
+			Usage:    "Removes the local pallet",
+			Action:   rmAction,
+		},
+		&cli.Command{
+			Name:     "add-repo",
+			Aliases:  []string{"add-repositories", "require-repo", "require-repositories"},
+			Category: category,
+			Usage: "Adds (or re-adds) repo requirements to the pallet, tracking specified versions " +
+				"or branches",
+			ArgsUsage: "[repo_path@version_query]...",
+			Action:    addRepoAction(versions),
+		},
+	// TODO: add an rm-repo action with alias "drop-repo"; it should ensure no depls depend on it
+	// or delete those depls if `--force` is set
+	// TODO: add an add-depl --features=... depl_path package_path action
+	// TODO: add an rm-depl action
+	// TODO: add an add-depl-feat depl_path [feature]... action
+	// TODO: add an rm-depl-feat depl_path [feature]... action
+	)
+}
+
+func makeModifyGitSubcmds() []*cli.Command {
 	const category = "Modify the pallet"
 	return []*cli.Command{
 		{
@@ -219,6 +248,7 @@ func makeModifySubcmds() []*cli.Command {
 			},
 			Action: cloneAction,
 		},
+		// TODO: add a "checkout" action
 		{
 			Name:     "fetch",
 			Category: category,
@@ -240,18 +270,7 @@ func makeModifySubcmds() []*cli.Command {
 		// 		return nil
 		// 	},
 		// },
-		{
-			Name:     "rm",
-			Aliases:  []string{"remove"},
-			Category: category,
-			Usage:    "Removes the local pallet",
-			Action:   rmAction,
-		},
 		// remoteCmd,
-		// TODO: add an add-repo action
-		// TODO: add an rm-repo action
-		// TODO: add an add-depl action
-		// TODO: add an rm-depl action
 	}
 }
 

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -34,10 +34,6 @@ func MakeCmd(versions Versions) *cli.Command {
 							Usage: "don't download container images (this flag is ignored if --apply is set)",
 						},
 						&cli.BoolFlag{
-							Name:  "parallel",
-							Usage: "parallelize updating of package deployments",
-						},
-						&cli.BoolFlag{
 							Name:  "apply",
 							Usage: "immediately apply the pallet after staging it",
 						},
@@ -67,12 +63,6 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 			Usage: "Determines the changes needed to update the host to match the deployments " +
 				"specified by the local pallet",
 			Action: planAction(versions),
-			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name:  "parallel",
-					Usage: "construct a plan for parallel updating of deployments",
-				},
-			},
 		},
 		&cli.Command{
 			Name:     "stage",
@@ -84,10 +74,6 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 					Name:  "no-cache-img",
 					Usage: "don't download container images",
 				},
-				&cli.BoolFlag{
-					Name:  "parallel",
-					Usage: "parallelize downloading of container images",
-				},
 			},
 		},
 		&cli.Command{
@@ -96,12 +82,6 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 			Usage: "Builds, stages, and immediately applies a bundle of the local pallet to update the " +
 				"host to match the deployments specified by the local pallet",
 			Action: applyAction(versions),
-			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name:  "parallel",
-					Usage: "parallelize updating of package deployments",
-				},
-			},
 		},
 	)
 }
@@ -118,10 +98,6 @@ func makeUseCacheSubcmds(versions Versions) []*cli.Command {
 				&cli.BoolFlag{
 					Name:  "include-disabled",
 					Usage: "also cache things needed for disabled package deployments",
-				},
-				&cli.BoolFlag{
-					Name:  "parallel",
-					Usage: "parallelize downloading of container images",
 				},
 			},
 		},
@@ -142,10 +118,6 @@ func makeUseCacheSubcmds(versions Versions) []*cli.Command {
 				&cli.BoolFlag{
 					Name:  "include-disabled",
 					Usage: "also download images for disabled package deployments",
-				},
-				&cli.BoolFlag{
-					Name:  "parallel",
-					Usage: "parallelize downloading of container images",
 				},
 			},
 		},

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -221,7 +221,14 @@ func makeModifySubcmds(versions Versions) []*cli.Command {
 			Usage: "Adds (or re-adds) repo requirements to the pallet, tracking specified versions " +
 				"or branches",
 			ArgsUsage: "[repo_path@version_query]...",
-			Action:    addRepoAction(versions),
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name: "no-cache-req",
+					Usage: "Don't download repositories and pallets required by this pallet after adding " +
+						"the repo",
+				},
+			},
+			Action: addRepoAction(versions),
 		},
 	// TODO: add an rm-repo action with alias "drop-repo"; it should ensure no depls depend on it
 	// or delete those depls if `--force` is set
@@ -263,7 +270,14 @@ func makeModifyGitSubcmds(versions Versions) []*cli.Command {
 			Name:     "pull",
 			Category: category,
 			Usage:    "Fast-forwards the local pallet to match the remote release",
-			Action:   pullAction,
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name: "no-cache-req",
+					Usage: "Don't download repositories and pallets required by this pallet after adding " +
+						"the repo",
+				},
+			},
+			Action: pullAction(versions),
 		},
 		// {
 		// 	Name:  "push",

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -31,11 +31,11 @@ func MakeCmd(versions Versions) *cli.Command {
 					Flags: []cli.Flag{
 						&cli.BoolFlag{
 							Name:  "no-cache-img",
-							Usage: "don't download container images (this flag is ignored if --apply is set)",
+							Usage: "Don't download container images (this flag is ignored if --apply is set)",
 						},
 						&cli.BoolFlag{
 							Name:  "apply",
-							Usage: "immediately apply the pallet after staging it",
+							Usage: "Immediately apply the pallet after staging it",
 						},
 					},
 				},
@@ -72,7 +72,7 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "no-cache-img",
-					Usage: "don't download container images",
+					Usage: "Don't download container images",
 				},
 			},
 		},
@@ -97,7 +97,7 @@ func makeUseCacheSubcmds(versions Versions) []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "include-disabled",
-					Usage: "also cache things needed for disabled package deployments",
+					Usage: "Also cache things needed for disabled package deployments",
 				},
 			},
 		},
@@ -117,7 +117,7 @@ func makeUseCacheSubcmds(versions Versions) []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "include-disabled",
-					Usage: "also download images for disabled package deployments",
+					Usage: "Also download images for disabled package deployments",
 				},
 			},
 		},
@@ -196,7 +196,7 @@ func makeQueryDeplSubcmds(category string) []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "allow-disabled",
-					Usage: "locates the package even if the specified deployment is disabled",
+					Usage: "Locates the package even if the specified deployment is disabled",
 				},
 			},
 		},
@@ -206,7 +206,7 @@ func makeQueryDeplSubcmds(category string) []*cli.Command {
 func makeModifySubcmds(versions Versions) []*cli.Command {
 	const category = "Modify the pallet"
 	return append(
-		makeModifyGitSubcmds(),
+		makeModifyGitSubcmds(versions),
 		&cli.Command{
 			Name:     "rm",
 			Aliases:  []string{"remove"},
@@ -232,7 +232,7 @@ func makeModifySubcmds(versions Versions) []*cli.Command {
 	)
 }
 
-func makeModifyGitSubcmds() []*cli.Command {
+func makeModifyGitSubcmds(versions Versions) []*cli.Command {
 	const category = "Modify the pallet"
 	return []*cli.Command{
 		{
@@ -245,8 +245,12 @@ func makeModifyGitSubcmds() []*cli.Command {
 					Name:  "force",
 					Usage: "Deletes the local pallet if it already exists",
 				},
+				&cli.BoolFlag{
+					Name:  "no-cache-req",
+					Usage: "Don't download repositories and pallets required by this pallet",
+				},
 			},
-			Action: cloneAction,
+			Action: cloneAction(versions),
 		},
 		// TODO: add a "checkout" action
 		{

--- a/cmd/forklift/plt/deployments.go
+++ b/cmd/forklift/plt/deployments.go
@@ -9,7 +9,7 @@ import (
 // ls-depl
 
 func lsDeplAction(c *cli.Context) error {
-	pallet, cache, err := processFullBaseArgs(c, true)
+	pallet, cache, err := processFullBaseArgs(c.String("workspace"), true)
 	if err != nil {
 		return err
 	}
@@ -20,7 +20,7 @@ func lsDeplAction(c *cli.Context) error {
 // show-depl
 
 func showDeplAction(c *cli.Context) error {
-	pallet, cache, err := processFullBaseArgs(c, true)
+	pallet, cache, err := processFullBaseArgs(c.String("workspace"), true)
 	if err != nil {
 		return err
 	}
@@ -32,7 +32,7 @@ func showDeplAction(c *cli.Context) error {
 // locate-depl-pkg
 
 func locateDeplPkgAction(c *cli.Context) error {
-	pallet, cache, err := processFullBaseArgs(c, true)
+	pallet, cache, err := processFullBaseArgs(c.String("workspace"), true)
 	if err != nil {
 		return err
 	}

--- a/cmd/forklift/plt/images.go
+++ b/cmd/forklift/plt/images.go
@@ -30,7 +30,7 @@ func cacheImgAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 		fmt.Println()
-		fmt.Println("Done! Next, you'll probably want to run `sudo -E forklift plt apply`.")
+		fmt.Println("Done!")
 		return nil
 	}
 }

--- a/cmd/forklift/plt/images.go
+++ b/cmd/forklift/plt/images.go
@@ -12,7 +12,7 @@ import (
 
 func cacheImgAction(versions Versions) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		pallet, cache, err := processFullBaseArgs(c, true)
+		pallet, cache, err := processFullBaseArgs(c.String("workspace"), true)
 		if err != nil {
 			return err
 		}

--- a/cmd/forklift/plt/packages.go
+++ b/cmd/forklift/plt/packages.go
@@ -9,7 +9,7 @@ import (
 // ls-pkg
 
 func lsPkgAction(c *cli.Context) error {
-	pallet, cache, err := processFullBaseArgs(c, true)
+	pallet, cache, err := processFullBaseArgs(c.String("workspace"), true)
 	if err != nil {
 		return err
 	}
@@ -20,7 +20,7 @@ func lsPkgAction(c *cli.Context) error {
 // show-pkg
 
 func showPkgAction(c *cli.Context) error {
-	pallet, cache, err := processFullBaseArgs(c, true)
+	pallet, cache, err := processFullBaseArgs(c.String("workspace"), true)
 	if err != nil {
 		return err
 	}

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -99,10 +99,10 @@ func switchAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 		if !c.Bool("apply") {
-      fmt.Println(
-        "Done! To apply the staged pallet, you may need to reboot or run " +
-        "`forklift stage apply` (or `sudo -E forklift stage apply` if you need sudo for Docker).",
-      )
+			fmt.Println(
+				"Done! To apply the staged pallet, you may need to reboot or run " +
+					"`forklift stage apply` (or `sudo -E forklift stage apply` if you need sudo for Docker).",
+			)
 			return nil
 		}
 

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -13,12 +13,12 @@ import (
 )
 
 func processFullBaseArgs(
-	c *cli.Context, ensureCache bool,
+	wpath string, ensureCache bool,
 ) (pallet *forklift.FSPallet, cache forklift.PathedRepoCache, err error) {
-	if pallet, err = getPallet(c.String("workspace")); err != nil {
+	if pallet, err = getPallet(wpath); err != nil {
 		return nil, nil, err
 	}
-	if cache, _, err = fcli.GetRepoCache(c.String("workspace"), pallet, ensureCache); err != nil {
+	if cache, _, err = fcli.GetRepoCache(wpath, pallet, ensureCache); err != nil {
 		return nil, nil, err
 	}
 	return pallet, cache, nil
@@ -42,7 +42,7 @@ func getPallet(wpath string) (pallet *forklift.FSPallet, err error) {
 
 func cacheAllAction(versions Versions) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		pallet, cache, err := processFullBaseArgs(c, false)
+		pallet, cache, err := processFullBaseArgs(c.String("workspace"), false)
 		if err != nil {
 			return err
 		}
@@ -76,7 +76,9 @@ func switchAction(versions Versions) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		pallet, repoCache, err := preparePallet(c, workspace, versions)
+		pallet, repoCache, err := preparePallet(
+			workspace, c.Args().First(), true, true, c.Bool("ignore-tool-version"), versions,
+		)
 		if err != nil {
 			return err
 		}
@@ -116,6 +118,9 @@ func switchAction(versions Versions) cli.ActionFunc {
 }
 
 func ensureWorkspace(wpath string) (*forklift.FSWorkspace, error) {
+	if !forklift.Exists(wpath) {
+		fmt.Printf("Making a new workspace at %s...", wpath)
+	}
 	if err := forklift.EnsureExists(wpath); err != nil {
 		return nil, errors.Wrapf(err, "couldn't make new workspace at %s", wpath)
 	}
@@ -130,70 +135,62 @@ func ensureWorkspace(wpath string) (*forklift.FSWorkspace, error) {
 }
 
 func preparePallet(
-	c *cli.Context, workspace *forklift.FSWorkspace, versions Versions,
+	workspace *forklift.FSWorkspace, gitRepoQuery string,
+	removeExistingLocalPallet, cacheStagingReqs, ignoreToolVersion bool, versions Versions,
 ) (pallet *forklift.FSPallet, repoCache forklift.PathedRepoCache, err error) {
 	// clone pallet
-	if err = os.RemoveAll(workspace.GetCurrentPalletPath()); err != nil {
-		return nil, nil, errors.Wrap(err, "couldn't remove local pallet")
+	if removeExistingLocalPallet {
+		fmt.Println("Warning: if a local pallet already exists, it will be deleted now...")
+		if err = os.RemoveAll(workspace.GetCurrentPalletPath()); err != nil {
+			return nil, nil, errors.Wrap(err, "couldn't remove local pallet")
+		}
 	}
 	if err = fcli.CloneQueriedGitRepoUsingLocalMirror(
-		0, workspace.GetPalletCachePath(), c.Args().First(), workspace.GetCurrentPalletPath(),
+		0, workspace.GetPalletCachePath(), gitRepoQuery, workspace.GetCurrentPalletPath(),
 	); err != nil {
 		return nil, nil, err
 	}
 	fmt.Println()
-	// TODO: warn if the git repo doesn't appear to be an actual pallet, or if the pallet's forklift
-	// version is incompatible
+	// TODO: warn if the git repo doesn't appear to be an actual pallet
 
-	// cache everything required by pallet
-	if pallet, repoCache, err = processFullBaseArgs(c, false); err != nil {
+	if pallet, repoCache, err = processFullBaseArgs(workspace.FS.Path(), false); err != nil {
 		return nil, nil, err
 	}
 	if err = fcli.CheckShallowCompatibility(
 		pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
-		c.Bool("ignore-tool-version"),
+		ignoreToolVersion,
 	); err != nil {
 		return pallet, repoCache, err
 	}
-	if _, err = fcli.CacheStagingRequirements(pallet, repoCache.Path()); err != nil {
-		return pallet, repoCache, err
+
+	// cache everything required by pallet
+	if cacheStagingReqs {
+		if _, err = fcli.CacheStagingRequirements(pallet, repoCache.Path()); err != nil {
+			return pallet, repoCache, err
+		}
 	}
 	return pallet, repoCache, nil
 }
 
 // clone
 
-func cloneAction(c *cli.Context) error {
-	wpath := c.String("workspace")
-	if !forklift.Exists(wpath) {
-		fmt.Printf("Making a new workspace at %s...", wpath)
-	}
-	if err := forklift.EnsureExists(wpath); err != nil {
-		return errors.Wrapf(err, "couldn't make new workspace at %s", wpath)
-	}
-	workspace, err := forklift.LoadWorkspace(wpath)
-	if err != nil {
-		return err
-	}
-	if err = forklift.EnsureExists(workspace.GetDataPath()); err != nil {
-		return errors.Wrapf(err, "couldn't ensure the existence of %s", workspace.GetDataPath())
-	}
-
-	if c.Bool("force") {
-		if err = os.RemoveAll(workspace.GetCurrentPalletPath()); err != nil {
-			return errors.Wrap(err, "couldn't remove local pallet")
+func cloneAction(versions Versions) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		workspace, err := ensureWorkspace(c.String("workspace"))
+		if err != nil {
+			return err
 		}
-	}
-	if err := fcli.CloneQueriedGitRepoUsingLocalMirror(
-		0, workspace.GetPalletCachePath(), c.Args().First(), workspace.GetCurrentPalletPath(),
-	); err != nil {
-		return err
-	}
 
-	// TODO: warn if the git repo doesn't appear to be an actual pallet, or if the pallet's forklift
-	// version is incompatible
-	fmt.Println("Done! Next, you'll probably want to run `forklift plt cache-all`.")
-	return nil
+		if _, _, err = preparePallet(
+			workspace, c.Args().First(),
+			c.Bool("force"), !c.Bool("no-cache-req"), c.Bool("ignore-tool-version"), versions,
+		); err != nil {
+			return err
+		}
+
+		fmt.Println("Done!")
+		return nil
+	}
 }
 
 // fetch
@@ -271,7 +268,7 @@ func showAction(c *cli.Context) error {
 
 func checkAction(versions Versions) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		pallet, cache, err := processFullBaseArgs(c, true)
+		pallet, cache, err := processFullBaseArgs(c.String("workspace"), true)
 		if err != nil {
 			return err
 		}
@@ -293,7 +290,7 @@ func checkAction(versions Versions) cli.ActionFunc {
 
 func planAction(versions Versions) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		pallet, cache, err := processFullBaseArgs(c, true)
+		pallet, cache, err := processFullBaseArgs(c.String("workspace"), true)
 		if err != nil {
 			return err
 		}
@@ -317,7 +314,7 @@ func planAction(versions Versions) cli.ActionFunc {
 
 func stageAction(versions Versions) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		pallet, cache, err := processFullBaseArgs(c, true)
+		pallet, cache, err := processFullBaseArgs(c.String("workspace"), true)
 		if err != nil {
 			return err
 		}
@@ -354,7 +351,7 @@ func stageAction(versions Versions) cli.ActionFunc {
 
 func applyAction(versions Versions) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		pallet, repoCache, err := processFullBaseArgs(c, true)
+		pallet, repoCache, err := processFullBaseArgs(c.String("workspace"), true)
 		if err != nil {
 			return err
 		}

--- a/cmd/forklift/plt/repositories.go
+++ b/cmd/forklift/plt/repositories.go
@@ -35,7 +35,7 @@ func cacheRepoAction(versions Versions) cli.ActionFunc {
 
 		// TODO: warn if any downloaded repo doesn't appear to be an actual repo, or if any repo's
 		// forklift version is incompatible or ahead of the pallet version
-		fmt.Println("Done! Next, you'll probably want to run `sudo -E forklift plt apply`.")
+		fmt.Println("Done!")
 		return nil
 	}
 }
@@ -66,19 +66,25 @@ func showRepoAction(c *cli.Context) error {
 
 func addRepoAction(versions Versions) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		pallet, cache, err := processFullBaseArgs(c.String("workspace"), false)
+		pallet, repoCache, err := processFullBaseArgs(c.String("workspace"), false)
 		if err != nil {
 			return err
 		}
 		if err = fcli.CheckShallowCompatibility(
-			pallet, cache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}
 
-		if err = fcli.AddRepoRequirements(0, pallet, cache.Path(), c.Args().Slice()); err != nil {
+		if err = fcli.AddRepoRequirements(0, pallet, repoCache.Path(), c.Args().Slice()); err != nil {
 			return err
+		}
+
+		if !c.Bool("no-cache-req") {
+			if _, err = fcli.CacheStagingRequirements(pallet, repoCache.Path()); err != nil {
+				return err
+			}
 		}
 		fmt.Println("Done!")
 		return nil

--- a/cmd/forklift/plt/repositories.go
+++ b/cmd/forklift/plt/repositories.go
@@ -12,7 +12,7 @@ import (
 
 func cacheRepoAction(versions Versions) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		pallet, cache, err := processFullBaseArgs(c, false)
+		pallet, cache, err := processFullBaseArgs(c.String("workspace"), false)
 		if err != nil {
 			return err
 		}
@@ -54,7 +54,7 @@ func lsRepoAction(c *cli.Context) error {
 // show-repo
 
 func showRepoAction(c *cli.Context) error {
-	pallet, cache, err := processFullBaseArgs(c, true)
+	pallet, cache, err := processFullBaseArgs(c.String("workspace"), true)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func showRepoAction(c *cli.Context) error {
 
 func addRepoAction(versions Versions) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		pallet, cache, err := processFullBaseArgs(c, false)
+		pallet, cache, err := processFullBaseArgs(c.String("workspace"), false)
 		if err != nil {
 			return err
 		}

--- a/cmd/forklift/plt/repositories.go
+++ b/cmd/forklift/plt/repositories.go
@@ -51,7 +51,7 @@ func lsRepoAction(c *cli.Context) error {
 	return fcli.PrintPalletRepos(0, pallet)
 }
 
-// show-plt
+// show-repo
 
 func showRepoAction(c *cli.Context) error {
 	pallet, cache, err := processFullBaseArgs(c, true)
@@ -59,6 +59,28 @@ func showRepoAction(c *cli.Context) error {
 		return err
 	}
 
-	repoPath := c.Args().First()
-	return fcli.PrintRepoInfo(0, pallet, cache, repoPath)
+	return fcli.PrintRepoInfo(0, pallet, cache, c.Args().First())
+}
+
+// add-repo
+
+func addRepoAction(versions Versions) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		pallet, cache, err := processFullBaseArgs(c, false)
+		if err != nil {
+			return err
+		}
+		if err = fcli.CheckShallowCompatibility(
+			pallet, cache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			c.Bool("ignore-tool-version"),
+		); err != nil {
+			return err
+		}
+
+		if err = fcli.AddRepoRequirements(0, pallet, cache.Path(), c.Args().Slice()); err != nil {
+			return err
+		}
+		fmt.Println("Done!")
+		return nil
+	}
 }

--- a/cmd/forklift/stage/cli.go
+++ b/cmd/forklift/stage/cli.go
@@ -134,8 +134,9 @@ func makeQueryBunSubcmds(versions Versions) []*cli.Command {
 
 func makeModifySubcmds(versions Versions) []*cli.Command {
 	category := "Modify the stage store"
-	return []*cli.Command{
-		{
+	return append(
+		makeModifyBunSubcmds(versions),
+		&cli.Command{
 			Name:     "set-next",
 			Category: category,
 			Usage: "Sets the specified staged pallet bundle as the next one to be applied, then " +
@@ -145,10 +146,29 @@ func makeModifySubcmds(versions Versions) []*cli.Command {
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "no-cache-img",
-					Usage: "don't download container images",
+					Usage: "Don't download container images",
 				},
 			},
 		},
+		&cli.Command{
+			Name:     "unset-next",
+			Category: category,
+			Usage:    "Updates the store so that no staged pallet bundle will be applied next",
+			Action:   unsetNextAction(versions),
+		},
+		&cli.Command{
+			Name:      "set-next-result",
+			Category:  category,
+			Usage:     "Manually records that the next staged pallet to apply was applied (un)successfully",
+			ArgsUsage: "pending|success|failure",
+			Action:    setNextResultAction(versions),
+		},
+	)
+}
+
+func makeModifyBunSubcmds(versions Versions) []*cli.Command {
+	category := "Modify the stage store"
+	return []*cli.Command{
 		{
 			Name:     "add-bun-name",
 			Aliases:  []string{"add-bundle-name"},

--- a/cmd/forklift/stage/cli.go
+++ b/cmd/forklift/stage/cli.go
@@ -34,12 +34,6 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 			Category: category,
 			Usage:    "Pre-downloads the Docker container images required for the next apply",
 			Action:   cacheImgAction(versions),
-			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name:  "parallel",
-					Usage: "parallelize downloading of container images",
-				},
-			},
 		},
 		{
 			Name:     "check",
@@ -52,12 +46,6 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 			Category: category,
 			Usage:    "Determines the changes needed to update the host for the next apply",
 			Action:   planAction(versions),
-			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name:  "parallel",
-					Usage: "construct a plan for parallel updating of deployments",
-				},
-			},
 		},
 		{
 			Name:     "apply",
@@ -65,12 +53,6 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 			Usage: "Updates the host according to the next staged pallet, falling back to the last " +
 				"successfully-staged pallet if the next one already failed",
 			Action: applyAction(versions),
-			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name:  "parallel",
-					Usage: "parallelize updating of package deployments",
-				},
-			},
 		},
 	}
 }
@@ -164,10 +146,6 @@ func makeModifySubcmds(versions Versions) []*cli.Command {
 				&cli.BoolFlag{
 					Name:  "no-cache-img",
 					Usage: "don't download container images",
-				},
-				&cli.BoolFlag{
-					Name:  "parallel",
-					Usage: "parallelize downloading of container images",
 				},
 			},
 		},

--- a/cmd/forklift/stage/images.go
+++ b/cmd/forklift/stage/images.go
@@ -26,9 +26,7 @@ func cacheImgAction(versions Versions) cli.ActionFunc {
 		); err != nil {
 			return err
 		}
-		fmt.Println(
-			"Done caching images! They will be used when you run `sudo -E forklift stage apply`.",
-		)
+		fmt.Println("Done caching images! They will be used when the staged pallet bundle is applied.")
 		return nil
 	}
 }

--- a/cmd/forklift/stage/store.go
+++ b/cmd/forklift/stage/store.go
@@ -269,7 +269,10 @@ func setNextAction(versions Versions) cli.ActionFunc {
 		); err != nil {
 			return err
 		}
-		fmt.Println("Done! To apply changes immediately, run `sudo -E forklift stage apply`")
+		fmt.Println(
+      "Done! To apply the staged pallet, you may need to reboot or run " +
+      "`forklift stage apply` (or `sudo -E forklift stage apply` if you need sudo for Docker).",
+    )
 		return nil
 	}
 }

--- a/cmd/forklift/stage/store.go
+++ b/cmd/forklift/stage/store.go
@@ -249,6 +249,15 @@ func setNextAction(versions Versions) cli.ActionFunc {
 			return errMissingStore
 		}
 
+		if c.Args().First() == "0" {
+			store.SetNext(0)
+			fmt.Println("Committing update to the stage store so that no stage will be applied next...")
+			if err := store.CommitState(); err != nil {
+				return errors.Wrap(err, "couldn't commit updated stage store state")
+			}
+			return nil
+		}
+
 		newNext, err := resolveBundleIdentifier(c.Args().First(), store)
 		if err != nil {
 			return err
@@ -270,9 +279,30 @@ func setNextAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 		fmt.Println(
-      "Done! To apply the staged pallet, you may need to reboot or run " +
-      "`forklift stage apply` (or `sudo -E forklift stage apply` if you need sudo for Docker).",
-    )
+			"Done! To apply the staged pallet, you may need to reboot or run " +
+				"`forklift stage apply` (or `sudo -E forklift stage apply` if you need sudo for Docker).",
+		)
+		return nil
+	}
+}
+
+// unset-next
+
+func unsetNextAction(versions Versions) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		store, err := getStageStore(c.String("workspace"), c.String("stage-store"), versions)
+		if err != nil {
+			return err
+		}
+		if !store.Exists() {
+			return errMissingStore
+		}
+
+		store.SetNext(0)
+		fmt.Println("Committing update to the stage store so that no stage will be applied next...")
+		if err := store.CommitState(); err != nil {
+			return errors.Wrap(err, "couldn't commit updated stage store state")
+		}
 		return nil
 	}
 }
@@ -396,6 +426,39 @@ func applyAction(versions Versions) cli.ActionFunc {
 
 		if err = fcli.ApplyNextOrCurrentBundle(0, store, bundle, c.Bool("parallel")); err != nil {
 			return err
+		}
+		fmt.Println("Done!")
+		return nil
+	}
+}
+
+// set-next-result
+
+func setNextResultAction(versions Versions) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		store, err := getStageStore(c.String("workspace"), c.String("stage-store"), versions)
+		if err != nil {
+			return err
+		}
+		if !store.Exists() {
+			return errMissingStore
+		}
+
+		switch result := c.Args().First(); result {
+		case "success":
+			store.RecordNextSuccess(true)
+		case "pending":
+			store.Manifest.Stages.NextFailed = false
+		case "failure":
+			store.RecordNextSuccess(false)
+		default:
+			return errors.Errorf(
+				"unknown result (must be 'pending', 'success', or 'failure'): %s", result,
+			)
+		}
+		fmt.Println("Committing result to the stage store...")
+		if err := store.CommitState(); err != nil {
+			return errors.Wrap(err, "couldn't commit updated stage store state")
 		}
 		fmt.Println("Done!")
 		return nil

--- a/docs/design.md
+++ b/docs/design.md
@@ -24,7 +24,7 @@ As a software deployment & configuration system, Forklift consists of the follow
 
 Together, the Forklift specifications and the `forklift` tool can be used by project maintainers, contributors, and users to:
 
-1. Specify one or more apps, each of which may consist of a Docker Compose app definition and/or a set of files to make available on the operating system as bind mounts, and specify how it will integrate with other modules.
+1. Specify one or more modules, each of which may consist of a Docker Compose app definition and/or a set of files to export to a directory which can be made available on the operating system (e.g. with overlay mounts and/or bind mounts), and specify how the module will integrate with other modules.
 2. Distribute app specifications as *packages* in one or more *repositories*, each of which is a Git repository hosted online by a hosting service such as - but not limited to - GitHub.
 3. Specify the exact and complete configuration of a set of packages to be deployed as apps on a computer; the complete configuration for a computer is called a *pallet*, which is a Git repository which may be hosted online.
 4. Run continuous integration checks on a pallet - including first-class support for GitHub Actions - to automatically ensure that many kinds of changes to a pallet will not break compatibility or introduce conflicts between deployed apps.
@@ -44,7 +44,7 @@ Related packages are organized into a *repository*, which is just a Git reposito
 
 [fig-pkg-repo]: (add a nested-boxes-and-lines figure with an example directory structure, repository paths, package paths, and a schematic representation of resource interface & feature flags)
 
-Each package can specify a *resource interface*, including the system resources which a deployment of that package provides - such as files, bind mounts, network port listeners, and service APIs - and the resources which a deployment of that package requires. Resource interfaces are used for verifying correctness of app deployment configurations.
+Each package can specify a *resource interface*, including the system resources which a deployment of that package provides - such as files, network port listeners, and service APIs - and the resources which a deployment of that package requires. Resource interfaces are used for verifying correctness of app deployment configurations.
 
 Each package can also specify particular files which should be *exported* (i.e. copied) into a path. This enables tools to make certain files (e.g. systemd service definitions) available on the operating system via an overlay filesystem.
 
@@ -86,7 +86,7 @@ Resource requirement constraints are used in planning the order of changes neede
 
 ### File exporting
 
-(talk about how we prepare bind mounts)
+(talk about how we export files, and how OSes can use the export directory for bind mounts, overlay mounts, systemd-sysexts/confexts, etc.)
 
 ### User interfacing
 

--- a/internal/app/forklift/cli/git-repositories.go
+++ b/internal/app/forklift/cli/git-repositories.go
@@ -21,10 +21,10 @@ import (
 func DownloadQueriedGitReposUsingLocalMirrors(
 	indent int, cachePath string, queries []string,
 ) (resolved map[string]forklift.GitRepoReq, changed map[forklift.GitRepoReq]bool, err error) {
-	if err = ValidateGitRepoQueries(queries); err != nil {
+	if err = validateGitRepoQueries(queries); err != nil {
 		return nil, nil, errors.Wrap(err, "one or more arguments is invalid")
 	}
-	if resolved, err = ResolveQueriesUsingLocalMirrors(indent, cachePath, queries); err != nil {
+	if resolved, err = resolveQueriesUsingLocalMirrors(indent, cachePath, queries); err != nil {
 		return nil, nil, err
 	}
 
@@ -51,7 +51,7 @@ func DownloadQueriedGitReposUsingLocalMirrors(
 	return resolved, changed, nil
 }
 
-func ValidateGitRepoQueries(queries []string) error {
+func validateGitRepoQueries(queries []string) error {
 	if len(queries) == 0 {
 		return errors.Errorf("at least one query must be specified")
 	}
@@ -63,7 +63,7 @@ func ValidateGitRepoQueries(queries []string) error {
 	return nil
 }
 
-func ResolveQueriesUsingLocalMirrors(
+func resolveQueriesUsingLocalMirrors(
 	indent int, cachePath string, queries []string,
 ) (resolved map[string]forklift.GitRepoReq, err error) {
 	IndentedPrintln(indent, "Resolving version queries using local mirrors of remote Git repos...")
@@ -420,7 +420,7 @@ func CloneQueriedGitRepoUsingLocalMirror(
 	}
 
 	queries := []string{query}
-	if _, err := ResolveQueriesUsingLocalMirrors(indent, cachePath, queries); err != nil {
+	if _, err := resolveQueriesUsingLocalMirrors(indent, cachePath, queries); err != nil {
 		return err
 	}
 

--- a/internal/app/forklift/cli/images.go
+++ b/internal/app/forklift/cli/images.go
@@ -77,6 +77,11 @@ func DownloadImages(
 	if err != nil {
 		return errors.Wrap(err, "couldn't determine images required by package deployments")
 	}
+	if len(orderedImages) == 0 {
+		// When there are no images to download, don't cause an error if we can't initialize the
+		// Docker API client!
+		return nil
+	}
 
 	dc, err := docker.NewClient()
 	if err != nil {


### PR DESCRIPTION
This PR changes the CLI so that `--parallel` is enabled by default, since parallelized download of container images and parallelized bringup of containers so much better for usage (because it's so much faster). This PR also adds some other subcommands which I found I needed, and some automatic caching of required repos because I found it was annoying to have to remember to run `cache-repo` after those commands.