### PR TITLE
Add CLI for modifying local pallets' package deployments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,11 +43,11 @@ linters:
     - gocyclo
     - godot
     - gofumpt
-    - gomnd
     - goprintffuncname
     - gosec
     - lll
     - misspell
+    - mnd
     - noctx
     - nolintlint
     - rowserrcheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Added
+
+- Added a `[dev] plt rm-repo` subcommand which removes requirements for the specified repo paths, as an inverse of the `[dev] plt add-repo` subcommand.
+
 ## 0.7.2-alpha.1 - 2024-05-07
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `[dev] plt set-depl-pkg` subcommand which modifies a package deployment at the specified deployment name, to change the deployment's package.
 - Added a `[dev] plt add-depl-feat` subcommand which modifies a package deployment at the specified deployment name, to enable the specified feature flags (for feature flags which are not already enabled).
 - Added a `[dev] plt rm-depl-feat` subcommand which modifies a package deployment at the specified deployment name, to disable the specified feature flags (for feature flags which are not already disabled), as the inverse of the `[dev] plt add-depl-feat` subcommand.
+- Added a `[dev] plt set-depl-disabled` subcommand which modifies a package deployment at the specified deployment name, to disable the deployment.
+- Added a `[dev] plt set-depl-enabled` subcommand which modifies a package deployment at the specified deployment name, to enable the deployment.
 
 ## 0.7.2-alpha.1 - 2024-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 - Added a `[dev] plt rm-repo` subcommand which removes requirements for the specified repo paths, as an inverse of the `[dev] plt add-repo` subcommand.
+- Added a `[dev] plt add-depl` subcommand which adds a package deployment at the specified deployment name, for the specified package path (and optionally for the specified feature flags and enabled/disabled setting).
 
 ## 0.7.2-alpha.1 - 2024-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `[dev] plt rm-repo` subcommand which removes requirements for the specified repo paths, as an inverse of the `[dev] plt add-repo` subcommand.
 - Added a `[dev] plt add-depl` subcommand which adds a package deployment at the specified deployment name, for the specified package path (and optionally for the specified feature flags and enabled/disabled setting).
 - Added a `[dev] plt rm-depl` subcommand which deletes the package deployment declaration(s) at the specified deployment name(s), as the inverse of the `[dev] plt add-depl` subcommand.
+- Added a `[dev] plt set-depl-pkg` subcommand which modifies a package deployment at the specified deployment name, to change the deployment's package.
 - Added a `[dev] plt add-depl-feat` subcommand which modifies a package deployment at the specified deployment name, to enable the specified feature flags (for feature flags which are not already enabled).
 - Added a `[dev] plt rm-depl-feat` subcommand which modifies a package deployment at the specified deployment name, to disable the specified feature flags (for feature flags which are not already disabled), as the inverse of the `[dev] plt add-depl-feat` subcommand.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a `[dev] plt rm-repo` subcommand which removes requirements for the specified repo paths, as an inverse of the `[dev] plt add-repo` subcommand.
 - Added a `[dev] plt add-depl` subcommand which adds a package deployment at the specified deployment name, for the specified package path (and optionally for the specified feature flags and enabled/disabled setting).
+- Added a `[dev] plt rm-depl` subcommand which deletes the package deployment declaration(s) at the specified deployment name(s), as the inverse of the `[dev] plt add-depl` subcommand.
 
 ## 0.7.2-alpha.1 - 2024-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `[dev] plt add-depl` subcommand which adds a package deployment at the specified deployment name, for the specified package path (and optionally for the specified feature flags and enabled/disabled setting).
 - Added a `[dev] plt rm-depl` subcommand which deletes the package deployment declaration(s) at the specified deployment name(s), as the inverse of the `[dev] plt add-depl` subcommand.
 - Added a `[dev] plt add-depl-feat` subcommand which modifies a package deployment at the specified deployment name, to enable the specified feature flags (for feature flags which are not already enabled).
+- Added a `[dev] plt rm-depl-feat` subcommand which modifies a package deployment at the specified deployment name, to disable the specified feature flags (for feature flags which are not already disabled), as the inverse of the `[dev] plt add-depl-feat` subcommand.
 
 ## 0.7.2-alpha.1 - 2024-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `[dev] plt rm-repo` subcommand which removes requirements for the specified repo paths, as an inverse of the `[dev] plt add-repo` subcommand.
 - Added a `[dev] plt add-depl` subcommand which adds a package deployment at the specified deployment name, for the specified package path (and optionally for the specified feature flags and enabled/disabled setting).
 - Added a `[dev] plt rm-depl` subcommand which deletes the package deployment declaration(s) at the specified deployment name(s), as the inverse of the `[dev] plt add-depl` subcommand.
+- Added a `[dev] plt add-depl-feat` subcommand which modifies a package deployment at the specified deployment name, to enable the specified feature flags (for feature flags which are not already enabled).
 
 ## 0.7.2-alpha.1 - 2024-05-07
 

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -252,7 +252,7 @@ func makeModifyDeplSubcmds(versions Versions) []*cli.Command {
 			Aliases:   []string{"add-deployment"},
 			Category:  category,
 			Usage:     "Adds (or re-adds) a package deployment to the pallet",
-			ArgsUsage: "depl_path package_path...",
+			ArgsUsage: "deployment_name package_path...",
 			Flags: []cli.Flag{
 				&cli.StringSliceFlag{
 					Name:  "feature",
@@ -269,8 +269,17 @@ func makeModifyDeplSubcmds(versions Versions) []*cli.Command {
 			},
 			Action: addDeplAction(versions),
 		},
-		// TODO: add an rm-depl action
+		{
+			Name:      "rm-depl",
+			Aliases:   []string{"remove-deployment", "remove-deployments"},
+			Category:  category,
+			Usage:     "Removes deployment from the pallet",
+			ArgsUsage: "deployment_name...",
+			Action:    rmDeplAction(versions),
+		},
 		// TODO: add an add-depl-feat depl_path [feature]... action
 		// TODO: add an rm-depl-feat depl_path [feature]... action
+		// TODO: add a set-depl-pkg action
+		// TODO: add a set-depl-disabled action
 	}
 }

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -318,6 +318,21 @@ func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's 
 			ArgsUsage: "deployment_name feature_name...",
 			Action:    rmDeplFeatAction(versions),
 		},
-		// TODO: add a set-depl-disabled action
+		{
+			Name:      "set-depl-disabled",
+			Aliases:   []string{"set-deployment-disabled", "disable-depl", "disable-deployment"},
+			Category:  category,
+			Usage:     "Disables the specified deployment",
+			ArgsUsage: "deployment_name",
+			Action:    setDeplDisabledAction(versions, true),
+		},
+		{
+			Name:      "unset-depl-disabled",
+			Aliases:   []string{"unset-deployment-disabled", "enable-depl", "enable-deployment"},
+			Category:  category,
+			Usage:     "Enables the specified deployment",
+			ArgsUsage: "deployment_name",
+			Action:    setDeplDisabledAction(versions, false),
+		},
 	}
 }

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -292,7 +292,14 @@ func makeModifyDeplSubcmds(versions Versions) []*cli.Command {
 			},
 			Action: addDeplFeatAction(versions),
 		},
-		// TODO: add an rm-depl-feat depl_path [feature]... action
+		{
+			Name:      "rm-depl-feat",
+			Aliases:   []string{"remove-deployment-feature", "remove-deployment-features"},
+			Category:  category,
+			Usage:     "Disables the specified package features in the specified deployment",
+			ArgsUsage: "deployment_name feature_name...",
+			Action:    rmDeplFeatAction(versions),
+		},
 		// TODO: add a set-depl-pkg action
 		// TODO: add a set-depl-disabled action
 	}

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -219,8 +219,21 @@ func makeModifySubcmds(versions Versions) []*cli.Command {
 			},
 			Action: addRepoAction(versions),
 		},
