### PR TITLE
Fix export of symlinks from archives & OCI images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.2-alpha.5 - 2024-05-15
+
+### Fixed
+
+- (cli) Symlinks are now handled correctly when they need to be exported from downloaded archives or OCI images.
+
 ## 0.7.2-alpha.4 - 2024-05-15
 
 ### Fixed


### PR DESCRIPTION
This PR fixes the error which occurs when `forklift` attempts to export a symlink from a downloaded tar archive or a downloaded OCI image tarball.