### PR TITLE
Try using the zig toolchain for CGo builds for macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,9 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Prepare Go package cache for cross-compilation
         run: |
           chmod +w -R ~/go/pkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Release test
         env:
           MACOS_SDK: /tmp/MacOSX13.3.sdk
-          ZIG_CC_COMMAND: /tmp/zig-cc.sh
+          ZIG_CC_COMMAND: zig cc
           ZIG_GLOBAL_CACHE_DIR: ${{ steps.zig-build-cache.outputs.destination }}
           ZIG_LOCAL_CACHE_DIR: ${{ steps.zig-build-cache.outputs.destination }}
         run: make build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,8 +69,7 @@ jobs:
         id: zig-build-cache
         run: |
           destination="$HOME/zig-build"
-          sudo mkdir -p "$destination"
-          sudo chown $USER "$destination"
+          mkdir -p "$destination"
           echo "destination=$destination" >> $GITHUB_OUTPUT
 
       - name: Set up caching for the Zig build cache
@@ -88,8 +87,6 @@ jobs:
       - name: Prepare macOS SDK for cross-compilation
         run: |
           cp zig-cc.sh /tmp/zig-cc.sh
-          chmod a+x /tmp/zig-cc.sh
-          sudo chown $USER -R /opt/hostedtoolcache/go
           tar -xJf /tmp/MacOSX13.3.sdk.tar.xz -C /tmp
 
       - name: Release test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,15 +64,18 @@ jobs:
         uses: goto-bus-stop/setup-zig@v2
 
       - name: Set up the zig build cache
+        id: zig-build-cache
         run: |
-          sudo mkdir -p ~/zig-build
-          sudo chown $USER ~/zig-build
+          destination="$HOME/zig-build"
+          sudo mkdir -p "$destination"
+          sudo chown $USER "$destination"
+          echo "destination=$destination" >> $GITHUB_OUTPUT
 
       - name: Set up caching for the Zig build cache
         uses: Hanaasagi/zig-action-cache@v1.1.5
         env:
-          ZIG_GLOBAL_CACHE_DIR: ~/zig-build
-          ZIG_LOCAL_CACHE_DIR: ~/zig-build
+          ZIG_GLOBAL_CACHE_DIR: ${{ steps.zig-build-cache.outputs.destination }}
+          ZIG_LOCAL_CACHE_DIR: ${{ steps.zig-build-cache.outputs.destination }}
 
       - name: Download macOS SDK for cross-compilation
         uses: ethanjli/cached-download-action@v0.1.2
@@ -91,6 +94,6 @@ jobs:
         env:
           MACOS_SDK: /tmp/MacOSX13.3.sdk
           ZIG_CC_COMMAND: /tmp/zig-cc.sh
-          ZIG_GLOBAL_CACHE_DIR: ~/zig-build
-          ZIG_LOCAL_CACHE_DIR: ~/zig-build
+          ZIG_GLOBAL_CACHE_DIR: ${{ steps.zig-build-cache.outputs.destination }}
+          ZIG_LOCAL_CACHE_DIR: ${{ steps.zig-build-cache.outputs.destination }}
         run: make build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,8 +85,6 @@ jobs:
           cp zig-cc.sh /tmp/zig-cc.sh
           chmod a+x /tmp/zig-cc.sh
           sudo chown $USER -R /opt/hostedtoolcache/go
-          ls -l /opt/hostedtoolcache/go/1.22.3/x64/pkg/mod/github.com/fsnotify
-          ls -l /opt/hostedtoolcache/go/1.22.3/x64/pkg/mod/github.com/fsnotify/fsevents@*
           tar -xJf /tmp/MacOSX13.3.sdk.tar.xz -C /tmp
 
       - name: Release test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,6 @@ jobs:
 
       - name: Prepare macOS SDK for cross-compilation
         run: |
-          cp zig-cc.sh /tmp/zig-cc.sh
           tar -xJf /tmp/MacOSX13.3.sdk.tar.xz -C /tmp
 
       - name: Release test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,14 +65,14 @@ jobs:
 
       - name: Set up the zig build cache
         run: |
-          sudo mkdir -p zig-build
+          sudo mkdir -p ~/zig-build
           sudo chown $USER zig-build
 
       - name: Set up caching for the Zig build cache
         uses: Hanaasagi/zig-action-cache@v1.1.5
         env:
-          ZIG_GLOBAL_CACHE_DIR: /tmp/zig-build
-          ZIG_LOCAL_CACHE_DIR: /tmp/zig-build
+          ZIG_GLOBAL_CACHE_DIR: ~/zig-build
+          ZIG_LOCAL_CACHE_DIR: ~/zig-build
 
       - name: Download macOS SDK for cross-compilation
         uses: ethanjli/cached-download-action@v0.1.2
@@ -91,6 +91,6 @@ jobs:
         env:
           MACOS_SDK: /tmp/MacOSX13.3.sdk
           ZIG_CC_COMMAND: /tmp/zig-cc.sh
-          ZIG_GLOBAL_CACHE_DIR: /tmp/zig-build
-          ZIG_LOCAL_CACHE_DIR: /tmp/zig-build
+          ZIG_GLOBAL_CACHE_DIR: ~/zig-build
+          ZIG_LOCAL_CACHE_DIR: ~/zig-build
         run: make build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,10 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Prepare Go package cache for cross-compilation
+        run: |
+          chmod +w -R ~/go/pkg
+
       - name: Set up Zig for CGo cross-compilation
         uses: goto-bus-stop/setup-zig@v2
         with:
@@ -92,7 +96,7 @@ jobs:
       - name: Release test
         env:
           MACOS_SDK: /tmp/MacOSX13.3.sdk
-          ZIG_CC_COMMAND: /tmp/zig-cc.sh
+          ZIG_CC_COMMAND: zig cc
           ZIG_GLOBAL_CACHE_DIR: ${{ steps.zig-build-cache.outputs.destination }}
           ZIG_LOCAL_CACHE_DIR: ${{ steps.zig-build-cache.outputs.destination }}
         run: make build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,12 +36,6 @@ jobs:
           name: coverage-${{ matrix.os }}
           path: coverage.*
 
-      - name: Upload dist
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist-${{ matrix.os }}
-          path: dist
-
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.4.1
         with:
@@ -95,7 +89,12 @@ jobs:
       - name: Release test
         env:
           MACOS_SDK: /tmp/MacOSX13.3.sdk
-          ZIG_CC_COMMAND: zig cc
           ZIG_GLOBAL_CACHE_DIR: ${{ steps.zig-build-cache.outputs.destination }}
           ZIG_LOCAL_CACHE_DIR: ${{ steps.zig-build-cache.outputs.destination }}
         run: make build
+
+      - name: Upload dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.os }}
+          path: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,8 @@ jobs:
         run: |
           cp zig-cc.sh /tmp/zig-cc.sh
           chmod a+x /tmp/zig-cc.sh
+          ls -l /opt/hostedtoolcache/go/1.22.3/x64=/_/GOROOT
+          sudo chown $USER -R /opt/hostedtoolcache/go
           tar -xJf /tmp/MacOSX13.3.sdk.tar.xz -C /tmp
 
       - name: Release test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Set up the zig build cache
         run: |
           sudo mkdir -p ~/zig-build
-          sudo chown $USER zig-build
+          sudo chown $USER ~/zig-build
 
       - name: Set up caching for the Zig build cache
         uses: Hanaasagi/zig-action-cache@v1.1.5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,8 @@ jobs:
           cp zig-cc.sh /tmp/zig-cc.sh
           chmod a+x /tmp/zig-cc.sh
           sudo chown $USER -R /opt/hostedtoolcache/go
-          ls -l /opt/hostedtoolcache/go/1.22.3/x64
+          ls -l /opt/hostedtoolcache/go/1.22.3/x64/pkg/mod/github.com/fsnotify
+          ls -l /opt/hostedtoolcache/go/1.22.3/x64/pkg/mod/github.com/fsnotify/fsevents@*
           tar -xJf /tmp/MacOSX13.3.sdk.tar.xz -C /tmp
 
       - name: Release test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           cp zig-cc.sh /tmp/zig-cc.sh
           chmod a+x /tmp/zig-cc.sh
-          ls -l /opt/hostedtoolcache/go/1.22.3/x64=/_/GOROOT
+          ls -l /opt/hostedtoolcache/go/
           sudo chown $USER -R /opt/hostedtoolcache/go
           tar -xJf /tmp/MacOSX13.3.sdk.tar.xz -C /tmp
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,8 +84,8 @@ jobs:
         run: |
           cp zig-cc.sh /tmp/zig-cc.sh
           chmod a+x /tmp/zig-cc.sh
-          ls -l /opt/hostedtoolcache/go/
           sudo chown $USER -R /opt/hostedtoolcache/go
+          ls -l /opt/hostedtoolcache/go/1.22.3/x64
           tar -xJf /tmp/MacOSX13.3.sdk.tar.xz -C /tmp
 
       - name: Release test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,8 @@ jobs:
 
       - name: Set up Zig for CGo cross-compilation
         uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.12.0
 
       - name: Set up the zig build cache
         id: zig-build-cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Release test
         env:
           MACOS_SDK: /tmp/MacOSX13.3.sdk
-          ZIG_CC_COMMAND: zig cc
+          ZIG_CC_COMMAND: /tmp/zig-cc.sh
           ZIG_GLOBAL_CACHE_DIR: ${{ steps.zig-build-cache.outputs.destination }}
           ZIG_LOCAL_CACHE_DIR: ${{ steps.zig-build-cache.outputs.destination }}
         run: make build

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ builds:
     - goos: darwin
       goarch: amd64
       goamd64: v1
-      ldflags: -w -v
+      ldflags: -s -w -v -linkmode internal
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)
@@ -39,7 +39,7 @@ builds:
         - ZIG_GLOBAL_CACHE_DIR={{ .Env.ZIG_GLOBAL_CACHE_DIR }}
         - ZIG_LOCAL_CACHE_DIR={{ .Env.ZIG_LOCAL_CACHE_DIR }}
         - >-
-            CC={{ .Env.ZIG_CC_COMMAND }}
+            CC=zig cc
               -target x86_64-macos
               --sysroot={{ .Env.MACOS_SDK }}
               -I{{ .Env.MACOS_SDK }}/usr/include -L{{ .Env.MACOS_SDK }}/usr/lib
@@ -49,7 +49,7 @@ builds:
               -Wno-macro-redefined
               -Wno-deprecated-declarations
         - >-
-            CXX={{ .Env.ZIG_CC_COMMAND }}
+            CXX=zig cc
               -target x86_64-macos
               --sysroot={{ .Env.MACOS_SDK }}
               -I{{ .Env.MACOS_SDK }}/usr/include -L{{ .Env.MACOS_SDK }}/usr/lib