-		// TODO: add an rm-repo action with alias "drop-repo"; it should ensure no depls depend on it
-		// or delete those depls if `--force` is set
+		{
+			Name:      "rm-repo",
+			Aliases:   []string{"remove-repositories", "drop-repo", "drop-repositories"},
+			Category:  category,
+			Usage:     "Removes repo requirements from the pallet",
+			ArgsUsage: "repo_path...",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name: "force",
+					Usage: "Remove specified repo requirements even if some declared package deployments " +
+						"depend on them",
+				},
+			},
+			Action: rmRepoAction(versions),
+		},
 		// TODO: add an add-depl --features=... depl_path package_path action
 		// TODO: add an rm-depl action
 		// TODO: add an add-depl-feat depl_path [feature]... action

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -201,6 +201,13 @@ func makeQueryDeplSubcmds(category string) []*cli.Command {
 }
 
 func makeModifySubcmds(versions Versions) []*cli.Command {
+	return slices.Concat(
+		makeModifyRepoSubcmds(versions),
+		makeModifyDeplSubcmds(versions),
+	)
+}
+
+func makeModifyRepoSubcmds(versions Versions) []*cli.Command {
 	const category = "Modify the pallet"
 	return []*cli.Command{
 		{
@@ -234,7 +241,34 @@ func makeModifySubcmds(versions Versions) []*cli.Command {
 			},
 			Action: rmRepoAction(versions),
 		},
-		// TODO: add an add-depl --features=... depl_path package_path action
+	}
+}
+
+func makeModifyDeplSubcmds(versions Versions) []*cli.Command {
+	const category = "Modify the pallet"
+	return []*cli.Command{
+		{
+			Name:      "add-depl",
+			Aliases:   []string{"add-deployment"},
+			Category:  category,
+			Usage:     "Adds (or re-adds) a package deployment to the pallet",
+			ArgsUsage: "depl_path package_path...",
+			Flags: []cli.Flag{
+				&cli.StringSliceFlag{
+					Name:  "feature",
+					Usage: "Enable the specified feature flag in the package deployment",
+				},
+				&cli.BoolFlag{
+					Name:  "disabled",
+					Usage: "Add a disabled package deployment",
+				},
+				&cli.BoolFlag{
+					Name:  "force",
+					Usage: "Add specified deployment even if package_path cannot be resolved",
+				},
+			},
+			Action: addDeplAction(versions),
+		},
 		// TODO: add an rm-depl action
 		// TODO: add an add-depl-feat depl_path [feature]... action
 		// TODO: add an rm-depl-feat depl_path [feature]... action

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -244,7 +244,9 @@ func makeModifyRepoSubcmds(versions Versions) []*cli.Command {
 	}
 }
 
-func makeModifyDeplSubcmds(versions Versions) []*cli.Command {
+func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's hard to split more
+	versions Versions,
+) []*cli.Command {
 	const category = "Modify the pallet"
 	return []*cli.Command{
 		{
@@ -263,8 +265,9 @@ func makeModifyDeplSubcmds(versions Versions) []*cli.Command {
 					Usage: "Add a disabled package deployment",
 				},
 				&cli.BoolFlag{
-					Name:  "force",
-					Usage: "Add specified deployment even if package_path cannot be resolved",
+					Name: "force",
+					Usage: "Add specified deployment even if package_path cannot be resolved or the " +
+						"specified feature flags are not allowed for it",
 				},
 			},
 			Action: addDeplAction(versions),
@@ -276,6 +279,21 @@ func makeModifyDeplSubcmds(versions Versions) []*cli.Command {
 			Usage:     "Removes deployment from the pallet",
 			ArgsUsage: "deployment_name...",
 			Action:    rmDeplAction(versions),
+		},
+		{
+			Name:      "set-depl-pkg",
+			Aliases:   []string{"set-deployment-package"},
+			Category:  category,
+			Usage:     "Sets the path of the package to deploy in the specified deployment",
+			ArgsUsage: "deployment_name package_path...",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name: "force",
+					Usage: "Use the specified package path even if it cannot be resolved or makes the " +
+						"enabled feature flags invalid",
+				},
+			},
+			Action: setDeplPkgAction(versions),
 		},
 		{
 			Name:      "add-depl-feat",
@@ -300,7 +318,6 @@ func makeModifyDeplSubcmds(versions Versions) []*cli.Command {
 			ArgsUsage: "deployment_name feature_name...",
 			Action:    rmDeplFeatAction(versions),
 		},
-		// TODO: add a set-depl-pkg action
 		// TODO: add a set-depl-disabled action
 	}
 }

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -248,6 +248,21 @@ func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's 
 	versions Versions,
 ) []*cli.Command {
 	const category = "Modify the pallet"
+	baseFlags := []cli.Flag{
+		&cli.BoolFlag{
+			Name: "stage",
+			Usage: "Immediately stage the pallet after making the modification (this flag is ignored " +
+				"if --apply is set)",
+		},
+		&cli.BoolFlag{
+			Name:  "no-cache-img",
+			Usage: "Don't download container images (this flag is only used if --stage is set)",
+		},
+		&cli.BoolFlag{
+			Name:  "apply",
+			Usage: "Immediately apply the pallet after staging it",
+		},
+	}
 	return []*cli.Command{
 		{
 			Name:      "add-depl",
@@ -255,21 +270,24 @@ func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's 
 			Category:  category,
 			Usage:     "Adds (or re-adds) a package deployment to the pallet",
 			ArgsUsage: "deployment_name package_path...",
-			Flags: []cli.Flag{
-				&cli.StringSliceFlag{
-					Name:  "feature",
-					Usage: "Enable the specified feature flag in the package deployment",
+			Flags: slices.Concat(
+				[]cli.Flag{
+					&cli.StringSliceFlag{
+						Name:  "feature",
+						Usage: "Enable the specified feature flag in the package deployment",
+					},
+					&cli.BoolFlag{
+						Name:  "disabled",
+						Usage: "Add a disabled package deployment",
+					},
+					&cli.BoolFlag{
+						Name: "force",
+						Usage: "Add specified deployment even if package_path cannot be resolved or the " +
+							"specified feature flags are not allowed for it",
+					},
 				},
-				&cli.BoolFlag{
-					Name:  "disabled",
-					Usage: "Add a disabled package deployment",
-				},
-				&cli.BoolFlag{
-					Name: "force",
-					Usage: "Add specified deployment even if package_path cannot be resolved or the " +
-						"specified feature flags are not allowed for it",
-				},
-			},
+				baseFlags,
+			),
 			Action: addDeplAction(versions),
 		},
 		{
@@ -278,6 +296,7 @@ func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's 
 			Category:  category,
 			Usage:     "Removes deployment from the pallet",
 			ArgsUsage: "deployment_name...",
+			Flags:     baseFlags,
 			Action:    rmDeplAction(versions),
 		},
 		{
@@ -286,13 +305,16 @@ func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's 
 			Category:  category,
 			Usage:     "Sets the path of the package to deploy in the specified deployment",
 			ArgsUsage: "deployment_name package_path...",
-			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name: "force",
-					Usage: "Use the specified package path even if it cannot be resolved or makes the " +
-						"enabled feature flags invalid",
+			Flags: slices.Concat(
+				[]cli.Flag{
+					&cli.BoolFlag{
+						Name: "force",
+						Usage: "Use the specified package path even if it cannot be resolved or makes the " +
+							"enabled feature flags invalid",
+					},
 				},
-			},
+				baseFlags,
+			),
 			Action: setDeplPkgAction(versions),
 		},
 		{
@@ -301,13 +323,16 @@ func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's 
 			Category:  category,
 			Usage:     "Enables the specified package features in the specified deployment",
 			ArgsUsage: "deployment_name feature_name...",
-			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name: "force",
-					Usage: "Enable the specified feature flags even if they're not allowed by the  " +
-						"deployment's package",
+			Flags: slices.Concat(
+				[]cli.Flag{
+					&cli.BoolFlag{
+						Name: "force",
+						Usage: "Enable the specified feature flags even if they're not allowed by the  " +
+							"deployment's package",
+					},
 				},
-			},
+				baseFlags,
+			),
 			Action: addDeplFeatAction(versions),
 		},
 		{
@@ -316,6 +341,7 @@ func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's 
 			Category:  category,
 			Usage:     "Disables the specified package features in the specified deployment",
 			ArgsUsage: "deployment_name feature_name...",
+			Flags:     baseFlags,
 			Action:    rmDeplFeatAction(versions),
 		},
 		{
@@ -324,6 +350,7 @@ func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's 
 			Category:  category,
 			Usage:     "Disables the specified deployment",
 			ArgsUsage: "deployment_name",
+			Flags:     baseFlags,
 			Action:    setDeplDisabledAction(versions, true),
 		},
 		{
@@ -332,6 +359,7 @@ func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's 
 			Category:  category,
 			Usage:     "Enables the specified deployment",
 			ArgsUsage: "deployment_name",
+			Flags:     baseFlags,
 			Action:    setDeplDisabledAction(versions, false),
 		},
 	}

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -277,7 +277,21 @@ func makeModifyDeplSubcmds(versions Versions) []*cli.Command {
 			ArgsUsage: "deployment_name...",
 			Action:    rmDeplAction(versions),
 		},
