### PR TITLE
Preserve source file perms in http-archive file exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.2-alpha.1 - 2024-05-07
+
+## Fixed
+
+- (cli) File permissions are now preserved in the exports of `http-archive` source files extracted from `.tar`/`.tar.gz` archives.
+
 ## 0.7.2-alpha.0 - 2024-05-07
 
 ## Added

--- a/cmd/forklift/main.go
+++ b/cmd/forklift/main.go
@@ -104,7 +104,7 @@ const (
 	newStageStoreVersion = "v0.7.0"
 	// fallbackVersion is the version reported which the Forklift tool reports itself as if its actual
 	// version is unknown.
-	fallbackVersion = "v0.7.1-dev"
+	fallbackVersion = "v0.7.2-dev"
 )
 
 var (

--- a/internal/app/forklift/bundles.go
+++ b/internal/app/forklift/bundles.go
@@ -363,7 +363,10 @@ func extractFile(tarReader *tar.Reader, sourcePath string, exportPath string) er
 				)
 			}
 		case tar.TypeReg:
-			targetFile, err := os.Create(filepath.FromSlash(targetPath))
+			targetFile, err := os.OpenFile(
+				filepath.FromSlash(targetPath), os.O_RDWR|os.O_CREATE|os.O_TRUNC,
+				fs.FileMode(header.Mode&int64(fs.ModePerm)),
+			)
 			if err != nil {
 				return errors.Wrapf(err, "couldn't create export file at %s", targetPath)
 			}


### PR DESCRIPTION
This PR fixes an issue I hadn't noticed in #195 where file permissions of source files in `.tar`/`.tar.gz` archives weren't being copied to the exported files. This was preventing binaries from being executed.