@@ -60,7 +60,7 @@ builds:
               -Wno-deprecated-declarations
     - goos: darwin
       goarch: arm64
-      ldflags: -w -v
+      ldflags: -s -w -v -linkmode internal
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)
@@ -70,7 +70,7 @@ builds:
         - ZIG_GLOBAL_CACHE_DIR={{ .Env.ZIG_GLOBAL_CACHE_DIR }}
         - ZIG_LOCAL_CACHE_DIR={{ .Env.ZIG_LOCAL_CACHE_DIR }}
         - >-
-            CC={{ .Env.ZIG_CC_COMMAND }}
+            CC=zig cc
               -target aarch64-macos
               --sysroot={{ .Env.MACOS_SDK }}
               -I{{ .Env.MACOS_SDK }}/usr/include -L{{ .Env.MACOS_SDK }}/usr/lib
@@ -80,7 +80,7 @@ builds:
               -Wno-macro-redefined
               -Wno-deprecated-declarations
         - >-
-            CXX={{ .Env.ZIG_CC_COMMAND }}
+            CXX=zig cc
               -target aarch64-macos
               --sysroot={{ .Env.MACOS_SDK }}
               -I{{ .Env.MACOS_SDK }}/usr/include -L{{ .Env.MACOS_SDK }}/usr/lib

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,9 +30,6 @@ builds:
       goarch: amd64
       goamd64: v1
       buildmode: c-archive
-      flags:
-        - -v
-        - -x
       ldflags: -w -v -extldflags "--verbose"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
@@ -65,9 +62,6 @@ builds:
     - goos: darwin
       goarch: arm64
       buildmode: c-archive
-      flags:
-        - -v
-        - -x
       ldflags: -w -v -extldflags "--verbose"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,7 @@ builds:
     - goos: darwin
       goarch: amd64
       goamd64: v1
-      ldflags: -s -w -extldflags "--help --foobar"
+      ldflags: -s -w -extldflags "-###"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,6 +49,7 @@ builds:
               -Wno-expansion-to-defined
               -Wno-macro-redefined
               -Wno-deprecated-declarations
+              -Wl,-x
         - >-
             CXX=zig cc
               -target x86_64-macos
@@ -59,6 +60,7 @@ builds:
               -Wno-expansion-to-defined
               -Wno-macro-redefinedinternal
               -Wno-deprecated-declarations
+              -Wl,-x
     - goos: darwin
       goarch: arm64
       buildmode: pie

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,7 @@ builds:
     - goos: darwin
       goarch: amd64
       goamd64: v1
-      ldflags: -s -w --foobar
+      ldflags: -s -w -extldflags "--help --foobar"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)
@@ -59,7 +59,7 @@ builds:
               -Wno-deprecated-declarations
     - goos: darwin
       goarch: arm64
-      ldflags: -s -w --foobar
+      ldflags: -s -w -extldflags "--help --foobar"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,10 +6,6 @@ builds:
 - id: forklift
   main: ./cmd/forklift
   binary: forklift
-  buildmode: c-archive
-  flags:
-    - -v
-    - -x
   ldflags:
     - >-
         -s
@@ -33,6 +29,10 @@ builds:
     - goos: darwin
       goarch: amd64
       goamd64: v1
+      buildmode: c-archive
+      flags:
+        - -v
+        - -x
       ldflags: -w -v -extldflags "--verbose"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
@@ -64,6 +64,10 @@ builds:
               -Wno-deprecated-declarations
     - goos: darwin
       goarch: arm64
+      buildmode: c-archive
+      flags:
+        - -v
+        - -x
       ldflags: -w -v -extldflags "--verbose"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,7 @@ builds:
     - >-
         -s
         -w
+        -v
         -X main.buildVersion={{.Version}}
         -X main.buildCommit={{.Commit}}
         -X main.buildCommitTimestamp={{.CommitTimestamp}}
@@ -28,7 +29,7 @@ builds:
     - goos: darwin
       goarch: amd64
       goamd64: v1
-      ldflags: -s -w -v -extld "clang"
+      ldflags: -w -v
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)
@@ -59,7 +60,7 @@ builds:
               -Wno-deprecated-declarations
     - goos: darwin
       goarch: arm64
-      ldflags: -s -w -v -extld "clang"
+      ldflags: -w -v
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ builds:
     - goos: darwin
       goarch: amd64
       goamd64: v1
-      ldflags: -s -w -v -linkmode auto -extldflags "--verbose"
+      ldflags: -w -v -extldflags "--verbose"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)
@@ -56,11 +56,11 @@ builds:
               -F{{ .Env.MACOS_SDK }}/System/Library/Frameworks -framework CoreFoundation
               -Wno-nullability-completeness
               -Wno-expansion-to-defined
-              -Wno-macro-redefined
+              -Wno-macro-redefinedinternal
               -Wno-deprecated-declarations
     - goos: darwin
       goarch: arm64
-      ldflags: -s -w -v -linkmode auto -extldflags "--verbose"
+      ldflags: -w -v -extldflags "--verbose"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,7 @@ builds:
     - goos: darwin
       goarch: amd64
       goamd64: v1
-      ldflags: -s -w -v -linkmode external -extldflags "--help --foobar"
+      ldflags: -s -w -v -extldflags "-###"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)
@@ -59,7 +59,7 @@ builds:
               -Wno-deprecated-declarations
     - goos: darwin
       goarch: arm64
-      ldflags: -s -w -v -linkmode external -extldflags "--help --foobar"
+      ldflags: -s -w -v -extldflags "-###"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ builds:
     - goos: darwin
       goarch: amd64
       goamd64: v1