-		// TODO: add an add-depl-feat depl_path [feature]... action
+		{
+			Name:      "add-depl-feat",
+			Aliases:   []string{"add-deployment-feature", "add-deployment-features"},
+			Category:  category,
+			Usage:     "Enables the specified package features in the specified deployment",
+			ArgsUsage: "deployment_name feature_name...",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name: "force",
+					Usage: "Enable the specified feature flags even if they're not allowed by the  " +
+						"deployment's package",
+				},
+			},
+			Action: addDeplFeatAction(versions),
+		},
 		// TODO: add an rm-depl-feat depl_path [feature]... action
 		// TODO: add a set-depl-pkg action
 		// TODO: add a set-depl-disabled action

--- a/cmd/forklift/dev/plt/deployments.go
+++ b/cmd/forklift/dev/plt/deployments.go
@@ -71,3 +71,27 @@ func addDeplAction(versions Versions) cli.ActionFunc {
 		return nil
 	}
 }
+
+// rm-depl
+
+func rmDeplAction(versions Versions) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		pallet, repoCache, _, err := processFullBaseArgs(c, false, false)
+		if err != nil {
+			return err
+		}
+		if err = fcli.CheckShallowCompatibility(
+			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			c.Bool("ignore-tool-version"),
+		); err != nil {
+			return err
+		}
+
+		if err = fcli.RemoveDepls(0, pallet, c.Args().Slice()); err != nil {
+			return err
+		}
+
+		fmt.Println("Done!")
+		return nil
+	}
+}

--- a/cmd/forklift/dev/plt/deployments.go
+++ b/cmd/forklift/dev/plt/deployments.go
@@ -51,7 +51,7 @@ func addDeplAction(versions Versions) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		if err = fcli.CheckShallowCompatibility(
+		if err = fcli.CheckCompatibility(
 			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
@@ -67,8 +67,15 @@ func addDeplAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		fmt.Println("Done!")
-		return nil
+		switch {
+		case c.Bool("apply"):
+			return applyAction(versions)(c)
+		case c.Bool("stage"):
+			return stageAction(versions)(c)
+		default:
+			fmt.Println("Done!")
+			return nil
+		}
 	}
 }
 
@@ -80,7 +87,7 @@ func rmDeplAction(versions Versions) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		if err = fcli.CheckShallowCompatibility(
+		if err = fcli.CheckCompatibility(
 			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
@@ -91,8 +98,15 @@ func rmDeplAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		fmt.Println("Done!")
-		return nil
+		switch {
+		case c.Bool("apply"):
+			return applyAction(versions)(c)
+		case c.Bool("stage"):
+			return stageAction(versions)(c)
+		default:
+			fmt.Println("Done!")
+			return nil
+		}
 	}
 }
 
@@ -104,7 +118,7 @@ func setDeplPkgAction(versions Versions) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		if err = fcli.CheckShallowCompatibility(
+		if err = fcli.CheckCompatibility(
 			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
@@ -117,8 +131,15 @@ func setDeplPkgAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		fmt.Println("Done!")
-		return nil
+		switch {
+		case c.Bool("apply"):
+			return applyAction(versions)(c)
+		case c.Bool("stage"):
+			return stageAction(versions)(c)
+		default:
+			fmt.Println("Done!")
+			return nil
+		}
 	}
 }
 
@@ -130,7 +151,7 @@ func addDeplFeatAction(versions Versions) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		if err = fcli.CheckShallowCompatibility(
+		if err = fcli.CheckCompatibility(
 			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
@@ -145,8 +166,15 @@ func addDeplFeatAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		fmt.Println("Done!")
-		return nil
+		switch {
+		case c.Bool("apply"):
+			return applyAction(versions)(c)
+		case c.Bool("stage"):
+			return stageAction(versions)(c)
+		default:
+			fmt.Println("Done!")
+			return nil
+		}
 	}
 }
 
@@ -158,7 +186,7 @@ func rmDeplFeatAction(versions Versions) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		if err = fcli.CheckShallowCompatibility(
+		if err = fcli.CheckCompatibility(
 			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
@@ -171,8 +199,15 @@ func rmDeplFeatAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		fmt.Println("Done!")
-		return nil
+		switch {
+		case c.Bool("apply"):
+			return applyAction(versions)(c)
+		case c.Bool("stage"):
+			return stageAction(versions)(c)
+		default:
+			fmt.Println("Done!")
+			return nil
+		}
 	}
 }
 
@@ -184,7 +219,7 @@ func setDeplDisabledAction(versions Versions, setting bool) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		if err = fcli.CheckShallowCompatibility(
+		if err = fcli.CheckCompatibility(
 			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
@@ -196,7 +231,14 @@ func setDeplDisabledAction(versions Versions, setting bool) cli.ActionFunc {
 			return err
 		}
 
-		fmt.Println("Done!")
-		return nil
+		switch {
+		case c.Bool("apply"):
+			return applyAction(versions)(c)
+		case c.Bool("stage"):
+			return stageAction(versions)(c)
+		default:
+			fmt.Println("Done!")
+			return nil
+		}
 	}
 }

--- a/cmd/forklift/dev/plt/deployments.go
+++ b/cmd/forklift/dev/plt/deployments.go
@@ -96,6 +96,32 @@ func rmDeplAction(versions Versions) cli.ActionFunc {
 	}
 }
 
+// set-depl-pkg
+
+func setDeplPkgAction(versions Versions) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		pallet, repoCache, _, err := processFullBaseArgs(c, true, true)
+		if err != nil {
+			return err
+		}
+		if err = fcli.CheckShallowCompatibility(
+			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			c.Bool("ignore-tool-version"),
+		); err != nil {
+			return err
+		}
+
+		deplName := c.Args().Slice()[0]
+		pkgPath := c.Args().Slice()[1]
+		if err = fcli.SetDeplPkg(0, pallet, repoCache, deplName, pkgPath, c.Bool("force")); err != nil {
+			return err
+		}
+
+		fmt.Println("Done!")
+		return nil
+	}
+}
+
 // add-depl-feat
 
 func addDeplFeatAction(versions Versions) cli.ActionFunc {

--- a/cmd/forklift/dev/plt/deployments.go
+++ b/cmd/forklift/dev/plt/deployments.go
@@ -175,3 +175,28 @@ func rmDeplFeatAction(versions Versions) cli.ActionFunc {
 		return nil
 	}
 }
