### PR TITLE
Allow the entire filetree of a downloaded archive or OCI image to be exported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.7.2-alpha.4 - 2024-05-15
+
+### Fixed
+
+- (cli) Allowed the entire filetree in downloaded archives and OCI images to be used as a source for export, by specifying '/' or '.' as the source path.
+- (spec) Clarified that, for the `source` field of file export resources with `source-type` `http-archive` and `oci-image`, a value of `/` or `.` will be interpreted as specifying that all files in the archive or OCI image will be exported.
 
 ## 0.7.2-alpha.3 - 2024-05-15
 

--- a/docs/specs/00-package.md
+++ b/docs/specs/00-package.md
@@ -1314,9 +1314,9 @@ A file export object consists of the following fields:
 
 - For the `http` source type, the source path is ignored.
 
-- For the `http-archive` source type, the source path is interpreted as being relative to the root of the archive.
+- For the `http-archive` source type, the source path is interpreted as being relative to the root of the archive. If the source path is "." or "/", all files in the archive will be exported.
 
-- For the `oci-image` source type, the source path is interpreted as being relative to the root of the container image's filesystem.
+- For the `oci-image` source type, the source path is interpreted as being relative to the root of the container image's filesystem. If the source path is "." or "/", all files in the container image will be exported.
 
 - Example:
   

--- a/internal/app/forklift/bundles.go
+++ b/internal/app/forklift/bundles.go
@@ -366,7 +366,9 @@ func determineFileType(
 }
 
 func extractFile(tarReader *tar.Reader, sourcePath string, exportPath string) error {
-	// var sourcefile *fs.File
+	if sourcePath == "/" || sourcePath == "." {
+		sourcePath = ""
+	}
 	fmt.Printf("exporting into %s...\n", exportPath)
 	for {
 		header, err := tarReader.Next()
@@ -376,7 +378,8 @@ func extractFile(tarReader *tar.Reader, sourcePath string, exportPath string) er
 		if err != nil {
 			return err
 		}
-		if sourcePath != header.Name && !strings.HasPrefix(header.Name, sourcePath+"/") {
+		if sourcePath != "" && sourcePath != header.Name &&
+			!strings.HasPrefix(header.Name, sourcePath+"/") {
 			continue
 		}
 		targetPath := path.Join(exportPath, strings.TrimPrefix(header.Name, sourcePath))


### PR DESCRIPTION
This PR fixes a bug in the interpretation of the `source` path for file exports with `source-type` `http-archive` and `oci-image`, so that the entire contents of the archive or image tarball can be exported by specifying a `source` path of `/` or `.`. This is needed for https://github.com/ethanjli/ublue-forklift-sysext-demo/pull/6