-      buildmode: exe
+      buildmode: pie
       ldflags: -w -v -extldflags "--verbose"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
@@ -61,7 +61,7 @@ builds:
               -Wno-deprecated-declarations
     - goos: darwin
       goarch: arm64
-      buildmode: exe
+      buildmode: pie
       ldflags: -w -v -extldflags "--verbose"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ builds:
     - goos: darwin
       goarch: amd64
       goamd64: v1
-      ldflags: -s -w -v -linkmode internal
+      ldflags: -s -w -v -linkmode auto -extldflags "--verbose"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)
@@ -60,7 +60,7 @@ builds:
               -Wno-deprecated-declarations
     - goos: darwin
       goarch: arm64
-      ldflags: -s -w -v -linkmode internal
+      ldflags: -s -w -v -linkmode auto -extldflags "--verbose"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,7 @@ builds:
     - goos: darwin
       goarch: amd64
       goamd64: v1
-      ldflags: -s -w -extldflags "-###"
+      ldflags: -s -w -v -linkmode external -extldflags "--help --foobar"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)
@@ -59,7 +59,7 @@ builds:
               -Wno-deprecated-declarations
     - goos: darwin
       goarch: arm64
-      ldflags: -s -w -extldflags "--help --foobar"
+      ldflags: -s -w -v -linkmode external -extldflags "--help --foobar"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,10 @@ builds:
 - id: forklift
   main: ./cmd/forklift
   binary: forklift
+  buildmode: c-archive
+  flags:
+    - -v
+    - -x
   ldflags:
     - >-
         -s

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,10 +40,8 @@ builds:
             CC={{ .Env.ZIG_CC_COMMAND }}
               -target x86_64-macos
               --sysroot={{ .Env.MACOS_SDK }}
-              -I{{ .Env.MACOS_SDK }}/usr/include
-              -L{{ .Env.MACOS_SDK }}/usr/lib
-              -F{{ .Env.MACOS_SDK }}/System/Library/Frameworks
-              -framework CoreFoundation
+              -I{{ .Env.MACOS_SDK }}/usr/include -L{{ .Env.MACOS_SDK }}/usr/lib
+              -F{{ .Env.MACOS_SDK }}/System/Library/Frameworks -framework CoreFoundation
               -Wno-nullability-completeness
               -Wno-expansion-to-defined
               -Wno-macro-redefined
@@ -52,10 +50,8 @@ builds:
             CXX={{ .Env.ZIG_CC_COMMAND }}
               -target x86_64-macos
               --sysroot={{ .Env.MACOS_SDK }}
-              -I{{ .Env.MACOS_SDK }}/usr/include
-              -L{{ .Env.MACOS_SDK }}/usr/lib
-              -F{{ .Env.MACOS_SDK }}/System/Library/Frameworks
-              -framework CoreFoundation
+              -I{{ .Env.MACOS_SDK }}/usr/include -L{{ .Env.MACOS_SDK }}/usr/lib
+              -F{{ .Env.MACOS_SDK }}/System/Library/Frameworks -framework CoreFoundation
               -Wno-nullability-completeness
               -Wno-expansion-to-defined
               -Wno-macro-redefined
@@ -74,10 +70,8 @@ builds:
             CC={{ .Env.ZIG_CC_COMMAND }}
               -target aarch64-macos
               --sysroot={{ .Env.MACOS_SDK }}
-              -I{{ .Env.MACOS_SDK }}/usr/include
-              -L{{ .Env.MACOS_SDK }}/usr/lib
-              -F{{ .Env.MACOS_SDK }}/System/Library/Frameworks
-              -framework CoreFoundation
+              -I{{ .Env.MACOS_SDK }}/usr/include -L{{ .Env.MACOS_SDK }}/usr/lib
+              -F{{ .Env.MACOS_SDK }}/System/Library/Frameworks -framework CoreFoundation
               -Wno-nullability-completeness
               -Wno-expansion-to-defined
               -Wno-macro-redefined
@@ -86,10 +80,8 @@ builds:
             CXX={{ .Env.ZIG_CC_COMMAND }}
               -target aarch64-macos
               --sysroot={{ .Env.MACOS_SDK }}
-              -I{{ .Env.MACOS_SDK }}/usr/include
-              -L{{ .Env.MACOS_SDK }}/usr/lib
-              -F{{ .Env.MACOS_SDK }}/System/Library/Frameworks
-              -framework CoreFoundation
+              -I{{ .Env.MACOS_SDK }}/usr/include -L{{ .Env.MACOS_SDK }}/usr/lib
+              -F{{ .Env.MACOS_SDK }}/System/Library/Frameworks -framework CoreFoundation
               -Wno-nullability-completeness
               -Wno-expansion-to-defined
               -Wno-macro-redefined

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,7 @@ builds:
               -Wno-expansion-to-defined
               -Wno-macro-redefined
               -Wno-deprecated-declarations
-              -Wl,-x
+              -Wl,--discard-all
         - >-
             CXX=zig cc
               -target x86_64-macos
@@ -60,7 +60,7 @@ builds:
               -Wno-expansion-to-defined
               -Wno-macro-redefinedinternal
               -Wno-deprecated-declarations
-              -Wl,-x
+              -Wl,--discard-all
     - goos: darwin
       goarch: arm64
       buildmode: pie
@@ -83,6 +83,7 @@ builds:
               -Wno-expansion-to-defined
               -Wno-macro-redefined
               -Wno-deprecated-declarations