+
+// set-depl-disabled
+
+func setDeplDisabledAction(versions Versions, setting bool) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		pallet, repoCache, _, err := processFullBaseArgs(c, true, true)
+		if err != nil {
+			return err
+		}
+		if err = fcli.CheckShallowCompatibility(
+			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			c.Bool("ignore-tool-version"),
+		); err != nil {
+			return err
+		}
+
+		deplName := c.Args().Slice()[0]
+		if err = fcli.SetDeplDisabled(0, pallet, deplName, setting); err != nil {
+			return err
+		}
+
+		fmt.Println("Done!")
+		return nil
+	}
+}

--- a/cmd/forklift/dev/plt/deployments.go
+++ b/cmd/forklift/dev/plt/deployments.go
@@ -58,10 +58,10 @@ func addDeplAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		deplPath := c.Args().Slice()[0]
+		deplName := c.Args().Slice()[0]
 		pkgPath := c.Args().Slice()[1]
 		if err = fcli.AddDepl(
-			0, pallet, repoCache, deplPath, pkgPath, c.StringSlice("feature"), c.Bool("disabled"),
+			0, pallet, repoCache, deplName, pkgPath, c.StringSlice("feature"), c.Bool("disabled"),
 			c.Bool("force"),
 		); err != nil {
 			return err
@@ -88,6 +88,34 @@ func rmDeplAction(versions Versions) cli.ActionFunc {
 		}
 
 		if err = fcli.RemoveDepls(0, pallet, c.Args().Slice()); err != nil {
+			return err
+		}
+
+		fmt.Println("Done!")
+		return nil
+	}
+}
+
+// add-depl-feat
+
+func addDeplFeatAction(versions Versions) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		pallet, repoCache, _, err := processFullBaseArgs(c, true, true)
+		if err != nil {
+			return err
+		}
+		if err = fcli.CheckShallowCompatibility(
+			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			c.Bool("ignore-tool-version"),
+		); err != nil {
+			return err
+		}
+
+		deplName := c.Args().Slice()[0]
+		features := c.Args().Slice()[1:]
+		if err = fcli.AddDeplFeat(
+			0, pallet, repoCache, deplName, features, c.Bool("force"),
+		); err != nil {
 			return err
 		}
 

--- a/cmd/forklift/dev/plt/deployments.go
+++ b/cmd/forklift/dev/plt/deployments.go
@@ -123,3 +123,29 @@ func addDeplFeatAction(versions Versions) cli.ActionFunc {
 		return nil
 	}
 }
+
+// rm-depl-feat
+
+func rmDeplFeatAction(versions Versions) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		pallet, repoCache, _, err := processFullBaseArgs(c, true, true)
+		if err != nil {
+			return err
+		}
+		if err = fcli.CheckShallowCompatibility(
+			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			c.Bool("ignore-tool-version"),
+		); err != nil {
+			return err
+		}
+
+		deplName := c.Args().Slice()[0]
+		features := c.Args().Slice()[1:]
+		if err = fcli.RemoveDeplFeat(0, pallet, deplName, features); err != nil {
+			return err
+		}
+
+		fmt.Println("Done!")
+		return nil
+	}
+}

--- a/cmd/forklift/dev/plt/deployments.go
+++ b/cmd/forklift/dev/plt/deployments.go
@@ -1,6 +1,8 @@
 package plt
 
 import (
+	"fmt"
+
 	"github.com/urfave/cli/v2"
 
 	fcli "github.com/PlanktoScope/forklift/internal/app/forklift/cli"
@@ -39,4 +41,33 @@ func locateDeplPkgAction(c *cli.Context) error {
 
 	deplName := c.Args().First()
 	return fcli.PrintDeplPkgPath(0, pallet, cache, deplName, c.Bool("allow-disabled"))
+}
+
+// add-depl
+
+func addDeplAction(versions Versions) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		pallet, repoCache, _, err := processFullBaseArgs(c, true, true)
+		if err != nil {
+			return err
+		}
+		if err = fcli.CheckShallowCompatibility(
+			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			c.Bool("ignore-tool-version"),
+		); err != nil {
+			return err
+		}
+
+		deplPath := c.Args().Slice()[0]
+		pkgPath := c.Args().Slice()[1]
+		if err = fcli.AddDepl(
+			0, pallet, repoCache, deplPath, pkgPath, c.StringSlice("feature"), c.Bool("disabled"),
+			c.Bool("force"),
+		); err != nil {
+			return err
+		}
+
+		fmt.Println("Done!")
+		return nil
+	}
 }

--- a/cmd/forklift/dev/plt/repositories.go
+++ b/cmd/forklift/dev/plt/repositories.go
@@ -93,3 +93,27 @@ func addRepoAction(versions Versions) cli.ActionFunc {
 		return nil
 	}
 }
+
+// rm-repo
+
+func rmRepoAction(versions Versions) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		pallet, repoCache, _, err := processFullBaseArgs(c, false, false)
+		if err != nil {
+			return err
+		}
+		if err = fcli.CheckShallowCompatibility(
+			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			c.Bool("ignore-tool-version"),
+		); err != nil {
+			return err
+		}
+
+		if err = fcli.RemoveRepoRequirements(0, pallet, c.Args().Slice(), c.Bool("force")); err != nil {
+			return err
+		}
+
+		fmt.Println("Done!")
+		return nil
+	}
+}

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -333,7 +333,9 @@ func makeModifyRepoSubcmds(versions Versions) []*cli.Command {
 	}
 }
 
