### PR TITLE
Simplify local pallet upgrade UX, make auto-upgrades feasible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- (cli) Previously, the atomic commit mechanism for the stage store state file did not correctly error out if a swap file already existed. This check should now work.
+
 ## 0.7.3 - 2024-06-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - (cli) Added tracking of the last pallet path@version query used with the `plt clone` and `plt switch` subcommands, so that those subcommands can be called again with a partial query (i.e. `@version_query` or `pallet_path@` or `@`) to reuse the last provided value(s) for omitted parts of the query.
+- (cli) Added a `plt upgrade` subcommand as a more user-friendly equivalent to `plt switch @`.
+- (cli) Added `plt show-upgrade-query` to show the pallet path@version query which will be used for `plt upgrade` and for `plt clone/switch` subcommands with partial queries.
+- (cli) Added `plt set-upgrade-query` to modify the pallet path@version query which will be used for `plt upgrade` and for `plt clone/switch` subcommands with partial queries.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- (cli) Added tracking of the last pallet path@version query used with the `plt clone` and `plt switch` subcommands, so that those subcommands can be called again with a partial query (i.e. `@version_query` or `pallet_path@` or `@`) to reuse the last provided value(s) for omitted parts of the query.
+
 ### Fixed
 
 - (cli) Previously, the atomic commit mechanism for the stage store state file did not correctly error out if a swap file already existed. This check should now work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -320,7 +320,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `env check` and `dev env check` now checks resource constraints againt all provided resources and resource requirements among all package deployments in the environment, and reports any identified resource constraint violations.
+- `env check` and `dev env check` now checks resource constraints against all provided resources and resource requirements among all package deployments in the environment, and reports any identified resource constraint violations.
 - `dev env` now allows specifying one or more directories containing Pallet repositories to replace any corresponding cached repositories, using the `--repo` flag (which can be specified repeatedly).
 - `env plan` and `dev env plan` now show the changes which will be made by `env apply` and `dev env apply`, respectively.
 - The (draft) implementation of the (draft) specification for the Pallets package management system is now available in the `/pkg/pallets` directory of this repository. Note that the specification and implementation will be changed to simplify terminology, so the API will definitely change.
@@ -349,7 +349,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- (Breaking change: cli) Renamed the `env deploy` and `dev env deploy` commands to `env apply` and `dev env apply`, respectively. This is meant to make the mental model for forklift slightly more familiar to people who have used HashiCorp Terraform.
+- (Breaking change: cli) Renamed the `env deploy` and `dev env deploy` commands to `env apply` and `dev env apply`, respectively. This is meant to make the mental model for forklift slightly more familiar to people who have used Terraform.
 - (Breaking change: cli) Renamed the `env cache` and `dev env cache` commands to `env cache-repo` and `dev env cache-repo`, respectively. This disambiguates the commands for caching Pallets-related data and for caching Docker container images, while allowing them to be run separately (useful on Docker environments where root permissions are required to talk to the Docker daemon).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - (cli) Added tracking of the last pallet path@version query used with the `plt clone` and `plt switch` subcommands, so that those subcommands can be called again with a partial query (i.e. `@version_query` or `pallet_path@` or `@`) to reuse the last provided value(s) for omitted parts of the query.
-- (cli) Added a `plt upgrade` subcommand as a more user-friendly equivalent to `plt switch @`.
-- (cli) Added `plt show-upgrade-query` to show the pallet path@version query which will be used for `plt upgrade` and for `plt clone/switch` subcommands with partial queries.
-- (cli) Added `plt set-upgrade-query` to modify the pallet path@version query which will be used for `plt upgrade` and for `plt clone/switch` subcommands with partial queries.
+- (cli) Added a `plt upgrade` subcommand as a upgrade-specific version of `plt switch` (with additional checks and log messages).
+- (cli) Added a `plt check-upgrade` subcommand to show whether an upgrade is available and, if so, what change to the local pallet would be made by `plt upgrade`.
+- (cli) Added a `plt show-upgrade-query` subcommand to show the pallet path@version query which will be used for `plt upgrade` and for `plt clone/switch` subcommands with partial queries.
+- (cli) Added a `plt set-upgrade-query` subcommand to modify the pallet path@version query which will be used for `plt upgrade` and for `plt clone/switch` subcommands with partial queries.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - (cli) Added tracking of the last pallet path@version query used with the `plt clone` and `plt switch` subcommands, so that those subcommands can be called again with a partial query (i.e. `@version_query` or `pallet_path@` or `@`) to reuse the last provided value(s) for omitted parts of the query.
+- (cli) Added a `--force` flag to the `plt switch` subcommand.
 - (cli) Added a `plt upgrade` subcommand as a upgrade-specific version of `plt switch` (with additional checks and log messages).
 - (cli) Added a `plt check-upgrade` subcommand to show whether an upgrade is available and, if so, what change to the local pallet would be made by `plt upgrade`.
 - (cli) Added a `plt show-upgrade-query` subcommand to show the pallet path@version query which will be used for `plt upgrade` and for `plt clone/switch` subcommands with partial queries.
 - (cli) Added a `plt set-upgrade-query` subcommand to modify the pallet path@version query which will be used for `plt upgrade` and for `plt clone/switch` subcommands with partial queries.
+- (cli) Now `plt clone` and `plt switch` add a `forklift-cache-mirror` remote to the list of remotes of the local pallet, which points to the Forklift pallet cache's mirror of the `origin` remote of the local pallet.
+- (cli) Now `plt show` will print refs from the Forklift pallet cache's mirror of the `origin` remote of the local pallet, if the `origin` remote cannot be queried (e.g. due to lack of internet connection).
+
+### Changed
+
+- (cli) Now `plt switch` will quit early with an error message if you use it to try to replace a local pallet which 1) is not a Git repo, 2) has uncommitted changes, or 3) is on a commit which does not exist in the remote, unless you enable the `--force` flag. This is intended to prevent unintentional deletion of user customizations.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.8.0-alpha.1 - 2024-07-05
 
 ### Added
 
@@ -16,11 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (cli) Added a `plt show-upgrade-query` subcommand to show the pallet path@version query which will be used for `plt upgrade` and for `plt clone/switch` subcommands with partial queries.
 - (cli) Added a `plt set-upgrade-query` subcommand to modify the pallet path@version query which will be used for `plt upgrade` and for `plt clone/switch` subcommands with partial queries.
 - (cli) Now `plt clone` and `plt switch` add a `forklift-cache-mirror` remote to the list of remotes of the local pallet, which points to the Forklift pallet cache's mirror of the `origin` remote of the local pallet.
-- (cli) Now `plt show` will print refs from the Forklift pallet cache's mirror of the `origin` remote of the local pallet, if the `origin` remote cannot be queried (e.g. due to lack of internet connection).
+- (cli) Now `plt show` will print git refs from the Forklift pallet cache's mirror of the `origin` remote of the local pallet, if the `origin` remote cannot be queried (e.g. due to lack of internet connection).
 
 ### Changed
 