+              -Wl,--discard-all
         - >-
             CXX=zig cc
               -target aarch64-macos
@@ -93,6 +94,7 @@ builds:
               -Wno-expansion-to-defined
               -Wno-macro-redefined
               -Wno-deprecated-declarations
+              -Wl,--discard-all
 
 archives:
   - id: forklift

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,6 +47,7 @@ builds:
               -Wno-nullability-completeness
               -Wno-expansion-to-defined
               -Wno-macro-redefined
+              -Wno-deprecated-declarations
         - >-
             CXX={{ .Env.ZIG_CC_COMMAND }}
               -target x86_64-macos
@@ -58,6 +59,7 @@ builds:
               -Wno-nullability-completeness
               -Wno-expansion-to-defined
               -Wno-macro-redefined
+              -Wno-deprecated-declarations
     - goos: darwin
       goarch: arm64
       env:
@@ -79,6 +81,7 @@ builds:
               -Wno-nullability-completeness
               -Wno-expansion-to-defined
               -Wno-macro-redefined
+              -Wno-deprecated-declarations
         - >-
             CXX={{ .Env.ZIG_CC_COMMAND }}
               -target aarch64-macos
@@ -90,6 +93,7 @@ builds:
               -Wno-nullability-completeness
               -Wno-expansion-to-defined
               -Wno-macro-redefined
+              -Wno-deprecated-declarations
 
 archives:
   - id: forklift

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,13 +8,13 @@ builds:
   binary: forklift
   ldflags:
     - >-
-      -s
-      -w
-      -X main.buildVersion={{.Version}}
-      -X main.buildCommit={{.Commit}}
-      -X main.buildCommitTimestamp={{.CommitTimestamp}}
-      -X main.buildSummary={{.Summary}}
-      -X main.builtBy=goreleaser
+        -s
+        -w
+        -X main.buildVersion={{.Version}}
+        -X main.buildCommit={{.Commit}}
+        -X main.buildCommitTimestamp={{.CommitTimestamp}}
+        -X main.buildSummary={{.Summary}}
+        -X main.builtBy=goreleaser
   env:
     - CGO_ENABLED=0
   targets:
@@ -28,6 +28,7 @@ builds:
     - goos: darwin
       goarch: amd64
       goamd64: v1
+      ldflags: -s -w --foobar
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)
@@ -58,6 +59,7 @@ builds:
               -Wno-deprecated-declarations
     - goos: darwin
       goarch: arm64
+      ldflags: -s -w --foobar
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,7 @@ builds:
     - goos: darwin
       goarch: amd64
       goamd64: v1
-      ldflags: -s -w -v -extld "clang" -extldflags "-###"
+      ldflags: -s -w -v -extld "clang"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)
@@ -59,7 +59,7 @@ builds:
               -Wno-deprecated-declarations
     - goos: darwin
       goarch: arm64
-      ldflags: -s -w -v -extld "clang" -extldflags "-###"
+      ldflags: -s -w -v -extld "clang"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,7 @@ builds:
     - goos: darwin
       goarch: amd64
       goamd64: v1
-      ldflags: -s -w -v -extldflags "-###"
+      ldflags: -s -w -v -extld "clang" -extldflags "-###"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)
@@ -59,7 +59,7 @@ builds:
               -Wno-deprecated-declarations
     - goos: darwin
       goarch: arm64
-      ldflags: -s -w -v -extldflags "-###"
+      ldflags: -s -w -v -extld "clang" -extldflags "-###"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
         # (though Forklift doesn't actually need it)

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ builds:
     - goos: darwin
       goarch: amd64
       goamd64: v1
-      buildmode: c-archive
+      buildmode: exe
       ldflags: -w -v -extldflags "--verbose"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI
@@ -61,7 +61,7 @@ builds:
               -Wno-deprecated-declarations
     - goos: darwin
       goarch: arm64
-      buildmode: c-archive
+      buildmode: exe
       ldflags: -w -v -extldflags "--verbose"
       env:
         # CGo is needed for github.com/fsnotify/fsevents, which is needed by the Docker Compose CLI

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,6 @@ builds:
               -Wno-expansion-to-defined
               -Wno-macro-redefined
               -Wno-deprecated-declarations
-              -Wl,--discard-all
         - >-
             CXX=zig cc
               -target x86_64-macos
@@ -60,7 +59,6 @@ builds:
               -Wno-expansion-to-defined
               -Wno-macro-redefinedinternal
               -Wno-deprecated-declarations
-              -Wl,--discard-all
     - goos: darwin
       goarch: arm64
       buildmode: pie

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -83,7 +83,6 @@ builds:
               -Wno-expansion-to-defined
               -Wno-macro-redefined
               -Wno-deprecated-declarations
-              -Wl,--discard-all
         - >-
             CXX=zig cc
               -target aarch64-macos
@@ -94,7 +93,6 @@ builds:
               -Wno-expansion-to-defined
               -Wno-macro-redefined
               -Wno-deprecated-declarations
-              -Wl,--discard-all
 
 archives:
   - id: forklift

--- a/cmd/forklift/main_darwin.go
+++ b/cmd/forklift/main_darwin.go
@@ -1,8 +1,9 @@
 //go:build darwin
 
-package main
-
 // This is needed because Forklift imports Docker Compose, which on darwin imports
 // github.com/fsnotify/fsevents, which requires CGo; and we need to make CGo do something so that
 // we can generate CGo runtime stuff for the linker:
+
+package main
+
 import "C"

--- a/cmd/forklift/main_darwin.go
+++ b/cmd/forklift/main_darwin.go
@@ -1,0 +1,8 @@
+//go:build darwin
+
+package main
+
+// This is needed because Forklift imports Docker Compose, which on darwin imports
+// github.com/fsnotify/fsevents, which requires CGo; and we need to make CGo do something so that
+// we can generate CGo runtime stuff for the linker:
+import "C"

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -2,8 +2,8 @@
 
 log="$(mktemp)"
 
-echo $@
+echo "zig-cc args:" $@ | tee $log
 
 exit_code=0
-zig cc $@ 2>&1 || exit_code=$? | tee $log
+zig cc $@ 2>&1 || exit_code=$? | tee --append $log
 exit $exit_code

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -3,16 +3,14 @@
 if ls | grep "fsevents" > /dev/null; then
   pwd 1>&2
   ls -l 1>&2
-  cat /tmp/cgo-gcc-input-*.c 1>&2
-  ls /home/runner/go/pkg/mod/github.com/fsnotify/fsevents@v0.2.0/
+  ls -l /tmp
 fi
 
 zig cc $@
 exit_code=$?
 
 if ls | grep "fsevents" > /dev/null; then
-  zig env 1>&2
-  ls -l 1>&2
+  ls -l /tmp 1>&2
 fi
 
 exit $exit_code

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/sh -e
 
+sudo chown $USER -R $(pwd)
 sudo chown $USER -R $ZIG_GLOBAL_CACHE_DIR
 sudo chown $USER -R $ZIG_LOCAL_CACHE_DIR
 zig cc $@ 1>&2

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -3,6 +3,11 @@
 sudo chown $USER -R $(pwd)
 sudo chown $USER -R $ZIG_GLOBAL_CACHE_DIR
 sudo chown $USER -R $ZIG_LOCAL_CACHE_DIR
+ls -l $ZIG_LOCAL_CACHE_DIR/.. 1>&2
+ls -l $ZIG_LOCAL_CACHE_DIR 1>&2
+ls -l $(pwd)/.. 1>&2
+ls -l $(pwd) 1>&2
+zig env 1>&2
 echo "zig cc $@" 1>&2
 zig cc $@ 1>&2
 exit $?

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,7 +1,9 @@
-#!/bin/sh
+#!/bin/bash -x
 
-echo "zig-cc args: $@" 1>&2
-echo $CC
-echo $CXX
+ls -lR $WORK 1>&2
+
+zig env
 
 zig cc $@
+
+ls -lR $WORK 1>&2

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -9,5 +9,5 @@ ls -l $(pwd)/.. 1>&2
 ls -l $(pwd) 1>&2
 zig env 1>&2
 echo "zig cc $@" 1>&2
-zig cc $@ 1>&2
+strace zig cc $@ 1>&2
 exit $?

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -x
 
 mkdir -p zig-build
-ZIG_GLOBAL_CACHE_DIR="$(pwd)/zig-build"
-ZIG_LOCAL_CACHE_DIR="$(pwd)/zig-build"
+export ZIG_GLOBAL_CACHE_DIR="$(pwd)/zig-build"
+export ZIG_LOCAL_CACHE_DIR="$(pwd)/zig-build"
+zig env 1>&2
 zig cc $@ 1>&2

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -3,4 +3,4 @@
 ls -l /tmp 1>&2
 
 cat /tmp/cgo-gcc-input-*.c 1>&2 || true
-zig cc $@ 1>&2
+zig cc --verbose $@ 1>&2

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,11 +1,7 @@
 #!/bin/bash -eux
 
 chmod +w $(pwd)
-if ls -l $(pwd) | grep "fsevents"; then
-  ls -l $(pwd)/.. 1>&2
-  ls -l $(pwd) 1>&2
-  echo "zig cc $@" 1>&2
-fi
-
 zig cc $@ 1>&2
-exit $?
+exit_code=$?
+ls -l $(pwd)
+exit $exit_code

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,19 +1,19 @@
 #!/bin/sh
 
-echo "workspace: $WORK"
-ls -lR $WORK
+echo "workspace: $WORK" 1>&2
+ls -lR $WORK 1>&2
 
-echo "zig cache: $ZIG_GLOBAL_CACHE_DIR"
-ls -l $ZIG_GLOBAL_CACHE_DIR
+echo "zig cache: $ZIG_GLOBAL_CACHE_DIR" 1>&2
+ls -l $ZIG_GLOBAL_CACHE_DIR 1>&2
 
-echo "zig-cc args: $@"
+echo "zig-cc args: $@" 1>&2
 
 zig cc $@
 
-echo "zig cache: $ZIG_GLOBAL_CACHE_DIR"
-ls -l $ZIG_GLOBAL_CACHE_DIR
+echo "zig cache: $ZIG_GLOBAL_CACHE_DIR" 1>&2
+ls -l $ZIG_GLOBAL_CACHE_DIR 1>&2
 
-echo "workspace parent:"
-ls -l $WORK/..
-echo "workspace: $WORK"
-ls -lR $WORK
+echo "workspace parent:" 1>&2
+ls -l $WORK/.. 1>&2
+echo "workspace: $WORK" 1>&2
+ls -lR $WORK 1>&2

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -x
 