-func makeModifyDeplSubcmds(versions Versions) []*cli.Command {
+func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's hard to split more
+	versions Versions,
+) []*cli.Command {
 	const category = "Modify the pallet"
 	return []*cli.Command{
 		{
@@ -352,8 +354,9 @@ func makeModifyDeplSubcmds(versions Versions) []*cli.Command {
 					Usage: "Add a disabled package deployment",
 				},
 				&cli.BoolFlag{
-					Name:  "force",
-					Usage: "Add specified deployment even if package_path cannot be resolved",
+					Name: "force",
+					Usage: "Add specified deployment even if package_path cannot be resolved or the " +
+						"specified feature flags are not allowed for it",
 				},
 			},
 			Action: addDeplAction(versions),
@@ -365,6 +368,21 @@ func makeModifyDeplSubcmds(versions Versions) []*cli.Command {
 			Usage:     "Removes deployment from the pallet",
 			ArgsUsage: "deployment_name...",
 			Action:    rmDeplAction(versions),
+		},
+		{
+			Name:      "set-depl-pkg",
+			Aliases:   []string{"set-deployment-package"},
+			Category:  category,
+			Usage:     "Sets the path of the package to deploy in the specified deployment",
+			ArgsUsage: "deployment_name package_path...",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name: "force",
+					Usage: "Use the specified package path even if it cannot be resolved or makes the " +
+						"enabled feature flags invalid",
+				},
+			},
+			Action: setDeplPkgAction(versions),
 		},
 		{
 			Name:      "add-depl-feat",
@@ -389,7 +407,6 @@ func makeModifyDeplSubcmds(versions Versions) []*cli.Command {
 			ArgsUsage: "deployment_name feature_name...",
 			Action:    rmDeplFeatAction(versions),
 		},
-		// TODO: add a set-depl-pkg action
 		// TODO: add a set-depl-disabled action
 	}
 }

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -337,6 +337,21 @@ func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's 
 	versions Versions,
 ) []*cli.Command {
 	const category = "Modify the pallet"
+	baseFlags := []cli.Flag{
+		&cli.BoolFlag{
+			Name: "stage",
+			Usage: "Immediately stage the pallet after making the modification (this flag is ignored " +
+				"if --apply is set)",
+		},
+		&cli.BoolFlag{
+			Name:  "no-cache-img",
+			Usage: "Don't download container images (this flag is only used if --stage is set)",
+		},
+		&cli.BoolFlag{
+			Name:  "apply",
+			Usage: "Immediately apply the pallet after staging it",
+		},
+	}
 	return []*cli.Command{
 		{
 			Name:      "add-depl",
@@ -344,21 +359,24 @@ func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's 
 			Category:  category,
 			Usage:     "Adds (or re-adds) a package deployment to the pallet",
 			ArgsUsage: "deployment_name package_path...",
-			Flags: []cli.Flag{
-				&cli.StringSliceFlag{
-					Name:  "feature",
-					Usage: "Enable the specified feature flag in the package deployment",
+			Flags: slices.Concat(
+				[]cli.Flag{
+					&cli.StringSliceFlag{
+						Name:  "feature",
+						Usage: "Enable the specified feature flag in the package deployment",
+					},
+					&cli.BoolFlag{
+						Name:  "disabled",
+						Usage: "Add a disabled package deployment",
+					},
+					&cli.BoolFlag{
+						Name: "force",
+						Usage: "Add specified deployment even if package_path cannot be resolved or the " +
+							"specified feature flags are not allowed for it",
+					},
 				},
-				&cli.BoolFlag{
-					Name:  "disabled",
-					Usage: "Add a disabled package deployment",
-				},
-				&cli.BoolFlag{
-					Name: "force",
-					Usage: "Add specified deployment even if package_path cannot be resolved or the " +
-						"specified feature flags are not allowed for it",
-				},
-			},
+				baseFlags,
+			),
 			Action: addDeplAction(versions),
 		},
 		{
@@ -367,6 +385,7 @@ func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's 
 			Category:  category,
 			Usage:     "Removes deployment from the pallet",
 			ArgsUsage: "deployment_name...",
+			Flags:     baseFlags,
 			Action:    rmDeplAction(versions),
 		},
 		{
@@ -375,13 +394,16 @@ func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's 
 			Category:  category,
 			Usage:     "Sets the path of the package to deploy in the specified deployment",
 			ArgsUsage: "deployment_name package_path...",
-			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name: "force",
-					Usage: "Use the specified package path even if it cannot be resolved or makes the " +
-						"enabled feature flags invalid",
+			Flags: slices.Concat(
+				[]cli.Flag{
+					&cli.BoolFlag{
+						Name: "force",
+						Usage: "Use the specified package path even if it cannot be resolved or makes the " +
+							"enabled feature flags invalid",
+					},
 				},
-			},
+				baseFlags,
+			),
 			Action: setDeplPkgAction(versions),
 		},
 		{
@@ -390,13 +412,16 @@ func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's 
 			Category:  category,
 			Usage:     "Enables the specified package features in the specified deployment",
 			ArgsUsage: "deployment_name feature_name...",
-			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name: "force",
-					Usage: "Enable the specified feature flags even if they're not allowed by the  " +
-						"deployment's package",
+			Flags: slices.Concat(
+				[]cli.Flag{
+					&cli.BoolFlag{
+						Name: "force",
+						Usage: "Enable the specified feature flags even if they're not allowed by the  " +
+							"deployment's package",
+					},
 				},
-			},
+				baseFlags,
+			),
 			Action: addDeplFeatAction(versions),
 		},
 		{
@@ -405,6 +430,7 @@ func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's 
 			Category:  category,
 			Usage:     "Disables the specified package features in the specified deployment",
 			ArgsUsage: "deployment_name feature_name...",
+			Flags:     baseFlags,
 			Action:    rmDeplFeatAction(versions),
 		},
 		{
@@ -413,6 +439,7 @@ func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's 
 			Category:  category,
 			Usage:     "Disables the specified deployment",
 			ArgsUsage: "deployment_name",
+			Flags:     baseFlags,
 			Action:    setDeplDisabledAction(versions, true),
 		},
 		{
@@ -421,6 +448,7 @@ func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's 
 			Category:  category,
 			Usage:     "Enables the specified deployment",
 			ArgsUsage: "deployment_name",
+			Flags:     baseFlags,
 			Action:    setDeplDisabledAction(versions, false),
 		},
 	}

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -341,7 +341,7 @@ func makeModifyDeplSubcmds(versions Versions) []*cli.Command {
 			Aliases:   []string{"add-deployment"},
 			Category:  category,
 			Usage:     "Adds (or re-adds) a package deployment to the pallet",
-			ArgsUsage: "depl_path package_path...",
+			ArgsUsage: "deployment_name package_path...",
 			Flags: []cli.Flag{
 				&cli.StringSliceFlag{
 					Name:  "feature",
@@ -358,8 +358,17 @@ func makeModifyDeplSubcmds(versions Versions) []*cli.Command {
 			},
 			Action: addDeplAction(versions),
 		},
-		// TODO: add an rm-depl action
+		{
+			Name:      "rm-depl",
+			Aliases:   []string{"remove-deployment", "remove-deployments"},
+			Category:  category,
+			Usage:     "Removes deployment from the pallet",
+			ArgsUsage: "deployment_name...",
+			Action:    rmDeplAction(versions),
+		},
 		// TODO: add an add-depl-feat depl_path [feature]... action
 		// TODO: add an rm-depl-feat depl_path [feature]... action
+		// TODO: add a set-depl-pkg action
+		// TODO: add a set-depl-disabled action
 	}
 }

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -366,7 +366,21 @@ func makeModifyDeplSubcmds(versions Versions) []*cli.Command {
 			ArgsUsage: "deployment_name...",
 			Action:    rmDeplAction(versions),
 		},
-		// TODO: add an add-depl-feat depl_path [feature]... action
+		{
+			Name:      "add-depl-feat",
+			Aliases:   []string{"add-deployment-feature", "add-deployment-features"},
+			Category:  category,
+			Usage:     "Enables the specified package features in the specified deployment",
+			ArgsUsage: "deployment_name feature_name...",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name: "force",
+					Usage: "Enable the specified feature flags even if they're not allowed by the  " +
+						"deployment's package",
+				},
+			},
+			Action: addDeplFeatAction(versions),
+		},
 		// TODO: add an rm-depl-feat depl_path [feature]... action
 		// TODO: add a set-depl-pkg action
 		// TODO: add a set-depl-disabled action

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -212,52 +212,19 @@ func makeQueryDeplSubcmds(category string) []*cli.Command {
 
 func makeModifySubcmds(versions Versions) []*cli.Command {
 	const category = "Modify the pallet"
-	return append(
+	return slices.Concat(
 		makeModifyGitSubcmds(versions),
-		&cli.Command{
-			Name:     "rm",
-			Aliases:  []string{"remove"},
-			Category: category,
-			Usage:    "Removes the local pallet",
-			Action:   rmAction,
-		},
-		&cli.Command{
-			Name:     "add-repo",
-			Aliases:  []string{"add-repositories", "require-repo", "require-repositories"},
-			Category: category,
-			Usage: "Adds (or re-adds) repo requirements to the pallet, tracking specified versions " +
-				"or branches",
-			ArgsUsage: "[repo_path@version_query]...",
-			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name: "no-cache-req",
-					Usage: "Don't download repositories and pallets required by this pallet after adding " +
-						"the repo",
-				},
+		[]*cli.Command{
+			{
+				Name:     "rm",
+				Aliases:  []string{"remove"},
+				Category: category,
+				Usage:    "Removes the local pallet",
+				Action:   rmAction,
 			},
-			Action: addRepoAction(versions),
 		},
-		&cli.Command{
-			Name:      "rm-repo",
-			Aliases:   []string{"remove-repositories", "drop-repo", "drop-repositories"},
-			Category:  category,
-			Usage:     "Removes repo requirements from the pallet",
-			ArgsUsage: "repo_path...",
-			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name: "force",
-					Usage: "Remove specified repo requirements even if some declared package deployments " +
-						"depend on them",
-				},
-			},
-			Action: rmRepoAction(versions),
-		},
-	// TODO: add an rm-repo action with alias "drop-repo"; it should ensure no depls depend on it
-	// or delete those depls if `--force` is set
-	// TODO: add an add-depl --features=... depl_path package_path action
-	// TODO: add an rm-depl action
-	// TODO: add an add-depl-feat depl_path [feature]... action
-	// TODO: add an rm-depl-feat depl_path [feature]... action
+		makeModifyRepoSubcmds(versions),
+		makeModifyDeplSubcmds(versions),
 	)
 }
 
