### PR TITLE
Disable Windows builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os:
+          - ubuntu-latest
+          - macos-latest
+          # - windows-latest
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
     - linux_arm_7
     - darwin_amd64_v1
     - darwin_arm64
-    - windows_amd64_v1
+    # - windows_amd64_v1
   overrides:
     - goos: darwin
       goarch: amd64


### PR DESCRIPTION
Windows builds have always been really slow (~10-12 m builds), which slows down the prototyping iteration cycle. I don't think anyone actually uses Forklift on Windows anyways (and if they really need to, we should first have them try running Forklift on WSL) - so I'm going to re-disable Windows builds again.

Related past PRs:
- #58 
- #219