-mkdir -p zig-build
+sudo mkdir -p zig-build
+sudo chown $USER -R zig-build
 export ZIG_GLOBAL_CACHE_DIR="$(pwd)/zig-build"
 export ZIG_LOCAL_CACHE_DIR="$(pwd)/zig-build"
 zig env 1>&2

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,15 +1,9 @@
 #!/bin/bash -eux
 
-sudo chown $USER -R $(pwd)
-sudo chown $USER -R $ZIG_GLOBAL_CACHE_DIR
-sudo chown $USER -R $ZIG_LOCAL_CACHE_DIR
+chmod a+x $(pwd)
 if ls -l $(pwd) | grep "fsevents"; then
   ls -l $(pwd)/.. 1>&2
   ls -l $(pwd) 1>&2
-  ls -l /tmp 1>&2
-  sudo chown $USER /tmp/cgo-gcc-input-*.o
-  sudo chmod a+w /tmp/cgo-gcc-input-*.o
-  ls -l /tmp 1>&2
   echo "zig cc $@" 1>&2
   strace zig cc $@ 1>&2
   exit $?

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -2,5 +2,5 @@
 
 ls -l /tmp 1>&2
 
-cat /tmp/cgo-gcc-input-*.c 1>&2
+cat /tmp/cgo-gcc-input-*.c 1>&2 || true
 zig cc $@ 1>&2

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 echo "zig-cc args: $@" 1>&2
-go env 1>&2
+echo $CC
+echo $CXX
 
 zig cc $@

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,8 +1,5 @@
-#!/bin/bash -x
+#!/bin/sh
 
-sudo mkdir -p zig-build
-sudo chown $USER -R zig-build
-export ZIG_GLOBAL_CACHE_DIR="$(pwd)/zig-build"
-export ZIG_LOCAL_CACHE_DIR="$(pwd)/zig-build"
-zig env 1>&2
+sudo chown $USER -R $ZIG_GLOBAL_CACHE_DIR
+sudo chown $USER -R $ZIG_LOCAL_CACHE_DIR
 zig cc $@ 1>&2

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,6 +1,8 @@
-#!/bin/sh -e
+#!/bin/bash -eux
 
 sudo chown $USER -R $(pwd)
 sudo chown $USER -R $ZIG_GLOBAL_CACHE_DIR
 sudo chown $USER -R $ZIG_LOCAL_CACHE_DIR
+echo "zig cc $@" 1>&2
 zig cc $@ 1>&2
+exit $?

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -5,8 +5,6 @@ if ls -l $(pwd) | grep "fsevents"; then
   ls -l $(pwd)/.. 1>&2
   ls -l $(pwd) 1>&2
   echo "zig cc $@" 1>&2
-  strace zig cc $@ 1>&2
-  exit $?
 fi
 
 zig cc $@ 1>&2

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -3,10 +3,10 @@
 if ls | grep "fsevents" > /dev/null; then
   pwd 1>&2
   ls -l 1>&2
-  ls -l /tmp
+  ls -l /tmp 1>&2
 fi
 
-zig cc $@
+zig cc $@ 1>&2
 exit_code=$?
 
 if ls | grep "fsevents" > /dev/null; then

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,14 +1,15 @@
 #!/bin/bash -x
 
-if ls "$WORK" | grep "fsevents" > /dev/null; then
+if ls | grep "fsevents" > /dev/null; then
   pwd 1>&2
-  ls -l $WORK 1>&2
+  ls -l 1>&2
   cat /tmp/cgo-gcc-input-* 1>&2
   ls /home/runner/go/pkg/mod/github.com/fsnotify/fsevents@v0.2.0/
 fi
 
-if ls "$WORK" | grep "fsevents" > /dev/null; then
+zig cc $@
+
+if ls | grep "fsevents" > /dev/null; then
   zig env 1>&2
-  zig cc $@
-  ls -l $WORK 1>&2
+  ls -l 1>&2
 fi

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-log="$(mktemp)"
-
 echo "zig-cc args:" $@ | tee $log
 
-exit_code=0
-zig cc $@ 2> $log || exit_code=$?
-cat $log
-exit $exit_code
+zig cc $@

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,9 +1,19 @@
 #!/bin/sh
 
-echo "zig-cc args:" $@
+echo "workspace: $WORK"
+ls -lR $WORK
+
+echo "zig cache: $ZIG_GLOBAL_CACHE_DIR"
+ls -l $ZIG_GLOBAL_CACHE_DIR
+
+echo "zig-cc args: $@"
 
 zig cc $@
 
-echo "workspace:" $WORK
+echo "zig cache: $ZIG_GLOBAL_CACHE_DIR"
+ls -l $ZIG_GLOBAL_CACHE_DIR
+
+echo "workspace parent:"
 ls -l $WORK/..
+echo "workspace: $WORK"
 ls -lR $WORK

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -3,11 +3,17 @@
 sudo chown $USER -R $(pwd)
 sudo chown $USER -R $ZIG_GLOBAL_CACHE_DIR
 sudo chown $USER -R $ZIG_LOCAL_CACHE_DIR
-ls -l $ZIG_LOCAL_CACHE_DIR/.. 1>&2
-ls -l $ZIG_LOCAL_CACHE_DIR 1>&2
-ls -l $(pwd)/.. 1>&2
-ls -l $(pwd) 1>&2
-zig env 1>&2
-echo "zig cc $@" 1>&2
-strace zig cc $@ 1>&2
+if ls -l $(pwd) | grep "fsevents"; then
+  ls -l $(pwd)/.. 1>&2
+  ls -l $(pwd) 1>&2
+  ls -l /tmp 1>&2
+  sudo chown $USER /tmp/cgo-gcc-input-*.o
+  sudo chmod a+w /tmp/cgo-gcc-input-*.o
+  ls -l /tmp 1>&2
+  echo "zig cc $@" 1>&2
+  strace zig cc $@ 1>&2
+  exit $?
+fi
+
+zig cc $@ 1>&2
 exit $?

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eux
 