@@ -328,3 +295,71 @@ func makeModifyGitSubcmds(versions Versions) []*cli.Command {
 //			},
 //		},
 //	}
+
+func makeModifyRepoSubcmds(versions Versions) []*cli.Command {
+	const category = "Modify the pallet"
+	return []*cli.Command{
+		{
+			Name:     "add-repo",
+			Aliases:  []string{"add-repositories", "require-repo", "require-repositories"},
+			Category: category,
+			Usage: "Adds (or re-adds) repo requirements to the pallet, tracking specified versions " +
+				"or branches",
+			ArgsUsage: "[repo_path@version_query]...",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name: "no-cache-req",
+					Usage: "Don't download repositories and pallets required by this pallet after adding " +
+						"the repo",
+				},
+			},
+			Action: addRepoAction(versions),
+		},
+		{
+			Name:      "rm-repo",
+			Aliases:   []string{"remove-repositories", "drop-repo", "drop-repositories"},
+			Category:  category,
+			Usage:     "Removes repo requirements from the pallet",
+			ArgsUsage: "repo_path...",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name: "force",
+					Usage: "Remove specified repo requirements even if some declared package deployments " +
+						"depend on them",
+				},
+			},
+			Action: rmRepoAction(versions),
+		},
+	}
+}
+
+func makeModifyDeplSubcmds(versions Versions) []*cli.Command {
+	const category = "Modify the pallet"
+	return []*cli.Command{
+		{
+			Name:      "add-depl",
+			Aliases:   []string{"add-deployment"},
+			Category:  category,
+			Usage:     "Adds (or re-adds) a package deployment to the pallet",
+			ArgsUsage: "depl_path package_path...",
+			Flags: []cli.Flag{
+				&cli.StringSliceFlag{
+					Name:  "feature",
+					Usage: "Enable the specified feature flag in the package deployment",
+				},
+				&cli.BoolFlag{
+					Name:  "disabled",
+					Usage: "Add a disabled package deployment",
+				},
+				&cli.BoolFlag{
+					Name:  "force",
+					Usage: "Add specified deployment even if package_path cannot be resolved",
+				},
+			},
+			Action: addDeplAction(versions),
+		},
+		// TODO: add an rm-depl action
+		// TODO: add an add-depl-feat depl_path [feature]... action
+		// TODO: add an rm-depl-feat depl_path [feature]... action
+	}
+}

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -407,6 +407,21 @@ func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's 
 			ArgsUsage: "deployment_name feature_name...",
 			Action:    rmDeplFeatAction(versions),
 		},
-		// TODO: add a set-depl-disabled action
+		{
+			Name:      "set-depl-disabled",
+			Aliases:   []string{"set-deployment-disabled", "disable-depl", "disable-deployment"},
+			Category:  category,
+			Usage:     "Disables the specified deployment",
+			ArgsUsage: "deployment_name",
+			Action:    setDeplDisabledAction(versions, true),
+		},
+		{
+			Name:      "unset-depl-disabled",
+			Aliases:   []string{"unset-deployment-disabled", "enable-depl", "enable-deployment"},
+			Category:  category,
+			Usage:     "Enables the specified deployment",
+			ArgsUsage: "deployment_name",
+			Action:    setDeplDisabledAction(versions, false),
+		},
 	}
 }

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -237,6 +237,21 @@ func makeModifySubcmds(versions Versions) []*cli.Command {
 			},
 			Action: addRepoAction(versions),
 		},
+		&cli.Command{
+			Name:      "rm-repo",
+			Aliases:   []string{"remove-repositories", "drop-repo", "drop-repositories"},
+			Category:  category,
+			Usage:     "Removes repo requirements from the pallet",
+			ArgsUsage: "repo_path...",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name: "force",
+					Usage: "Remove specified repo requirements even if some declared package deployments " +
+						"depend on them",
+				},
+			},
+			Action: rmRepoAction(versions),
+		},
 	// TODO: add an rm-repo action with alias "drop-repo"; it should ensure no depls depend on it
 	// or delete those depls if `--force` is set
 	// TODO: add an add-depl --features=... depl_path package_path action

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -381,7 +381,14 @@ func makeModifyDeplSubcmds(versions Versions) []*cli.Command {
 			},
 			Action: addDeplFeatAction(versions),
 		},
-		// TODO: add an rm-depl-feat depl_path [feature]... action
+		{
+			Name:      "rm-depl-feat",
+			Aliases:   []string{"remove-deployment-feature", "remove-deployment-features"},
+			Category:  category,
+			Usage:     "Disables the specified package features in the specified deployment",
+			ArgsUsage: "deployment_name feature_name...",
+			Action:    rmDeplFeatAction(versions),
+		},
 		// TODO: add a set-depl-pkg action
 		// TODO: add a set-depl-disabled action
 	}

--- a/cmd/forklift/plt/deployments.go
+++ b/cmd/forklift/plt/deployments.go
@@ -175,3 +175,28 @@ func rmDeplFeatAction(versions Versions) cli.ActionFunc {
 		return nil
 	}
 }
+
+// set-depl-disabled
+
+func setDeplDisabledAction(versions Versions, setting bool) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		pallet, repoCache, _, err := processFullBaseArgs(c.String("workspace"), true)
+		if err != nil {
+			return err
+		}
+		if err = fcli.CheckShallowCompatibility(
+			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			c.Bool("ignore-tool-version"),
+		); err != nil {
+			return err
+		}
+
+		deplName := c.Args().Slice()[0]
+		if err = fcli.SetDeplDisabled(0, pallet, deplName, setting); err != nil {
+			return err
+		}
+
+		fmt.Println("Done!")
+		return nil
+	}
+}

--- a/cmd/forklift/plt/deployments.go
+++ b/cmd/forklift/plt/deployments.go
@@ -1,6 +1,8 @@
 package plt
 
 import (
+	"fmt"
+
 	"github.com/urfave/cli/v2"
 
 	fcli "github.com/PlanktoScope/forklift/internal/app/forklift/cli"
@@ -39,4 +41,33 @@ func locateDeplPkgAction(c *cli.Context) error {
 
 	deplName := c.Args().First()
 	return fcli.PrintDeplPkgPath(0, pallet, cache, deplName, c.Bool("allow-disabled"))
+}
+
+// add-depl
+
+func addDeplAction(versions Versions) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		pallet, repoCache, _, err := processFullBaseArgs(c.String("workspace"), true)
+		if err != nil {
+			return err
+		}
+		if err = fcli.CheckShallowCompatibility(
+			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			c.Bool("ignore-tool-version"),
+		); err != nil {
+			return err
+		}
+
+		deplPath := c.Args().Slice()[0]
+		pkgPath := c.Args().Slice()[1]
+		if err = fcli.AddDepl(
+			0, pallet, repoCache, deplPath, pkgPath, c.StringSlice("feature"), c.Bool("disabled"),
+			c.Bool("force"),
+		); err != nil {
+			return err
+		}
+
+		fmt.Println("Done!")
+		return nil
+	}
 }