-- (cli) Now `plt switch` will quit early with an error message if you use it to try to replace a local pallet which 1) is not a Git repo, 2) has uncommitted changes, or 3) is on a commit which does not exist in the remote, unless you enable the `--force` flag. This is intended to prevent unintentional deletion of user customizations.
+- (Breaking change; cli) Now `plt switch` will quit early with an error message if you use it to try to replace a local pallet which 1) is not a Git repo, 2) has uncommitted changes, or 3) is on a commit which does not exist in the remote, unless you enable the `--force` flag. This is intended to prevent unintentional deletion of user customizations.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ the example commands in this section.
 
 If you are running Docker in [rootless mode](https://docs.docker.com/engine/security/rootless/) or
 your user is in
-[the `docker` group](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user)):
+[the `docker` group](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user):
 
 - If you want to apply the pallet immediately, you can run `forklift pallet switch --apply` with
 your specified pallet. For example:

--- a/cmd/forklift/cache/cache.go
+++ b/cmd/forklift/cache/cache.go
@@ -20,7 +20,7 @@ var errMissingCache = errors.New(
 
 func getPalletCache(wpath string, ensureWorkspace bool) (*forklift.FSPalletCache, error) {
 	if ensureWorkspace {
-		if !forklift.Exists(wpath) {
+		if !forklift.DirExists(wpath) {
 			fmt.Printf("Making a new workspace at %s...", wpath)
 		}
 		if err := forklift.EnsureExists(wpath); err != nil {
@@ -40,7 +40,7 @@ func getPalletCache(wpath string, ensureWorkspace bool) (*forklift.FSPalletCache
 
 func getRepoCache(wpath string, ensureWorkspace bool) (*forklift.FSRepoCache, error) {
 	if ensureWorkspace {
-		if !forklift.Exists(wpath) {
+		if !forklift.DirExists(wpath) {
 			fmt.Printf("Making a new workspace at %s...", wpath)
 		}
 		if err := forklift.EnsureExists(wpath); err != nil {

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -5,15 +5,13 @@ import (
 	"slices"
 
 	"github.com/urfave/cli/v2"
+
+	fcli "github.com/PlanktoScope/forklift/internal/app/forklift/cli"
 )
 
 type Versions struct {
-	Tool               string
-	MinSupportedRepo   string
-	MinSupportedPallet string
-	MinSupportedBundle string
-	NewBundle          string
-	NewStageStore      string
+	fcli.Versions
+	NewStageStore string
 }
 
 func MakeCmd(versions Versions) *cli.Command {

--- a/cmd/forklift/dev/plt/pallets.go
+++ b/cmd/forklift/dev/plt/pallets.go
@@ -71,7 +71,7 @@ func loadReplacementRepos(fsPaths []string) (replacements []*core.FSRepo, err er
 		if err != nil {
 			return nil, errors.Wrapf(err, "couldn't convert '%s' into an absolute path", path)
 		}
-		if !forklift.Exists(replacementPath) {
+		if !forklift.DirExists(replacementPath) {
 			return nil, errors.Errorf("couldn't find repo replacement path %s", replacementPath)
 		}
 		externalRepos, err := core.LoadFSRepos(

--- a/cmd/forklift/dev/plt/pallets.go
+++ b/cmd/forklift/dev/plt/pallets.go
@@ -122,14 +122,14 @@ func cacheAllAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 		if err = fcli.CheckShallowCompatibility(
-			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			pallet, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}
 
 		if err = fcli.CacheAllRequirements(
-			pallet, repoCache.Underlay.Path(), repoCache, dlCache,
+			0, pallet, repoCache.Underlay.Path(), repoCache, dlCache,
 			c.Bool("include-disabled"), c.Bool("parallel"),
 		); err != nil {
 			return err
@@ -201,8 +201,10 @@ func stageAction(versions Versions) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		if err = fcli.CheckCompatibility(
-			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+		// Note: we cannot guarantee that all requirements are cached, so we don't check their versions
+		// here; fcli.StagePallet will do those checks for us.
+		if err = fcli.CheckShallowCompatibility(
+			pallet, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
@@ -220,8 +222,7 @@ func stageAction(versions Versions) cli.ActionFunc {
 		}
 		if _, err = fcli.StagePallet(
 			pallet, stageStore, repoCache, dlCache, c.String("exports"),
-			versions.Tool, versions.MinSupportedBundle, versions.NewBundle,
-			c.Bool("no-cache-img"), c.Bool("parallel"), c.Bool("ignore-tool-version"),
+			versions.Versions, c.Bool("no-cache-img"), c.Bool("parallel"), c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}
@@ -241,8 +242,10 @@ func applyAction(versions Versions) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		if err = fcli.CheckCompatibility(
-			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+		// Note: we cannot guarantee that all requirements are cached, so we don't check their versions
+		// here; fcli.StagePallet will do those checks for us.
+		if err = fcli.CheckShallowCompatibility(
+			pallet, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
@@ -260,8 +263,7 @@ func applyAction(versions Versions) cli.ActionFunc {
 		}
 		index, err := fcli.StagePallet(
 			pallet, stageStore, repoCache, dlCache, c.String("exports"),
-			versions.Tool, versions.MinSupportedBundle, versions.NewBundle,
-			false, c.Bool("parallel"), c.Bool("ignore-tool-version"),
+			versions.Versions, false, c.Bool("parallel"), c.Bool("ignore-tool-version"),
 		)
 		if err != nil {
 			return errors.Wrap(err, "couldn't stage pallet to be applied immediately")

--- a/cmd/forklift/dev/plt/repositories.go
+++ b/cmd/forklift/dev/plt/repositories.go
@@ -17,7 +17,7 @@ func cacheRepoAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 		if err = fcli.CheckShallowCompatibility(
-			pallet, cache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			pallet, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
@@ -70,7 +70,7 @@ func addRepoAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 		if err = fcli.CheckShallowCompatibility(
-			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			pallet, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
@@ -84,7 +84,7 @@ func addRepoAction(versions Versions) cli.ActionFunc {
 
 		if !c.Bool("no-cache-req") {
 			if err = fcli.CacheStagingRequirements(
-				pallet, repoCache.Path(), repoCache, dlCache, false, c.Bool("parallel"),
+				0, pallet, repoCache.Path(), repoCache, dlCache, false, c.Bool("parallel"),
 			); err != nil {
 				return err
 			}
@@ -98,12 +98,12 @@ func addRepoAction(versions Versions) cli.ActionFunc {
 
 func rmRepoAction(versions Versions) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		pallet, repoCache, _, err := processFullBaseArgs(c, false, false)
+		pallet, _, _, err := processFullBaseArgs(c, false, false)
 		if err != nil {
 			return err
 		}
 		if err = fcli.CheckShallowCompatibility(
-			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			pallet, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err

--- a/cmd/forklift/main.go
+++ b/cmd/forklift/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/PlanktoScope/forklift/cmd/forklift/host"
 	"github.com/PlanktoScope/forklift/cmd/forklift/plt"
 	"github.com/PlanktoScope/forklift/cmd/forklift/stage"
+	fcli "github.com/PlanktoScope/forklift/internal/app/forklift/cli"
 )
 
 func main() {
@@ -23,18 +24,22 @@ func main() {
 
 var defaultWorkspaceBase, _ = os.UserHomeDir()
 
+var fcliVersions fcli.Versions = fcli.Versions{
+	Tool:               toolVersion,
+	MinSupportedRepo:   repoMinVersion,
+	MinSupportedPallet: palletMinVersion,
+	MinSupportedBundle: bundleMinVersion,
+	NewBundle:          newBundleVersion,
+}
+
 var app = &cli.App{
 	Name:    "forklift",
 	Version: toolVersion,
 	Usage:   "Manages pallets and package deployments",
 	Commands: []*cli.Command{
 		plt.MakeCmd(plt.Versions{
-			Tool:               toolVersion,
-			MinSupportedRepo:   repoMinVersion,
-			MinSupportedPallet: palletMinVersion,
-			MinSupportedBundle: bundleMinVersion,
-			NewBundle:          newBundleVersion,
-			NewStageStore:      newStageStoreVersion,
+			Versions:      fcliVersions,
+			NewStageStore: newStageStoreVersion,
 		}),
 		stage.MakeCmd(stage.Versions{
 			Tool:               toolVersion,
@@ -44,12 +49,8 @@ var app = &cli.App{
 		cache.Cmd,
 		host.Cmd,
 		dev.MakeCmd(dev.Versions{
-			Tool:               toolVersion,
-			MinSupportedRepo:   repoMinVersion,
-			MinSupportedPallet: palletMinVersion,
-			MinSupportedBundle: bundleMinVersion,
-			NewBundle:          newBundleVersion,
-			NewStageStore:      newStageStoreVersion,
+			Versions:      fcliVersions,
+			NewStageStore: newStageStoreVersion,
 		}),
 	},
 	Flags: []cli.Flag{

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -26,7 +26,7 @@ func MakeCmd(versions Versions) *cli.Command {
 				{
 					Name:      "switch",
 					Usage:     "(Re)initializes the local pallet, updates the cache, and stages the pallet",
-					ArgsUsage: "[pallet_path]@[version_query]",
+					ArgsUsage: "[[pallet_path]@[version_query]]",
 					Action:    switchAction(versions),
 					Flags: []cli.Flag{
 						&cli.BoolFlag{
@@ -54,8 +54,13 @@ func makeUpgradeSubcmds(versions Versions) []*cli.Command {
 			Name: "upgrade",
 			Usage: "Replaces the local pallet with an upgraded version, updates the cache, and " +
 				"stages the pallet",
-			Action: upgradeAction(versions),
+			ArgsUsage: "[[pallet_path]@[version_query]]",
+			Action:    upgradeAction(versions),
 			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "allow-downgrade",
+					Usage: "Allow upgrading to an older version (i.e. performing a downgrade)",
+				},
 				&cli.BoolFlag{
 					Name:  "no-cache-img",
 					Usage: "Don't download container images (this flag is ignored if --apply is set)",
@@ -67,6 +72,21 @@ func makeUpgradeSubcmds(versions Versions) []*cli.Command {
 			},
 		},
 		{
+			Name: "check-upgrade",
+			// TODO: also check whether the upgrade is cached
+			Usage:     "Checks whether an upgrade is available",
+			ArgsUsage: "[[pallet_path]@[version_query]]",
+			Action:    checkUpgradeAction,
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "allow-downgrade",
+					Usage: "Allow upgrading to an older version (i.e. performing a downgrade)",
+				},
+				// TODO: add a --require-cached flag
+			},
+		},
+		// TODO: add a cache-upgrade command
+		{
 			Name:   "show-upgrade-query",
 			Usage:  "Shows the query used for pallet upgrades",
 			Action: showUpgradeQueryAction,
@@ -74,7 +94,7 @@ func makeUpgradeSubcmds(versions Versions) []*cli.Command {
 		{
 			Name:      "set-upgrade-query",
 			Usage:     "Changes the query used for pallet upgrades",
-			ArgsUsage: "[pallet_path]@[version_query]",
+			ArgsUsage: "[[pallet_path]@[version_query]]",
 			Action:    setUpgradeQueryAction,
 		},
 	}
@@ -283,7 +303,7 @@ func makeModifyGitSubcmds(versions Versions) []*cli.Command {
 			Name:      "clone",
 			Category:  category,
 			Usage:     "Initializes the local pallet from a remote release",
-			ArgsUsage: "[pallet_path]@[version_query]",
+			ArgsUsage: "[[pallet_path]@[version_query]]",
 			Flags: slices.Concat(
 				[]cli.Flag{
 					&cli.BoolFlag{

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -5,15 +5,13 @@ import (
 	"slices"
 
 	"github.com/urfave/cli/v2"
+
+	fcli "github.com/PlanktoScope/forklift/internal/app/forklift/cli"
 )
 
 type Versions struct {
-	Tool               string
-	MinSupportedRepo   string
-	MinSupportedPallet string
-	MinSupportedBundle string
-	NewBundle          string
-	NewStageStore      string
+	fcli.Versions
+	NewStageStore string
 }
 
 func MakeCmd(versions Versions) *cli.Command {

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -24,11 +24,17 @@ func MakeCmd(versions Versions) *cli.Command {
 		Subcommands: slices.Concat(
 			[]*cli.Command{
 				{
-					Name:      "switch",
-					Usage:     "(Re)initializes the local pallet, updates the cache, and stages the pallet",
+					Name: "switch",
+					Usage: "Initializes or replaces the local pallet with the specified pallet, and " +
+						"stages the specified pallet",
 					ArgsUsage: "[[pallet_path]@[version_query]]",
 					Action:    switchAction(versions),
 					Flags: []cli.Flag{
+						&cli.BoolFlag{
+							Name: "force",
+							Usage: "Even if the local pallet already exists and has uncommitted/unpushed " +
+								"changes, replace it",
+						},
 						&cli.BoolFlag{
 							Name:  "no-cache-img",
 							Usage: "Don't download container images (this flag is ignored if --apply is set)",
@@ -60,6 +66,11 @@ func makeUpgradeSubcmds(versions Versions) []*cli.Command {
 				&cli.BoolFlag{
 					Name:  "allow-downgrade",
 					Usage: "Allow upgrading to an older version (i.e. performing a downgrade)",
+				},
+				&cli.BoolFlag{
+					Name: "force",
+					Usage: "Even if the local pallet has uncommitted/unpushed changes, replace it with the " +
+						"upggraded version",
 				},
 				&cli.BoolFlag{
 					Name:  "no-cache-img",
@@ -307,8 +318,9 @@ func makeModifyGitSubcmds(versions Versions) []*cli.Command {
 			Flags: slices.Concat(
 				[]cli.Flag{
 					&cli.BoolFlag{
-						Name:  "force",
-						Usage: "Deletes the local pallet if it already exists",
+						Name: "force",
+						Usage: "If a local pallet already exists, delete it to replace it with the specified" +
+							"pallet",
 					},
 					&cli.BoolFlag{
 						Name:  "no-cache-req",
@@ -336,6 +348,7 @@ func makeModifyGitSubcmds(versions Versions) []*cli.Command {
 						Name:  "no-cache-req",
 						Usage: "Don't download repositories and pallets required by this pallet after pulling",
 					},
+					// TODO: add an option to fall back to a rebase if a fast-forward is not possible
 				},
 				modifyBaseFlags,
 			),
@@ -378,7 +391,7 @@ var modifyBaseFlags []cli.Flag = []cli.Flag{
 //	}
 
 func makeModifyRepoSubcmds(versions Versions) []*cli.Command {
-	const category = "Modify the pallet's requirements"
+	const category = "Modify the pallet's package repository requirements"
 	return []*cli.Command{
 		{
 			Name: "add-repo",
@@ -400,6 +413,11 @@ func makeModifyRepoSubcmds(versions Versions) []*cli.Command {
 			},
 			Action: addRepoAction(versions),
 		},
+		// TODO: add an upgrade-repo [repo_path]... command (upgrade all if no args)
+		// TODO: add a check-upgrade-repo [repo_path]... command (check all upgrades if no args)
+		// TODO: add a cache-upgrade-repo repo_path command (cache all upgrades if no args)
+		// TODO: add a show-upgrade-repo-query repo_path[@] command
+		// TODO: add a set-upgrade-repo-query repo_path@version_query command
 		{
 			Name: "rm-repo",
 			Aliases: []string{

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -40,43 +40,43 @@ func MakeCmd(versions Versions) *cli.Command {
 					},
 				},
 			},
-			[]*cli.Command{
-				{
-					Name: "upgrade",
-					Usage: "Replaces the local pallet with an upgraded version, updates the cache, and " +
-						"stages the pallet",
-					Action: upgradeAction(versions),
-					Flags: []cli.Flag{
-						&cli.BoolFlag{
-							Name:  "no-cache-img",
-							Usage: "Don't download container images (this flag is ignored if --apply is set)",
-						},
-						&cli.BoolFlag{
-							Name:  "apply",
-							Usage: "Immediately apply the upgraded pallet after staging it",
-						},
-					},
-				},
-			},
-			[]*cli.Command{
-				{
-					Name:      "show-upgrade-query",
-					Usage:     "Shows the query used for pallet upgrades",
-					Action:    showUpgradeQueryAction,
-				},
-			},
-			[]*cli.Command{
-				{
-					Name:      "set-upgrade-query",
-					Usage:     "Changes the query used for pallet upgrades",
-					ArgsUsage: "[pallet_path]@[version_query]",
-					Action:    setUpgradeQueryAction,
-				},
-			},
+			makeUpgradeSubcmds(versions),
 			makeUseSubcmds(versions),
 			makeQuerySubcmds(),
 			makeModifySubcmds(versions),
 		),
+	}
+}
+
+func makeUpgradeSubcmds(versions Versions) []*cli.Command {
+	return []*cli.Command{
+		{
+			Name: "upgrade",
+			Usage: "Replaces the local pallet with an upgraded version, updates the cache, and " +
+				"stages the pallet",
+			Action: upgradeAction(versions),
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "no-cache-img",
+					Usage: "Don't download container images (this flag is ignored if --apply is set)",
+				},
+				&cli.BoolFlag{
+					Name:  "apply",
+					Usage: "Immediately apply the upgraded pallet after staging it",
+				},
+			},
+		},
+		{
+			Name:   "show-upgrade-query",
+			Usage:  "Shows the query used for pallet upgrades",
+			Action: showUpgradeQueryAction,
+		},
+		{
+			Name:      "set-upgrade-query",
+			Usage:     "Changes the query used for pallet upgrades",
+			ArgsUsage: "[pallet_path]@[version_query]",
+			Action:    setUpgradeQueryAction,
+		},
 	}
 }
 
@@ -358,7 +358,7 @@ var modifyBaseFlags []cli.Flag = []cli.Flag{
 //	}
 
 func makeModifyRepoSubcmds(versions Versions) []*cli.Command {
-	const category = "Modify the pallet"
+	const category = "Modify the pallet's requirements"
 	return []*cli.Command{
 		{
 			Name: "add-repo",
@@ -405,7 +405,7 @@ func makeModifyRepoSubcmds(versions Versions) []*cli.Command {
 func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's hard to split more
 	versions Versions,
 ) []*cli.Command {
-	const category = "Modify the pallet"
+	const category = "Modify the pallet's package deployments"
 	return []*cli.Command{
 		{
 			Name:      "add-depl",

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -26,7 +26,7 @@ func MakeCmd(versions Versions) *cli.Command {
 				{
 					Name:      "switch",
 					Usage:     "(Re)initializes the local pallet, updates the cache, and stages the pallet",
-					ArgsUsage: "[github_repository_path@release]",
+					ArgsUsage: "[github_repository_path]@[release]",
 					Action:    switchAction(versions),
 					Flags: []cli.Flag{
 						&cli.BoolFlag{
@@ -250,7 +250,7 @@ func makeModifyGitSubcmds(versions Versions) []*cli.Command {
 			Name:      "clone",
 			Category:  category,
 			Usage:     "Initializes the local pallet from a remote release",
-			ArgsUsage: "[github_repository_path@release]",
+			ArgsUsage: "[github_repository_path]@[release]",
 			Flags: slices.Concat(
 				[]cli.Flag{
 					&cli.BoolFlag{

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -26,7 +26,7 @@ func MakeCmd(versions Versions) *cli.Command {
 				{
 					Name:      "switch",
 					Usage:     "(Re)initializes the local pallet, updates the cache, and stages the pallet",
-					ArgsUsage: "[github_repository_path]@[release]",
+					ArgsUsage: "[pallet_path]@[version_query]",
 					Action:    switchAction(versions),
 					Flags: []cli.Flag{
 						&cli.BoolFlag{
@@ -38,6 +38,39 @@ func MakeCmd(versions Versions) *cli.Command {
 							Usage: "Immediately apply the pallet after staging it",
 						},
 					},
+				},
+			},
+			[]*cli.Command{
+				{
+					Name: "upgrade",
+					Usage: "Replaces the local pallet with an upgraded version, updates the cache, and " +
+						"stages the pallet",
+					Action: upgradeAction(versions),
+					Flags: []cli.Flag{
+						&cli.BoolFlag{
+							Name:  "no-cache-img",
+							Usage: "Don't download container images (this flag is ignored if --apply is set)",
+						},
+						&cli.BoolFlag{
+							Name:  "apply",
+							Usage: "Immediately apply the upgraded pallet after staging it",
+						},
+					},
+				},
+			},
+			[]*cli.Command{
+				{
+					Name:      "show-upgrade-query",
+					Usage:     "Shows the query used for pallet upgrades",
+					Action:    showUpgradeQueryAction,
+				},
+			},
+			[]*cli.Command{
+				{
+					Name:      "set-upgrade-query",
+					Usage:     "Changes the query used for pallet upgrades",
+					ArgsUsage: "[pallet_path]@[version_query]",
+					Action:    setUpgradeQueryAction,
 				},
 			},
 			makeUseSubcmds(versions),
@@ -250,7 +283,7 @@ func makeModifyGitSubcmds(versions Versions) []*cli.Command {
 			Name:      "clone",
 			Category:  category,
 			Usage:     "Initializes the local pallet from a remote release",
-			ArgsUsage: "[github_repository_path]@[release]",
+			ArgsUsage: "[pallet_path]@[version_query]",
 			Flags: slices.Concat(
 				[]cli.Flag{
 					&cli.BoolFlag{
@@ -266,7 +299,7 @@ func makeModifyGitSubcmds(versions Versions) []*cli.Command {
 			),
 			Action: cloneAction(versions),
 		},
-		// TODO: add a "checkout" action
+		// TODO: add a "checkout @version_query" action
 		{
 			Name:     "fetch",
 			Category: category,

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -70,7 +70,7 @@ func makeUpgradeSubcmds(versions Versions) []*cli.Command {
 				&cli.BoolFlag{
 					Name: "force",
 					Usage: "Even if the local pallet has uncommitted/unpushed changes, replace it with the " +
-						"upggraded version",
+						"upgraded version",
 				},
 				&cli.BoolFlag{
 					Name:  "no-cache-img",
@@ -331,7 +331,8 @@ func makeModifyGitSubcmds(versions Versions) []*cli.Command {
 			),
 			Action: cloneAction(versions),
 		},
-		// TODO: add a "checkout @version_query" action
+		// TODO: add a "checkout @version_query" action; it needs a --force flag to overwrite a dirty
+		// working directory
 		{
 			Name:     "fetch",
 			Category: category,

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -92,7 +92,7 @@ func switchAction(versions Versions) cli.ActionFunc {
 }
 
 func ensureWorkspace(wpath string) (*forklift.FSWorkspace, error) {
-	if !forklift.Exists(wpath) {
+	if !forklift.DirExists(wpath) {
 		fmt.Printf("Making a new workspace at %s...", wpath)
 	}
 	if err := forklift.EnsureExists(wpath); err != nil {

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -53,14 +53,14 @@ func cacheAllAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 		if err = fcli.CheckShallowCompatibility(
-			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			pallet, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}
 
 		if err = fcli.CacheAllRequirements(
-			pallet, repoCache.Path(), repoCache, dlCache,
+			0, pallet, repoCache.Path(), repoCache, dlCache,
 			c.Bool("include-disabled"), c.Bool("parallel"),
 		); err != nil {
 			return err
@@ -345,8 +345,9 @@ func preparePallet(
 	if err != nil {
 		return err
 	}
+
 	if err = fcli.CheckShallowCompatibility(
-		pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+		pallet, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 		ignoreToolVersion,
 	); err != nil {
 		return err
@@ -356,7 +357,7 @@ func preparePallet(
 	if cacheStagingReqs {
 		fmt.Println()
 		if err = fcli.CacheStagingRequirements(
-			pallet, repoCache.Path(), repoCache, dlCache, false, parallel,
+			0, pallet, repoCache.Path(), repoCache, dlCache, false, parallel,
 		); err != nil {
 			return err
 		}
@@ -705,7 +706,7 @@ func pullAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 		if err = fcli.CheckShallowCompatibility(
-			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			pallet, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
@@ -713,7 +714,7 @@ func pullAction(versions Versions) cli.ActionFunc {
 
 		if !c.Bool("no-cache-req") {
 			if err = fcli.CacheStagingRequirements(
-				pallet, repoCache.Path(), repoCache, dlCache, false, c.Bool("parallel"),
+				0, pallet, repoCache.Path(), repoCache, dlCache, false, c.Bool("parallel"),
 			); err != nil {
 				return err
 			}
@@ -810,8 +811,10 @@ func stageAction(versions Versions) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		if err = fcli.CheckCompatibility(
-			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+		// Note: we cannot guarantee that all requirements are cached, so we don't check their versions
+		// here; fcli.StagePallet will do those checks for us.
+		if err = fcli.CheckShallowCompatibility(
+			pallet, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
@@ -829,8 +832,7 @@ func stageAction(versions Versions) cli.ActionFunc {
 		}
 		if _, err = fcli.StagePallet(
 			pallet, stageStore, repoCache, dlCache, c.String("exports"),
-			versions.Tool, versions.MinSupportedBundle, versions.NewBundle,
-			c.Bool("no-cache-img"), c.Bool("parallel"), c.Bool("ignore-tool-version"),
+			versions.Versions, c.Bool("no-cache-img"), c.Bool("parallel"), c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}
@@ -847,8 +849,10 @@ func applyAction(versions Versions) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		if err = fcli.CheckCompatibility(
-			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+		// Note: we cannot guarantee that all requirements are cached, so we don't check their versions
+		// here; fcli.StagePallet will do those checks for us.
+		if err = fcli.CheckShallowCompatibility(
+			pallet, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
@@ -866,8 +870,7 @@ func applyAction(versions Versions) cli.ActionFunc {
 		}
 		index, err := fcli.StagePallet(
 			pallet, stageStore, repoCache, dlCache, c.String("exports"),
-			versions.Tool, versions.MinSupportedBundle, versions.NewBundle,
-			false, c.Bool("parallel"), c.Bool("ignore-tool-version"),
+			versions.Versions, false, c.Bool("parallel"), c.Bool("ignore-tool-version"),
 		)
 		if err != nil {
 			return errors.Wrap(err, "couldn't stage pallet to be applied immediately")

--- a/cmd/forklift/plt/repositories.go
+++ b/cmd/forklift/plt/repositories.go
@@ -17,7 +17,7 @@ func cacheRepoAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 		if err = fcli.CheckShallowCompatibility(
-			pallet, cache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			pallet, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
@@ -71,7 +71,7 @@ func addRepoAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 		if err = fcli.CheckShallowCompatibility(
-			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			pallet, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
@@ -83,7 +83,7 @@ func addRepoAction(versions Versions) cli.ActionFunc {
 
 		if !c.Bool("no-cache-req") {
 			if err = fcli.CacheStagingRequirements(
-				pallet, repoCache.Path(), repoCache, dlCache, false, c.Bool("parallel"),
+				0, pallet, repoCache.Path(), repoCache, dlCache, false, c.Bool("parallel"),
 			); err != nil {
 				return err
 			}
@@ -97,12 +97,12 @@ func addRepoAction(versions Versions) cli.ActionFunc {
 
 func rmRepoAction(versions Versions) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		pallet, repoCache, _, err := processFullBaseArgs(c.String("workspace"), false)
+		pallet, _, _, err := processFullBaseArgs(c.String("workspace"), false)
 		if err != nil {
 			return err
 		}
 		if err = fcli.CheckShallowCompatibility(
-			pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+			pallet, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
 			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err

--- a/internal/app/forklift/caching-downloads.go
+++ b/internal/app/forklift/caching-downloads.go
@@ -16,7 +16,7 @@ import (
 
 // Exists checks whether the cache actually exists on the OS's filesystem.
 func (c *FSDownloadCache) Exists() bool {
-	return Exists(filepath.FromSlash(c.FS.Path()))
+	return DirExists(filepath.FromSlash(c.FS.Path()))
 }
 
 // Remove deletes the cache from the OS's filesystem, if it exists.

--- a/internal/app/forklift/caching-pallets.go
+++ b/internal/app/forklift/caching-pallets.go
@@ -17,7 +17,7 @@ import (
 
 // Exists checks whether the cache actually exists on the OS's filesystem.
 func (c *FSPalletCache) Exists() bool {
-	return Exists(filepath.FromSlash(c.FS.Path()))
+	return DirExists(filepath.FromSlash(c.FS.Path()))
 }
 
 // Remove deletes the cache from the OS's filesystem, if it exists.

--- a/internal/app/forklift/caching-repositories.go
+++ b/internal/app/forklift/caching-repositories.go
@@ -18,7 +18,7 @@ import (
 
 // Exists checks whether the cache actually exists on the OS's filesystem.
 func (c *FSRepoCache) Exists() bool {
-	return Exists(filepath.FromSlash(c.FS.Path()))
+	return DirExists(filepath.FromSlash(c.FS.Path()))
 }
 
 // Remove deletes the cache from the OS's filesystem, if it exists.

--- a/internal/app/forklift/cli/compatibility.go
+++ b/internal/app/forklift/cli/compatibility.go
@@ -63,8 +63,7 @@ func CheckCompatibility(
 // palletMinVersion). Note that minimum versions are still enforced even if the ignoreTool flag is
 // set.
 func CheckShallowCompatibility(
-	pallet *forklift.FSPallet, repoLoader forklift.FSRepoLoader,
-	toolVersion, repoMinVersion, palletMinVersion string, ignoreTool bool,
+	pallet *forklift.FSPallet, toolVersion, repoMinVersion, palletMinVersion string, ignoreTool bool,
 ) error {
 	if ignoreTool {
 		fmt.Printf(

--- a/internal/app/forklift/cli/git-repositories.go
+++ b/internal/app/forklift/cli/git-repositories.go
@@ -105,7 +105,10 @@ func ResolveQueriesUsingLocalMirrors(
 	)
 	if err = updateQueriedLocalGitRepoMirrors(indent, queries, cachePath); err != nil {
 		IndentedPrintf(
-			indent, "Couldn't update local Git repo mirrors (do you have internet access?): %s\n", err,
+			indent,
+			"Warning: couldn't update local Git repo mirrors (do you have internet access? does the "+
+				"remote repo actually exist?): %s\n",
+			err,
 		)
 		return resolved, nil
 	}

--- a/internal/app/forklift/cli/git-repositories.go
+++ b/internal/app/forklift/cli/git-repositories.go
@@ -412,15 +412,11 @@ func validateCommit(versionLock forklift.VersionLock, gitRepo *git.Repo) error {
 // Cloning to local copy
 
 func CloneQueriedGitRepoUsingLocalMirror(
-	indent int, cachePath string, query string, destination string,
+	indent int, cachePath, gitRepoPath, versionQuery, destination string,
 ) error {
-	gitRepoPath, versionQuery, ok := strings.Cut(query, "@")
-	if !ok {
-		return errors.Errorf("couldn't parse '%s' as git_repo_path@version", query)
-	}
-
-	queries := []string{query}
-	if _, err := resolveQueriesUsingLocalMirrors(indent, cachePath, queries); err != nil {
+	if _, err := resolveQueriesUsingLocalMirrors(
+		indent, cachePath, []string{gitRepoPath + "@" + versionQuery},
+	); err != nil {
 		return err
 	}
 

--- a/internal/app/forklift/cli/git-repositories.go
+++ b/internal/app/forklift/cli/git-repositories.go
@@ -338,7 +338,7 @@ func downloadLockedGitRepoFromLocalMirror(
 	gitRepoCachePath := filepath.Join(
 		filepath.FromSlash(cachePath), fmt.Sprintf("%s@%s", filepath.FromSlash(gitRepoPath), version),
 	)
-	if forklift.Exists(gitRepoCachePath) {
+	if forklift.DirExists(gitRepoCachePath) {
 		// TODO: perform a disk checksum
 		return false, nil
 	}

--- a/internal/app/forklift/cli/pallets-repositories.go
+++ b/internal/app/forklift/cli/pallets-repositories.go
@@ -141,7 +141,7 @@ func AddRepoRequirements(
 	if err := validateGitRepoQueries(repoQueries); err != nil {
 		return errors.Wrap(err, "one or more repo queries is invalid")
 	}
-	resolved, err := resolveQueriesUsingLocalMirrors(0, cachePath, repoQueries)
+	resolved, err := ResolveQueriesUsingLocalMirrors(0, cachePath, repoQueries, true)
 	if err != nil {
 		return err
 	}

--- a/internal/app/forklift/cli/pallets-staging.go
+++ b/internal/app/forklift/cli/pallets-staging.go
@@ -22,6 +22,7 @@ func StagePallet(
 	); err != nil {
 		return 0, errors.Wrap(err, "couldn't cache requirements for staging the pallet")
 	}
+	fmt.Println()
 
 	index, err = stageStore.AllocateNew()
 	if err != nil {

--- a/internal/app/forklift/cli/pallets-staging.go
+++ b/internal/app/forklift/cli/pallets-staging.go
@@ -11,16 +11,32 @@ import (
 	"github.com/PlanktoScope/forklift/internal/clients/git"
 )
 
+type Versions struct {
+	Tool               string
+	MinSupportedRepo   string
+	MinSupportedPallet string
+	MinSupportedBundle string
+	NewBundle          string
+}
+
 func StagePallet(
 	pallet *forklift.FSPallet, stageStore *forklift.FSStageStore,
 	repoCache forklift.PathedRepoCache, dlCache *forklift.FSDownloadCache,
-	exportPath, toolVersion, bundleMinVersion, newBundleForkliftVersion string,
+	exportPath string, versions Versions,
 	skipImageCaching, parallel, ignoreToolVersion bool,
 ) (index int, err error) {
 	if err = CacheStagingRequirements(
-		pallet, repoCache.Path(), repoCache, dlCache, false, parallel,
+		0, pallet, repoCache.Path(), repoCache, dlCache, false, parallel,
 	); err != nil {
 		return 0, errors.Wrap(err, "couldn't cache requirements for staging the pallet")
+	}
+	// Note: we must have all requirements in the cache before we can check their compatibility with
+	// the Forklift tool version
+	if err = CheckCompatibility(
+		pallet, repoCache, versions.Tool, versions.MinSupportedRepo, versions.MinSupportedPallet,
+		ignoreToolVersion,
+	); err != nil {
+		return 0, err
 	}
 	fmt.Println()
 
@@ -31,12 +47,12 @@ func StagePallet(
 	fmt.Printf("Bundling pallet as stage %d for staged application...\n", index)
 	if err = buildBundle(
 		pallet, repoCache, dlCache,
-		newBundleForkliftVersion, path.Join(stageStore.FS.Path(), fmt.Sprintf("%d", index)),
+		versions.NewBundle, path.Join(stageStore.FS.Path(), fmt.Sprintf("%d", index)),
 	); err != nil {
 		return index, errors.Wrapf(err, "couldn't bundle pallet %s as stage %d", pallet.Path(), index)
 	}
 	if err = SetNextStagedBundle(
-		stageStore, index, exportPath, toolVersion, bundleMinVersion,
+		stageStore, index, exportPath, versions.Tool, versions.MinSupportedBundle,
 		skipImageCaching, parallel, ignoreToolVersion,
 	); err != nil {
 		return index, errors.Wrapf(

--- a/internal/app/forklift/cli/pallets.go
+++ b/internal/app/forklift/cli/pallets.go
@@ -1,9 +1,13 @@
 package cli
 
 import (
+	"cmp"
 	"fmt"
+	"slices"
+	"strings"
 
 	ggit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/pkg/errors"
 
 	"github.com/PlanktoScope/forklift/internal/app/forklift"
@@ -162,13 +166,38 @@ func printRemotesInfo(indent int, palletPath string) error {
 	fmt.Println()
 	indent++
 
+	SortRemotes(remotes)
+	printCacheMirrorRemote := false
 	for _, remote := range remotes {
-		printRemoteInfo(indent, remote)
+		if remote.Config().Name == ForkliftCacheMirrorRemoteName && !printCacheMirrorRemote {
+			IndentedPrintf(
+				indent, "%s: (skipped because origin was successfully queried)\n", remote.Config().Name,
+			)
+			continue
+		}
+
+		if err := printRemoteInfo(
+			indent, remote,
+		); err != nil && remote.Config().Name == OriginRemoteName {
+			printCacheMirrorRemote = true
+		}
 	}
 	return nil
 }
 
-func printRemoteInfo(indent int, remote *ggit.Remote) {
+func SortRemotes(remotes []*ggit.Remote) {
+	slices.SortFunc(remotes, func(a, b *ggit.Remote) int {
+		if a.Config().Name == OriginRemoteName {
+			return -1
+		}
+		if b.Config().Name == OriginRemoteName {
+			return 1
+		}
+		return cmp.Compare(a.Config().Name, b.Config().Name)
+	})
+}
+
+func printRemoteInfo(indent int, remote *ggit.Remote) error {
 	config := remote.Config()
 	IndentedPrintf(indent, "%s:\n", config.Name)
 	indent++
@@ -190,16 +219,24 @@ func printRemoteInfo(indent int, remote *ggit.Remote) {
 	refs, err := remote.List(git.EmptyListOptions())
 	if err != nil {
 		fmt.Printf(" (couldn't retrieve references: %s)\n", err)
-		return
+		return err
 	}
 
 	if len(refs) == 0 {
 		fmt.Print(" (none)")
 	}
 	fmt.Println()
+	slices.SortFunc(refs, func(a, b *plumbing.Reference) int {
+		return cmp.Compare(git.StringifyRef(a), git.StringifyRef(b))
+	})
 	for _, ref := range refs {
+		if strings.HasPrefix(git.StringifyRef(ref), "pull/") {
+			continue
+		}
 		BulletedPrintf(indent+1, "%s\n", git.StringifyRef(ref))
 	}
+
+	return nil
 }
 
 // Download

--- a/internal/app/forklift/cli/pallets.go
+++ b/internal/app/forklift/cli/pallets.go
@@ -266,17 +266,17 @@ func DownloadRequiredPallets(
 // Cache
 
 func CacheAllRequirements(
-	pallet *forklift.FSPallet, repoCachePath string,
+	indent int, pallet *forklift.FSPallet, repoCachePath string,
 	pkgLoader forklift.FSPkgLoader, dlCache *forklift.FSDownloadCache,
 	includeDisabled, parallel bool,
 ) error {
 	if err := CacheStagingRequirements(
-		pallet, repoCachePath, pkgLoader, dlCache, includeDisabled, parallel,
+		indent, pallet, repoCachePath, pkgLoader, dlCache, includeDisabled, parallel,
 	); err != nil {
 		return err
 	}
 
-	fmt.Println("Downloading Docker container images to be deployed by the local pallet...")
+	IndentedPrintln(indent, "Downloading Docker container images to be deployed by the local pallet...")
 	if err := DownloadImages(1, pallet, pkgLoader, includeDisabled, parallel); err != nil {
 		return err
 	}
@@ -284,19 +284,22 @@ func CacheAllRequirements(
 }
 
 func CacheStagingRequirements(
-	pallet *forklift.FSPallet, repoCachePath string,
+	indent int, pallet *forklift.FSPallet, repoCachePath string,
 	pkgLoader forklift.FSPkgLoader, dlCache *forklift.FSDownloadCache,
 	includeDisabled, parallel bool,
 ) error {
+	IndentedPrintln(indent, "Caching everything needed to stage the pallet...")
+	indent++
+
 	// TODO: download required pallets, once we allow layering pallets; then merge the pallets into
 	// a composite before downloading required repos
 
-	fmt.Println("Downloading repos required by the local pallet...")
+	IndentedPrintln(indent, "Downloading repos required by the local pallet...")
 	if _, err := DownloadRequiredRepos(0, pallet, repoCachePath); err != nil {
 		return err
 	}
 
-	fmt.Println("Downloading files for export by the local pallet...")
+	IndentedPrintln(indent, "Downloading files for export by the local pallet...")
 	if err := DownloadExportFiles(
 		1, pallet, pkgLoader, dlCache, includeDisabled, parallel,
 	); err != nil {

--- a/internal/app/forklift/config-models.go
+++ b/internal/app/forklift/config-models.go
@@ -1,0 +1,12 @@
+package forklift
+
+// A GitRepoQuery holds settings for upgrading the locked version of a Git repo from the
+// refs (branches & tags) in its origin.
+type GitRepoQuery struct {
+	// Path is the path of the pallet or Forklift repo being queried
+	// (e.g. github.com/PlanktoScope/pallet-standard)
+	Path string `yaml:"path"`
+	// VersionQuery is the version query of the pallet or Forklift repo being queried
+	// (e.g. edge or stable or v2024.0.0-beta.0)
+	VersionQuery string `yaml:"version-query"`
+}

--- a/internal/app/forklift/config.go
+++ b/internal/app/forklift/config.go
@@ -1,0 +1,62 @@
+package forklift
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+
+	"github.com/PlanktoScope/forklift/pkg/core"
+)
+
+// GitRepoQuery
+
+// loadGitRepoQuery loads a GitRepoQuery from the specified file path in the
+// provided base filesystem.
+func loadGitRepoQuery(fsys core.PathedFS, filePath string) (GitRepoQuery, error) {
+	bytes, err := fs.ReadFile(fsys, filePath)
+	if err != nil {
+		return GitRepoQuery{}, errors.Wrapf(
+			err, "couldn't read git repo query file %s/%s", fsys.Path(), filePath,
+		)
+	}
+	query := GitRepoQuery{}
+	if err = yaml.Unmarshal(bytes, &query); err != nil {
+		return GitRepoQuery{}, errors.Wrap(err, "couldn't parse git repo query")
+	}
+	return query, nil
+}
+
+func (q GitRepoQuery) Write(outputPath string) error {
+	marshaled, err := yaml.Marshal(q)
+	if err != nil {
+		return errors.Wrapf(err, "couldn't marshal stage store state")
+	}
+	const perm = 0o644 // owner rw, group r, public r
+	if err = os.WriteFile(filepath.FromSlash(outputPath), marshaled, perm); err != nil {
+		return errors.Wrapf(err, "couldn't save git repo query to %s", outputPath)
+	}
+	return nil
+}
+
+func (q GitRepoQuery) Complete() bool {
+	return q.Path != "" && q.VersionQuery != ""
+}
+
+func (q GitRepoQuery) String() string {
+	return fmt.Sprintf("%s@%s", q.Path, q.VersionQuery)
+}
+
+func (q GitRepoQuery) Overlay(r GitRepoQuery) GitRepoQuery {
+	result := q
+	if r.Path != "" {
+		result.Path = r.Path
+	}
+	if r.VersionQuery != "" {
+		result.VersionQuery = r.VersionQuery
+	}
+	return result
+}

--- a/internal/app/forklift/pallets.go
+++ b/internal/app/forklift/pallets.go
@@ -91,7 +91,7 @@ func LoadFSPallets(fsys core.PathedFS, searchPattern string) ([]*FSPallet, error
 
 // Exists checks whether the pallet actually exists on the OS's filesystem.
 func (p *FSPallet) Exists() bool {
-	return Exists(p.FS.Path())
+	return DirExists(p.FS.Path())
 }
 
 // Remove deletes the cache from the OS's filesystem, if it exists.

--- a/internal/app/forklift/staging.go
+++ b/internal/app/forklift/staging.go
@@ -58,7 +58,7 @@ func LoadFSStageStore(fsys core.PathedFS, subdirPath string) (s *FSStageStore, e
 
 // Exists checks whether the store actually exists on the OS's filesystem.
 func (s *FSStageStore) Exists() bool {
-	return Exists(filepath.FromSlash(s.FS.Path()))
+	return DirExists(filepath.FromSlash(s.FS.Path()))
 }
 
 // Remove deletes the store from the OS's filesystem, if it exists.
@@ -126,7 +126,7 @@ func (s *FSStageStore) AllocateNew() (index int, err error) {
 	// index (i.e. Go's default-initialization for an int) can represent a missing index.
 	index = prevIndex + 1
 	newPath := filepath.FromSlash(s.GetBundlePath(index))
-	if Exists(newPath) {
+	if DirExists(newPath) {
 		return index, errors.Wrapf(err, "a stage already exists at %s", newPath)
 	}
 	if err = EnsureExists(newPath); err != nil {
@@ -234,12 +234,12 @@ func (s *FSStageStore) CommitState() error {
 	// TODO: we might want to be less sloppy about read locks vs. write locks in the future. After
 	// successfully acquiring a write lock, then we could just overwrite the swap file.
 	swapPath := path.Join(s.FS.Path(), StageStoreManifestSwapFile)
-	if Exists(filepath.FromSlash(swapPath)) {
+	if FileExists(filepath.FromSlash(swapPath)) {
 		return errors.Errorf(
 			"stage store manifest swap file %s already exists, so either another operation is "+
 				"currently running or the previous operation failed or was interrupted before it could "+
 				"finish; please ensure that no other operations are currently running and delete the swap "+
-				" file before retrying",
+				"file before retrying",
 			swapPath,
 		)
 	}

--- a/internal/app/forklift/workspace-models.go
+++ b/internal/app/forklift/workspace-models.go
@@ -21,6 +21,14 @@ const (
 
 const (
 	dataDirPath              = ".local/share/forklift"
-	dataCurrentPalletDirName = "pallet" // TODO: cache pallets and track the "current" one in a file?
+	dataCurrentPalletDirName = "pallet"
 	dataStageStoreDirName    = "stages"
+)
+
+// in $HOME/.config/forklift:
+
+const (
+	configDirPath                       = ".config/forklift"
+	configCurrentPalletUpgradesFile     = "pallet-upgrades.yml"
+	configCurrentPalletUpgradesSwapFile = "pallet-upgrades-swap.yml"
 )

--- a/internal/app/forklift/workspace.go
+++ b/internal/app/forklift/workspace.go
@@ -9,7 +9,15 @@ import (
 	"github.com/PlanktoScope/forklift/pkg/core"
 )
 
-func Exists(dirPath string) bool {
+func FileExists(filePath string) bool {
+	results, err := os.Stat(filePath)
+	if err == nil && !results.IsDir() {
+		return true
+	}
+	return false
+}
+
+func DirExists(dirPath string) bool {
 	dir, err := os.Stat(dirPath)
 	if err == nil && dir.IsDir() {
 		return true
@@ -30,7 +38,7 @@ func EnsureExists(dirPath string) error {
 // [XDG base directory spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
 // The provided path must use the host OS's path separators.
 func LoadWorkspace(dirPath string) (*FSWorkspace, error) {
-	if !Exists(dirPath) {
+	if !DirExists(dirPath) {
 		return nil, errors.Errorf("couldn't find workspace at %s", dirPath)
 	}
 	return &FSWorkspace{

--- a/internal/app/forklift/workspace.go
+++ b/internal/app/forklift/workspace.go
@@ -3,6 +3,7 @@ package forklift
 import (
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 
@@ -175,4 +176,59 @@ func (w *FSWorkspace) GetDownloadCache() (*FSDownloadCache, error) {
 	return &FSDownloadCache{
 		FS: pathedFS,
 	}, nil
+}
+
+// Config
+
+func (w *FSWorkspace) getConfigPath() string {
+	return path.Join(w.FS.Path(), configDirPath)
+}
+
+func (w *FSWorkspace) getConfigFS() (core.PathedFS, error) {
+	if err := EnsureExists(w.getConfigPath()); err != nil {
+		return nil, errors.Wrapf(err, "couldn't ensure the existence of %s", w.getConfigPath())
+	}
+
+	fsys, err := w.FS.Sub(configDirPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't get config directory from workspace")
+	}
+	return fsys, nil
+}
+
+func (w *FSWorkspace) GetCurrentPalletUpgrades() (GitRepoQuery, error) {
+	fsys, err := w.getConfigFS()
+	if err != nil {
+		return GitRepoQuery{}, err
+	}
+	return loadGitRepoQuery(fsys, configCurrentPalletUpgradesFile)
+}
+
+// CommitCurrentPalletUpgrades atomoically updates the current pallet upgrades file.
+// Warning: on non-Unix platforms, the update is not entirely atomic!
+func (w *FSWorkspace) CommitCurrentPalletUpgrades(query GitRepoQuery) error {
+	// TODO: we might want to be less sloppy about read locks vs. write locks in the future. After
+	// successfully acquiring a write lock, then we could just overwrite the swap file.
+	swapPath := path.Join(w.getConfigPath(), configCurrentPalletUpgradesSwapFile)
+	if FileExists(filepath.FromSlash(swapPath)) {
+		return errors.Errorf(
+			"current pallet upgrades swap file %s already exists, so either another operation is "+
+				"currently running or the previous operation failed or was interrupted before it could "+
+				"finish; please ensure that no other operations are currently running and delete the swap "+
+				"file before retrying",
+			swapPath,
+		)
+	}
+	if err := query.Write(swapPath); err != nil {
+		return errors.Wrapf(err, "couldn't save current pallet upgrades to swap file %s", swapPath)
+	}
+	outputPath := path.Join(w.getConfigPath(), configCurrentPalletUpgradesFile)
+	// Warning: on non-Unix platforms, os.Rename is not an atomic operation! So if the program dies
+	// during the os.Rename call, we could end up breaking the state of the stage store.
+	if err := os.Rename(filepath.FromSlash(swapPath), filepath.FromSlash(outputPath)); err != nil {
+		return errors.Wrapf(
+			err, "couldn't commit current pallet upgrades update from %s to %s", swapPath, outputPath,
+		)
+	}
+	return nil
 }


### PR DESCRIPTION
This PR closes #246 by:
- Adding support for `plt clone/switch pallet_path@`, `plt clone/switch @version_query`, and `plt clone/switch @` which complete the omitted pallet path and/or version query based on last used values (tracked in a new config file at ~/.config/forklift/pallet-upgrades.yml`.
- Adding a `plt upgrade` subcommand which behaves like `plt switch @` but also shows information about the upgrade to be performed.
- Adding `plt show-upgrade-query` and `plt set-upgrade-query` subcommands to query and modify the query to be used for `plt upgrade`.
- Adding a `plt show-upgrade` command which shows whether an upgrade is available.

In order to prevent upgrades from causing unplanned loss of user changes, this PR also resolves #229 by adding some basic checks for un-committed/un-pushed user changes in `plt switch` and `plt upgrade`.