### PR TITLE
Check for validity of file export source paths in `check` subcmds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Added
+
+- (cli) Added checking for validity of source paths of file exports in `[dev] plt check` and `stage check` subcommands.
+
 ## 0.7.0-alpha.4 - 2024-04-25
 
 ### Added


### PR DESCRIPTION
This PR adds checks to the `[dev] plt check` subcommands to ensure that the source paths of all file export resources actually exist; if they don't exist, running `[dev] plt stage` will fail - so we want to catch invalid paths in `[dev] plt check` so that they can be caught in CI workflows which run `[dev] plt check`.