--- a/cmd/forklift/plt/deployments.go
+++ b/cmd/forklift/plt/deployments.go
@@ -51,7 +51,7 @@ func addDeplAction(versions Versions) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		if err = fcli.CheckShallowCompatibility(
+		if err = fcli.CheckCompatibility(
 			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
@@ -67,8 +67,15 @@ func addDeplAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		fmt.Println("Done!")
-		return nil
+		switch {
+		case c.Bool("apply"):
+			return applyAction(versions)(c)
+		case c.Bool("stage"):
+			return stageAction(versions)(c)
+		default:
+			fmt.Println("Done!")
+			return nil
+		}
 	}
 }
 
@@ -80,7 +87,7 @@ func rmDeplAction(versions Versions) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		if err = fcli.CheckShallowCompatibility(
+		if err = fcli.CheckCompatibility(
 			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
@@ -91,8 +98,15 @@ func rmDeplAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		fmt.Println("Done!")
-		return nil
+		switch {
+		case c.Bool("apply"):
+			return applyAction(versions)(c)
+		case c.Bool("stage"):
+			return stageAction(versions)(c)
+		default:
+			fmt.Println("Done!")
+			return nil
+		}
 	}
 }
 
@@ -104,7 +118,7 @@ func setDeplPkgAction(versions Versions) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		if err = fcli.CheckShallowCompatibility(
+		if err = fcli.CheckCompatibility(
 			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
@@ -117,8 +131,15 @@ func setDeplPkgAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		fmt.Println("Done!")
-		return nil
+		switch {
+		case c.Bool("apply"):
+			return applyAction(versions)(c)
+		case c.Bool("stage"):
+			return stageAction(versions)(c)
+		default:
+			fmt.Println("Done!")
+			return nil
+		}
 	}
 }
 
@@ -130,7 +151,7 @@ func addDeplFeatAction(versions Versions) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		if err = fcli.CheckShallowCompatibility(
+		if err = fcli.CheckCompatibility(
 			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
@@ -145,8 +166,15 @@ func addDeplFeatAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		fmt.Println("Done!")
-		return nil
+		switch {
+		case c.Bool("apply"):
+			return applyAction(versions)(c)
+		case c.Bool("stage"):
+			return stageAction(versions)(c)
+		default:
+			fmt.Println("Done!")
+			return nil
+		}
 	}
 }
 
@@ -158,7 +186,7 @@ func rmDeplFeatAction(versions Versions) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		if err = fcli.CheckShallowCompatibility(
+		if err = fcli.CheckCompatibility(
 			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
@@ -171,8 +199,15 @@ func rmDeplFeatAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		fmt.Println("Done!")
-		return nil
+		switch {
+		case c.Bool("apply"):
+			return applyAction(versions)(c)
+		case c.Bool("stage"):
+			return stageAction(versions)(c)
+		default:
+			fmt.Println("Done!")
+			return nil
+		}
 	}
 }
 
@@ -184,7 +219,7 @@ func setDeplDisabledAction(versions Versions, setting bool) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		if err = fcli.CheckShallowCompatibility(
+		if err = fcli.CheckCompatibility(
 			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
@@ -196,7 +231,14 @@ func setDeplDisabledAction(versions Versions, setting bool) cli.ActionFunc {
 			return err
 		}
 
-		fmt.Println("Done!")
-		return nil
+		switch {
+		case c.Bool("apply"):
+			return applyAction(versions)(c)
+		case c.Bool("stage"):
+			return stageAction(versions)(c)
+		default:
+			fmt.Println("Done!")
+			return nil
+		}
 	}
 }

--- a/cmd/forklift/plt/deployments.go
+++ b/cmd/forklift/plt/deployments.go
@@ -96,6 +96,32 @@ func rmDeplAction(versions Versions) cli.ActionFunc {
 	}
 }
 
+// set-depl-pkg
+
+func setDeplPkgAction(versions Versions) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		pallet, repoCache, _, err := processFullBaseArgs(c.String("workspace"), true)
+		if err != nil {
+			return err
+		}
+		if err = fcli.CheckShallowCompatibility(
+			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			c.Bool("ignore-tool-version"),
+		); err != nil {
+			return err
+		}
+
+		deplName := c.Args().Slice()[0]
+		pkgPath := c.Args().Slice()[1]
+		if err = fcli.SetDeplPkg(0, pallet, repoCache, deplName, pkgPath, c.Bool("force")); err != nil {
+			return err
+		}
+
+		fmt.Println("Done!")
+		return nil
+	}
+}
+
 // add-depl-feat
 
 func addDeplFeatAction(versions Versions) cli.ActionFunc {

--- a/cmd/forklift/plt/deployments.go
+++ b/cmd/forklift/plt/deployments.go
@@ -71,3 +71,27 @@ func addDeplAction(versions Versions) cli.ActionFunc {
 		return nil
 	}
 }
+
+// rm-depl
+
+func rmDeplAction(versions Versions) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		pallet, repoCache, _, err := processFullBaseArgs(c.String("workspace"), false)
+		if err != nil {
+			return err
+		}
+		if err = fcli.CheckShallowCompatibility(
+			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			c.Bool("ignore-tool-version"),
+		); err != nil {
+			return err
+		}
+
+		if err = fcli.RemoveDepls(0, pallet, c.Args().Slice()); err != nil {
+			return err
+		}
+
+		fmt.Println("Done!")
+		return nil
+	}
+}

--- a/cmd/forklift/plt/deployments.go
+++ b/cmd/forklift/plt/deployments.go
@@ -123,3 +123,29 @@ func addDeplFeatAction(versions Versions) cli.ActionFunc {
 		return nil
 	}
 }
+
+// rm-depl-feat
+
+func rmDeplFeatAction(versions Versions) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		pallet, repoCache, _, err := processFullBaseArgs(c.String("workspace"), true)
+		if err != nil {
+			return err
+		}
+		if err = fcli.CheckShallowCompatibility(
+			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			c.Bool("ignore-tool-version"),
+		); err != nil {
+			return err
+		}
+
+		deplName := c.Args().Slice()[0]
+		features := c.Args().Slice()[1:]
+		if err = fcli.RemoveDeplFeat(0, pallet, deplName, features); err != nil {
+			return err
+		}
+
+		fmt.Println("Done!")
+		return nil
+	}
+}

--- a/cmd/forklift/plt/deployments.go
+++ b/cmd/forklift/plt/deployments.go
@@ -58,10 +58,10 @@ func addDeplAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		deplPath := c.Args().Slice()[0]
+		deplName := c.Args().Slice()[0]
 		pkgPath := c.Args().Slice()[1]
 		if err = fcli.AddDepl(
-			0, pallet, repoCache, deplPath, pkgPath, c.StringSlice("feature"), c.Bool("disabled"),
+			0, pallet, repoCache, deplName, pkgPath, c.StringSlice("feature"), c.Bool("disabled"),
 			c.Bool("force"),
 		); err != nil {
 			return err
@@ -88,6 +88,34 @@ func rmDeplAction(versions Versions) cli.ActionFunc {
 		}
 
 		if err = fcli.RemoveDepls(0, pallet, c.Args().Slice()); err != nil {
+			return err
+		}
+
+		fmt.Println("Done!")
+		return nil
+	}
+}
+
+// add-depl-feat
+
+func addDeplFeatAction(versions Versions) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		pallet, repoCache, _, err := processFullBaseArgs(c.String("workspace"), true)
+		if err != nil {
+			return err
+		}
+		if err = fcli.CheckShallowCompatibility(
+			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			c.Bool("ignore-tool-version"),
+		); err != nil {
+			return err
+		}
+
+		deplName := c.Args().Slice()[0]
+		features := c.Args().Slice()[1:]
+		if err = fcli.AddDeplFeat(
+			0, pallet, repoCache, deplName, features, c.Bool("force"),
+		); err != nil {
 			return err
 		}
 