-chmod a+x $(pwd)
+chmod +w $(pwd)
 if ls -l $(pwd) | grep "fsevents"; then
   ls -l $(pwd)/.. 1>&2
   ls -l $(pwd) 1>&2

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,16 +1,10 @@
 #!/bin/bash -x
 
-if ls | grep "fsevents" > /dev/null; then
-  pwd 1>&2
-  ls -l 1>&2
-  ls -l /tmp 1>&2
-fi
+ls -l /tmp 1>&2
 
 zig cc $@ 1>&2
 exit_code=$?
 
-if ls | grep "fsevents" > /dev/null; then
-  ls -l /tmp 1>&2
-fi
+ls -l /tmp 1>&2
 
 exit $exit_code

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-ls -l /tmp 1>&2
-
-cat /tmp/cgo-gcc-input-*.c 1>&2 || true
-zig cc --verbose $@ 1>&2
+mkdir -p zig-build
+ZIG_GLOBAL_CACHE_DIR="$(pwd)/zig-build"
+ZIG_LOCAL_CACHE_DIR="$(pwd)/zig-build"
+zig cc $@ 1>&2

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -3,13 +3,16 @@
 if ls | grep "fsevents" > /dev/null; then
   pwd 1>&2
   ls -l 1>&2
-  cat /tmp/cgo-gcc-input-* 1>&2
+  cat /tmp/cgo-gcc-input-*.c 1>&2
   ls /home/runner/go/pkg/mod/github.com/fsnotify/fsevents@v0.2.0/
 fi
 
 zig cc $@
+exit_code=$?
 
 if ls | grep "fsevents" > /dev/null; then
   zig env 1>&2
   ls -l 1>&2
 fi
+
+exit $exit_code

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -2,4 +2,6 @@
 
 ls -l /tmp 1>&2
 
+zig env 1>&2
+ls -l $ZIG_LOCAL_CACHE_DIR 1>&2
 zig cc $@ 1>&2

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,4 +1,0 @@
-#!/bin/bash -x
-
-zig cc $@ 1>&2
-exit $?

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,19 +1,6 @@
 #!/bin/sh
 
-echo "workspace: $WORK" 1>&2
-ls -lR $WORK 1>&2
-
-echo "zig cache: $ZIG_GLOBAL_CACHE_DIR" 1>&2
-ls -l $ZIG_GLOBAL_CACHE_DIR 1>&2
-
 echo "zig-cc args: $@" 1>&2
+go env 1>&2
 
 zig cc $@
-
-echo "zig cache: $ZIG_GLOBAL_CACHE_DIR" 1>&2
-ls -l $ZIG_GLOBAL_CACHE_DIR 1>&2
-
-echo "workspace parent:" 1>&2
-ls -l $WORK/.. 1>&2
-echo "workspace: $WORK" 1>&2
-ls -lR $WORK 1>&2

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,9 +1,14 @@
 #!/bin/bash -x
 
-ls -lR $WORK 1>&2
+if ls "$WORK" | grep "fsevents" > /dev/null; then
+  pwd 1>&2
+  ls -l $WORK 1>&2
+  cat /tmp/cgo-gcc-input-* 1>&2
+  ls /home/runner/go/pkg/mod/github.com/fsnotify/fsevents@v0.2.0/
+fi
 
-zig env
-
-zig cc $@
-
-ls -lR $WORK 1>&2
+if ls "$WORK" | grep "fsevents" > /dev/null; then
+  zig env 1>&2
+  zig cc $@
+  ls -l $WORK 1>&2
+fi

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -5,5 +5,6 @@ log="$(mktemp)"
 echo "zig-cc args:" $@ | tee $log
 
 exit_code=0
-zig cc $@ 2>&1 || exit_code=$? | tee --append $log
+zig cc $@ 2> $log || exit_code=$?
+cat $log
 exit $exit_code

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -3,8 +3,3 @@
 ls -l /tmp 1>&2
 
 zig cc $@ 1>&2
-exit_code=$?
-
-ls -l /tmp 1>&2
-
-exit $exit_code

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
-echo "zig-cc args:" $@ | tee $log
+echo "zig-cc args:" $@
 
 zig cc $@
+
+echo "workspace:" $WORK
+ls -l $WORK/..
+ls -lR $WORK

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -1,7 +1,4 @@
-#!/bin/bash -eux
+#!/bin/bash -x
 
-chmod +w $(pwd)
 zig cc $@ 1>&2
-exit_code=$?
-ls -l $(pwd)
-exit $exit_code
+exit $?

--- a/zig-cc.sh
+++ b/zig-cc.sh
@@ -2,6 +2,5 @@
 
 ls -l /tmp 1>&2
 
-zig env 1>&2
-ls -l $ZIG_LOCAL_CACHE_DIR 1>&2
+cat /tmp/cgo-gcc-input-*.c 1>&2
 zig cc $@ 1>&2


### PR DESCRIPTION
This PR attempts to simplify builds by using the Zig toolchain for CGo builds for macOS (see https://github.com/goreleaser/goreleaser-example-zig-cgo and https://zig.news/kristoff/building-sqlite-with-cgo-for-every-os-4cic).