### PR TITLE
Fix export of hardlinks from archives, and auto-download files needed for staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.7.2-alpha.6 - 2024-05-16
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- (cli) Hard links should now be handled correctly when they need to be exported from downloaded archives or OCI images.
+
 ## 0.7.2-alpha.5 - 2024-05-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - (cli) Hard links should now be handled correctly when they need to be exported from downloaded archives or OCI images.
+- (cli) Staging a pallet now includes the download of any missing files, OCI container images, and repos required for staging.
 
 ## 0.7.2-alpha.5 - 2024-05-15
 

--- a/internal/app/forklift/cli/pallets-staging.go
+++ b/internal/app/forklift/cli/pallets-staging.go
@@ -17,6 +17,12 @@ func StagePallet(
 	exportPath, toolVersion, bundleMinVersion, newBundleForkliftVersion string,
 	skipImageCaching, parallel, ignoreToolVersion bool,
 ) (index int, err error) {
+	if err = CacheStagingRequirements(
+		pallet, repoCache.Path(), repoCache, dlCache, false, parallel,
+	); err != nil {
+		return 0, errors.Wrap(err, "couldn't cache requirements for staging the pallet")
+	}
+
 	index, err = stageStore.AllocateNew()
 	if err != nil {
 		return 0, errors.Wrap(err, "couldn't allocate a directory for staging")


### PR DESCRIPTION
This PR follows up on #209 by also adding proper handling of hardlinks in archives & OCI images for file exports. This fix is needed for https://github.com/ethanjli/ublue-forklift-sysext-demo/pull/8 .

This PR also fixes missing behavior when staging a pallet, so that file downloads needed for pallet staging are now automatically triggered as needed.