--- a/cmd/forklift/plt/repositories.go
+++ b/cmd/forklift/plt/repositories.go
@@ -92,3 +92,27 @@ func addRepoAction(versions Versions) cli.ActionFunc {
 		return nil
 	}
 }
+
+// rm-repo
+
+func rmRepoAction(versions Versions) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		pallet, repoCache, _, err := processFullBaseArgs(c.String("workspace"), false)
+		if err != nil {
+			return err
+		}
+		if err = fcli.CheckShallowCompatibility(
+			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			c.Bool("ignore-tool-version"),
+		); err != nil {
+			return err
+		}
+
+		if err = fcli.RemoveRepoRequirements(0, pallet, c.Args().Slice(), c.Bool("force")); err != nil {
+			return err
+		}
+
+		fmt.Println("Done!")
+		return nil
+	}
+}

--- a/internal/app/forklift/cli/pallets-deployments.go
+++ b/internal/app/forklift/cli/pallets-deployments.go
@@ -351,3 +351,24 @@ func checkDepl(
 	}
 	return nil
 }
+
+// Remove
+
+func RemoveDepls(indent int, pallet *forklift.FSPallet, deplNames []string) error {
+	fmt.Printf("Removing package deployments from %s...\n", pallet.FS.Path())
+	for _, deplName := range deplNames {
+		deplsFS, err := pallet.GetDeplsFS()
+		if err != nil {
+			return err
+		}
+		deplPath := path.Join(deplsFS.Path(), fmt.Sprintf("%s.deploy.yml", deplName))
+		if err = os.RemoveAll(deplPath); err != nil {
+			return errors.Wrapf(
+				err, "couldn't remove package deployment %s, at %s", deplName, deplPath,
+			)
+		}
+	}
+	// TODO: maybe it'd be better to remove everything we can remove and then report errors at the
+	// end?
+	return nil
+}

--- a/internal/app/forklift/cli/pallets-deployments.go
+++ b/internal/app/forklift/cli/pallets-deployments.go
@@ -502,3 +502,26 @@ func RemoveDeplFeat(
 	}
 	return nil
 }
+
+// Set Disabled
+
+func SetDeplDisabled(indent int, pallet *forklift.FSPallet, deplName string, disabled bool) error {
+	if disabled {
+		IndentedPrintf(indent, "Disabling package deployment %s...\n", deplName)
+	} else {
+		IndentedPrintf(indent, "Enabling package deployment %s...\n", deplName)
+	}
+	depl, err := pallet.LoadDepl(deplName)
+	if err != nil {
+		return errors.Wrapf(
+			err, "couldn't find package deployment declaration %s in pallet %s",
+			deplName, pallet.FS.Path(),
+		)
+	}
+
+	depl.Def.Disabled = disabled
+	if err := writeDepl(pallet, depl); err != nil {
+		return errors.Wrapf(err, "couldn't save updated deployment declaration %s", depl.Name)
+	}
+	return nil
+}

--- a/internal/app/forklift/cli/pallets-repositories.go
+++ b/internal/app/forklift/cli/pallets-repositories.go
@@ -159,7 +159,7 @@ func AddRepoRequirements(
 		repoReqPath := path.Join(reqsReposFS.Path(), req.Path(), forklift.VersionLockDefFile)
 		marshaled, err := yaml.Marshal(req.VersionLock.Def)
 		if err != nil {
-			return errors.Wrapf(err, "couldn't marshal repo requirement from %s", repoReqPath)
+			return errors.Wrapf(err, "couldn't marshal repo requirement for %s", repoReqPath)
 		}
 		if err := forklift.EnsureExists(filepath.FromSlash(path.Dir(repoReqPath))); err != nil {
 			return errors.Wrapf(
@@ -254,6 +254,7 @@ func determineUsedRepoReqs(
 			if !force {
 				return nil, err
 			}
+			IndentedPrintf(indent, "Warning: %s\n", err.Error())
 		}
 		usedRepoReqs[fsRepoReq.Path()] = append(usedRepoReqs[fsRepoReq.Path()], depl.Name)
 	}

--- a/internal/app/forklift/pallets-requirements.go
+++ b/internal/app/forklift/pallets-requirements.go
@@ -130,11 +130,11 @@ func loadFSRepoReq(fsys core.PathedFS, repoPath string) (r *FSRepoReq, err error
 	return r, nil
 }
 
-// loadFSRepoReqContaining loads the FSRepoReq containing the specified sub-directory path in
+// LoadFSRepoReqContaining loads the FSRepoReq containing the specified sub-directory path in
 // the provided base filesystem.
 // The sub-directory path does not have to actually exist; however, it would usually be provided
 // as a package path.
-func loadFSRepoReqContaining(fsys core.PathedFS, subdirPath string) (*FSRepoReq, error) {
+func LoadFSRepoReqContaining(fsys core.PathedFS, subdirPath string) (*FSRepoReq, error) {
 	repoCandidatePath := subdirPath
 	for {
 		if repo, err := loadFSRepoReq(fsys, repoCandidatePath); err == nil {

--- a/internal/app/forklift/pallets.go
+++ b/internal/app/forklift/pallets.go
@@ -226,15 +226,15 @@ func (p *FSPallet) LoadPkgReq(pkgPath string) (r PkgReq, err error) {
 
 // FSPallet: Deployments
 
-// getDeplsFS returns the [fs.FS] in the pallet which contains package deployment
+// GetDeplsFS returns the [fs.FS] in the pallet which contains package deployment
 // configurations.
-func (p *FSPallet) getDeplsFS() (core.PathedFS, error) {
+func (p *FSPallet) GetDeplsFS() (core.PathedFS, error) {
 	return p.FS.Sub(DeplsDirName)
 }
 
 // LoadDepl loads the Depl with the specified name from the pallet.
 func (p *FSPallet) LoadDepl(name string) (depl Depl, err error) {
-	deplsFS, err := p.getDeplsFS()
+	deplsFS, err := p.GetDeplsFS()
 	if err != nil {
 		return Depl{}, errors.Wrap(
 			err, "couldn't open directory for package deployment configurations from pallet",
@@ -250,7 +250,7 @@ func (p *FSPallet) LoadDepl(name string) (depl Depl, err error) {
 // The search pattern should not include the file extension for deployment specification files - the
 // file extension will be appended to the search pattern by LoadDepls.
 func (p *FSPallet) LoadDepls(searchPattern string) ([]Depl, error) {
-	fsys, err := p.getDeplsFS()
+	fsys, err := p.GetDeplsFS()
 	if err != nil {
 		return nil, errors.Wrap(
 			err, "couldn't open directory for package deployment configurations from pallet",

--- a/internal/app/forklift/pallets.go
+++ b/internal/app/forklift/pallets.go
@@ -215,7 +215,7 @@ func (p *FSPallet) LoadPkgReq(pkgPath string) (r PkgReq, err error) {
 	if err != nil {
 		return PkgReq{}, errors.Wrap(err, "couldn't open directory for repo requirements from pallet")
 	}
-	fsRepoReq, err := loadFSRepoReqContaining(reposFS, pkgPath)
+	fsRepoReq, err := LoadFSRepoReqContaining(reposFS, pkgPath)
 	if err != nil {
 		return PkgReq{}, errors.Wrapf(err, "couldn't find repo providing package %s in pallet", pkgPath)
 	}

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,8 +1,6 @@
 module github.com/PlanktoScope/forklift/tools
 
-go 1.21
-
-toolchain go1.21.2
+go 1.22
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
This PR adds a variety of `[dev] plt` subcommands to modify the files within the `deployments` directory of the pallet, so that a text editor does not need to be used to modify the declarations of package deployments.