### PR TITLE
Enable transitive pallet file imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (cli) Added a `[dev] plt locate-plt-file` command to print the actual filesystem path of the specified file in the specified pallet required by the local/development pallet.
 - (cli) Added a `[dev] plt show-plt-file` command to print the contents of the specified file in the specified pallet required by the local/development pallet.
 
+### Changed
+
+- (cli) Removed some aliases for `[dev] plt add-plt` and `[dev] plt add-repo` which should not have been added, because they were constructed as a combination of an abbrebiation and an unabbreviated word.
+
 ### Fixed
 
 - (cli) Transitive imports of files across pallets (e.g. importing a file from a pallet which actually imports that file from another pallet) is no longer completely broken (it should work, but there may still be undiscovered bugs because the code paths have not been thoroughly tested).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - (cli) Added a `[dev] plt ls-plt-file` command to list files in the specified pallet required by the local/development pallet, including files imported by that required pallet from its own required pallets.
-- (cli) Added a `[dev] plt locate-plt-file` command to print the actual filesystem path of the specified file in the specified pallet required by the local/development pallet. TODO: fix incorrect path resolution behavior for transitively-imported files!
+- (cli) Added a `[dev] plt locate-plt-file` command to print the actual filesystem path of the specified file in the specified pallet required by the local/development pallet.
 - (cli) Added a `[dev] plt show-plt-file` command to print the contents of the specified file in the specified pallet required by the local/development pallet.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- (cli) Added a `[dev] plt ls-plt-file` command to list files in the specified pallet required by the local/development pallet, including files imported by that required pallet from its own required pallets.
+- (cli) Added a `[dev] plt locate-plt-file` command to print the actual filesystem path of the specified file in the specified pallet required by the local/development pallet. TODO: fix incorrect path resolution behavior for transitively-imported files!
+- (cli) Added a `[dev] plt show-plt-file` command to print the contents of the specified file in the specified pallet required by the local/development pallet.
+
+### Fixed
+
+- (cli) Transitive imports of files across pallets (e.g. importing a file from a pallet which actually imports that file from another pallet) is no longer completely broken (it should work, but there may still be undiscovered bugs because the code paths have not been thoroughly tested).
+
 ## 0.8.0-alpha.1 - 2024-08-30
 
 ### Added
@@ -18,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (cli) Added a `[dev] plt show-imp` command to show the specified file import group declared by the local/development pallet.
 - (cli) Added a `[dev] plt locate-repo` command to print the actual filesystem path of the specified available package repository. The actual filesystem path may be for a subdirectory in the repositories cache, or a subdirectory in an override repository (in the case of `dev plt` with the `--repos` flag).
 - (cli) Added a `[dev] plt locate-pkg` command to print the actual filesystem path of the specified available package. The actual filesystem path may be for a subdirectory in the repositories cache, or a subdirectory in an override repository (in the case of `dev plt` with the `--repos` flag), or a subdirectory in the local/development pallet (in the case of a local package defined by the pallet), or a subdirectory in a required pallet (in the case of a local package imported from another pallet).
-- (cli) Added a `[dev] plt ls-file` command to list all files in the local/development pallet, including files imported by the pallet from required pallets.
+- (cli) Added a `[dev] plt ls-file` command to list files in the local/development pallet, including files imported by the pallet from required pallets.
 - (cli) Added a `[dev] plt locate-file` command to print the actual filesystem path of the specified file in the pallet. The actual filesystem path may be for a file in the pallets cache, or a file in an override pallet (in the case of `dev plt` with the `--plts` flag), or a file in the local/development pallet (in the case of a local file defined by the pallet), or a file in a required pallet (in the case of a file imported from another pallet).
 - (cli) Added a `[dev] plt show-file` command to print the contents of the specified file in the local/development pallet.
 - (cli) Added a `[dev] plt edit-file` command to edit the specified file in the local/development pallet, using the editor set by the `$EDITOR` environment variable. If the file was previously only in an underlay, a temporary copy is provided to the editor; if changes are saved when the editor quits, the changed file will be saved as an override file into the local/development pallet.

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -406,6 +406,7 @@ func makeModifyFileSubcmds() []*cli.Command {
 		},
 		{
 			Name:      "rm-file",
+			Aliases:   []string{"remove-file", "del-file", "delete-file"},
 			Category:  category,
 			Usage:     "Removes the specified file in the development pallet",
 			ArgsUsage: "file_path",
@@ -421,8 +422,7 @@ func makeModifyPltSubcmds(versions Versions) []*cli.Command {
 			Name: "add-plt",
 			Aliases: []string{
 				"add-pallet", "add-pallets",
-				"req-plt", "req-pallet", "req-pallets",
-				"require-plt", "require-pallet", "require-pallets",
+				"req-plt", "require-pallet", "require-pallets",
 			},
 			Category: category,
 			Usage: "Adds (or re-adds) pallet requirements to the pallet, tracking specified versions " +
@@ -471,8 +471,7 @@ func makeModifyRepoSubcmds(versions Versions) []*cli.Command {
 			Name: "add-repo",
 			Aliases: []string{
 				"add-repository", "add-repositories",
-				"req-repo", "req-repository", "req-repositories",
-				"require-repo", "require-repository", "require-repositories",
+				"req-repo", "require-repository", "require-repositories",
 			},
 			Category: category,
 			Usage: "Adds (or re-adds) repo requirements to the pallet, tracking specified versions " +

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -185,45 +185,82 @@ func makeQuerySubcmds() []*cli.Command {
 }
 
 func makeQueryReqSubcmds(category string) []*cli.Command {
+	return slices.Concat(
+		[]*cli.Command{
+			{
+				Name:     "ls-plt",
+				Aliases:  []string{"list-pallets"},
+				Category: category,
+				Usage:    "Lists pallets which the development pallet may import files from",
+				Action:   lsPltAction,
+			},
+			{
+				Name:      "show-plt",
+				Aliases:   []string{"show-pallet"},
+				Category:  category,
+				Usage:     "Describes a pallet which the development pallet may import files from",
+				ArgsUsage: "plt_path",
+				Action:    showPltAction,
+			},
+		},
+		makeQueryPltFileSubcmds(category),
+		[]*cli.Command{
+			{
+				Name:     "ls-repo",
+				Aliases:  []string{"list-repositories"},
+				Category: category,
+				Usage:    "Lists repos specified by the development pallet",
+				Action:   lsRepoAction,
+			},
+			{
+				Name:     "locate-repo",
+				Aliases:  []string{"locate-repository"},
+				Category: category,
+				Usage: "Prints the absolute filesystem path of a repo available in the development " +
+					"pallet",
+				ArgsUsage: "repo_path",
+				Action:    locateRepoAction,
+			},
+			{
+				Name:      "show-repo",
+				Aliases:   []string{"show-repository"},
+				Category:  category,
+				Usage:     "Describes a repo available in the development pallet",
+				ArgsUsage: "repo_path",
+				Action:    showRepoAction,
+			},
+		},
+	)
+}
+
+func makeQueryPltFileSubcmds(category string) []*cli.Command {
 	return []*cli.Command{
 		{
-			Name:     "ls-plt",
-			Aliases:  []string{"list-pallets"},
+			Name:     "ls-plt-file",
+			Aliases:  []string{"list-pallet-files"},
 			Category: category,
-			Usage:    "Lists pallets which the development pallet may import files from",
-			Action:   lsPltAction,
+			Usage: "Lists non-directory files in the specified pallet which the development pallet may " +
+				"import files from",
+			ArgsUsage: "pallet_path [path_glob]",
+			Action:    lsPltFileAction,
 		},
 		{
-			Name:      "show-plt",
-			Aliases:   []string{"show-pallet"},
-			Category:  category,
-			Usage:     "Describes a pallet which the development pallet may import files from",
-			ArgsUsage: "plt_path",
-			Action:    showPltAction,
-		},
-		{
-			Name:     "ls-repo",
-			Aliases:  []string{"list-repositories"},
+			Name:     "locate-plt-file",
+			Aliases:  []string{"locate-pallet-file"},
 			Category: category,
-			Usage:    "Lists repos specified by the development pallet",
-			Action:   lsRepoAction,
+			Usage: "Prints the absolute filesystem path of the specified file in the specified pallet " +
+				"which the development pallet may import files from",
+			ArgsUsage: "pallet_path file_path",
+			Action:    locatePltFileAction,
 		},
 		{
-			Name:     "locate-repo",
-			Aliases:  []string{"locate-repository"},
+			Name:     "show-plt-file",
+			Aliases:  []string{"show-pallet-file"},
 			Category: category,
-			Usage: "Prints the absolute filesystem path of a repo available in the development " +
-				"pallet",
-			ArgsUsage: "repo_path",
-			Action:    locateRepoAction,
-		},
-		{
-			Name:      "show-repo",
-			Aliases:   []string{"show-repository"},
-			Category:  category,
-			Usage:     "Describes a repo available in the development pallet",
-			ArgsUsage: "repo_path",
-			Action:    showRepoAction,
+			Usage: "Prints the specified file in the specified pallet which the development pallet may " +
+				"import files from",
+			ArgsUsage: "pallet_path file_path",
+			Action:    showPltFileAction,
 		},
 	}
 }
@@ -272,27 +309,6 @@ func makeQueryFileSubcmds(category string) []*cli.Command {
 			Usage:     "Prints the specified file in the development pallet",
 			ArgsUsage: "file_path",
 			Action:    showFileAction,
-		},
-		{
-			Name:      "edit-file",
-			Category:  category,
-			Usage:     "Edits the specified file in the development pallet",
-			ArgsUsage: "file_path",
-			Action:    editFileAction,
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:    "editor",
-					Usage:   "Path of text editor",
-					EnvVars: []string{"EDITOR"},
-				},
-			},
-		},
-		{
-			Name:      "rm-file",
-			Category:  category,
-			Usage:     "Removes the specified file in the development pallet",
-			ArgsUsage: "file_path",
-			Action:    rmFileAction,
 		},
 	}
 }
@@ -362,12 +378,40 @@ func makeQueryDeplSubcmds(category string) []*cli.Command {
 
 func makeModifySubcmds(versions Versions) []*cli.Command {
 	return slices.Concat(
+		makeModifyFileSubcmds(),
 		makeModifyPltSubcmds(versions),
 		// TODO: add `add-imp`, `rm-imp`, `set-imp-disabled`, `unset-imp-disabled`,
 		// `add-imp-mod`, and `rm-imp-mod` subcommands
 		makeModifyRepoSubcmds(versions),
 		makeModifyDeplSubcmds(versions),
 	)
+}
+
+func makeModifyFileSubcmds() []*cli.Command {
+	const category = "Modify the pallet's files"
+	return []*cli.Command{
+		{
+			Name:      "edit-file",
+			Category:  category,
+			Usage:     "Edits the specified file in the development pallet",
+			ArgsUsage: "file_path",
+			Action:    editFileAction,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:    "editor",
+					Usage:   "Path of text editor",
+					EnvVars: []string{"EDITOR"},
+				},
+			},
+		},
+		{
+			Name:      "rm-file",
+			Category:  category,
+			Usage:     "Removes the specified file in the development pallet",
+			ArgsUsage: "file_path",
+			Action:    rmFileAction,
+		},
+	}
 }
 
 func makeModifyPltSubcmds(versions Versions) []*cli.Command {

--- a/cmd/forklift/dev/plt/files.go
+++ b/cmd/forklift/dev/plt/files.go
@@ -8,7 +8,7 @@ import (
 	fcli "github.com/PlanktoScope/forklift/internal/app/forklift/cli"
 )
 
-// ls-files
+// ls-file
 
 func lsFileAction(c *cli.Context) error {
 	plt, _, err := processFullBaseArgs(c, processingOptions{

--- a/cmd/forklift/dev/plt/pallets.go
+++ b/cmd/forklift/dev/plt/pallets.go
@@ -512,3 +512,44 @@ func rmPltAction(versions Versions) cli.ActionFunc {
 		return nil
 	}
 }
+
+// ls-plt-file
+
+func lsPltFileAction(c *cli.Context) error {
+	plt, caches, err := processFullBaseArgs(c, processingOptions{
+		enableOverrides: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	plt, err = fcli.GetRequiredPallet(plt, caches.p, c.Args().First())
+	if err != nil {
+		return nil
+	}
+	paths, err := fcli.ListPalletFiles(plt, c.Args().Get(1))
+	if err != nil {
+		return err
+	}
+	for _, p := range paths {
+		fmt.Println(p)
+	}
+	return nil
+}
+
+// show-plt-file
+
+func showPltFileAction(c *cli.Context) error {
+	plt, caches, err := processFullBaseArgs(c, processingOptions{
+		enableOverrides: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	plt, err = fcli.GetRequiredPallet(plt, caches.p, c.Args().First())
+	if err != nil {
+		return nil
+	}
+	return fcli.PrintFile(plt, c.Args().Get(1))
+}

--- a/cmd/forklift/dev/plt/pallets.go
+++ b/cmd/forklift/dev/plt/pallets.go
@@ -537,6 +537,28 @@ func lsPltFileAction(c *cli.Context) error {
 	return nil
 }
 
+// locate-plt-file
+
+func locatePltFileAction(c *cli.Context) error {
+	plt, caches, err := processFullBaseArgs(c, processingOptions{
+		enableOverrides: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	plt, err = fcli.GetRequiredPallet(plt, caches.p, c.Args().First())
+	if err != nil {
+		return nil
+	}
+	location, err := fcli.GetFileLocation(plt, c.Args().Get(1))
+	if err != nil {
+		return err
+	}
+	fmt.Println(location)
+	return nil
+}
+
 // show-plt-file
 
 func showPltFileAction(c *cli.Context) error {

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -252,44 +252,81 @@ func makeQuerySubcmds() []*cli.Command {
 }
 
 func makeQueryReqSubcmds(category string) []*cli.Command {
+	return slices.Concat(
+		[]*cli.Command{
+			{
+				Name:     "ls-plt",
+				Aliases:  []string{"list-pallets"},
+				Category: category,
+				Usage:    "Lists pallets which the local pallet may import files from",
+				Action:   lsPltAction,
+			},
+			{
+				Name:      "show-plt",
+				Aliases:   []string{"show-pallet"},
+				Category:  category,
+				Usage:     "Describes a pallet which the local pallet may import files from",
+				ArgsUsage: "plt_path",
+				Action:    showPltAction,
+			},
+		},
+		makeQueryPltFileSubcmds(category),
+		[]*cli.Command{
+			{
+				Name:     "ls-repo",
+				Aliases:  []string{"list-repositories"},
+				Category: category,
+				Usage:    "Lists repos available in the local pallet",
+				Action:   lsRepoAction,
+			},
+			{
+				Name:      "locate-repo",
+				Aliases:   []string{"locate-repository"},
+				Category:  category,
+				Usage:     "Prints the absolute filesystem path of a repo available in the local pallet",
+				ArgsUsage: "repo_path",
+				Action:    locateRepoAction,
+			},
+			{
+				Name:      "show-repo",
+				Aliases:   []string{"show-repository"},
+				Category:  category,
+				Usage:     "Describes a repo available in the local pallet",
+				ArgsUsage: "repo_path",
+				Action:    showRepoAction,
+			},
+		},
+	)
+}
+
+func makeQueryPltFileSubcmds(category string) []*cli.Command {
 	return []*cli.Command{
 		{
-			Name:     "ls-plt",
-			Aliases:  []string{"list-pallets"},
+			Name:     "ls-plt-file",
+			Aliases:  []string{"list-pallet-files"},
 			Category: category,
-			Usage:    "Lists pallets which the local pallet may import files from",
-			Action:   lsPltAction,
+			Usage: "Lists non-directory files in the specified pallet which the local pallet may " +
+				"import files from",
+			ArgsUsage: "[path_glob]",
+			Action:    lsPltFileAction,
 		},
 		{
-			Name:      "show-plt",
-			Aliases:   []string{"show-pallet"},
-			Category:  category,
-			Usage:     "Describes a pallet which the local pallet may import files from",
-			ArgsUsage: "plt_path",
-			Action:    showPltAction,
-		},
-		{
-			Name:     "ls-repo",
-			Aliases:  []string{"list-repositories"},
+			Name:     "locate-plt-file",
+			Aliases:  []string{"locate-pallet-files"},
 			Category: category,
-			Usage:    "Lists repos available in the local pallet",
-			Action:   lsRepoAction,
+			Usage: "Prints the absolute filesystem path of the specified file in the specified " +
+				"pallet which the local pallet may import files from",
+			ArgsUsage: "file_path",
+			Action:    locatePltFileAction,
 		},
 		{
-			Name:      "locate-repo",
-			Aliases:   []string{"locate-repository"},
-			Category:  category,
-			Usage:     "Prints the absolute filesystem path of a repo available in the local pallet",
-			ArgsUsage: "repo_path",
-			Action:    locateRepoAction,
-		},
-		{
-			Name:      "show-repo",
-			Aliases:   []string{"show-repository"},
-			Category:  category,
-			Usage:     "Describes a repo available in the local pallet",
-			ArgsUsage: "repo_path",
-			Action:    showRepoAction,
+			Name:     "show-plt-file",
+			Aliases:  []string{"show-pallet-files"},
+			Category: category,
+			Usage: "Prints the specified file in the specified pallet which the local pallet may " +
+				"import files from",
+			ArgsUsage: "file_path",
+			Action:    showPltFileAction,
 		},
 	}
 }
@@ -337,27 +374,6 @@ func makeQueryFileSubcmds(category string) []*cli.Command {
 			Usage:     "Prints the specified file in the local pallet",
 			ArgsUsage: "file_path",
 			Action:    showFileAction,
-		},
-		{
-			Name:      "edit-file",
-			Category:  category,
-			Usage:     "Edits the specified file in the development pallet",
-			ArgsUsage: "file_path",
-			Action:    editFileAction,
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:    "editor",
-					Usage:   "Path of text editor",
-					EnvVars: []string{"EDITOR"},
-				},
-			},
-		},
-		{
-			Name:      "rm-file",
-			Category:  category,
-			Usage:     "Removes the specified file in the development pallet",
-			ArgsUsage: "file_path",
-			Action:    rmFileAction,
 		},
 	}
 }
@@ -437,6 +453,7 @@ func makeModifySubcmds(versions Versions) []*cli.Command {
 				Action:   rmAction,
 			},
 		},
+		makeModifyFileSubcmds(),
 		makeModifyPltSubcmds(versions),
 		// TODO: add `add-imp`, `rm-imp`, `set-imp-disabled`, `unset-imp-disabled`,
 		// `add-imp-mod`, and `rm-imp-mod` subcommands
@@ -528,6 +545,33 @@ var modifyBaseFlags []cli.Flag = []cli.Flag{
 //			},
 //		},
 //	}
+
+func makeModifyFileSubcmds() []*cli.Command {
+	const category = "Modify the pallet's files"
+	return []*cli.Command{
+		{
+			Name:      "edit-file",
+			Category:  category,
+			Usage:     "Edits the specified file in the development pallet",
+			ArgsUsage: "file_path",
+			Action:    editFileAction,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:    "editor",
+					Usage:   "Path of text editor",
+					EnvVars: []string{"EDITOR"},
+				},
+			},
+		},
+		{
+			Name:      "rm-file",
+			Category:  category,
+			Usage:     "Removes the specified file in the development pallet",
+			ArgsUsage: "file_path",
+			Action:    rmFileAction,
+		},
+	}
+}
 
 func makeModifyPltSubcmds(versions Versions) []*cli.Command {
 	const category = "Modify the pallet's pallet requirements"

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -565,6 +565,7 @@ func makeModifyFileSubcmds() []*cli.Command {
 		},
 		{
 			Name:      "rm-file",
+			Aliases:   []string{"remove-file", "del-file", "delete-file"},
 			Category:  category,
 			Usage:     "Removes the specified file in the development pallet",
 			ArgsUsage: "file_path",
@@ -580,8 +581,7 @@ func makeModifyPltSubcmds(versions Versions) []*cli.Command {
 			Name: "add-plt",
 			Aliases: []string{
 				"add-pallet", "add-pallets",
-				"req-plt", "req-pallet", "req-pallets",
-				"require-plt", "require-pallet", "require-pallets",
+				"req-plt", "require-pallet", "require-pallets",
 			},
 			Category: category,
 			Usage: "Adds (or re-adds) pallet requirements to the pallet, tracking specified versions " +
@@ -630,8 +630,7 @@ func makeModifyRepoSubcmds(versions Versions) []*cli.Command {
 			Name: "add-repo",
 			Aliases: []string{
 				"add-repository", "add-repositories",
-				"req-repo", "req-repository", "req-repositories",
-				"require-repo", "require-repository", "require-repositories",
+				"req-repo", "require-repository", "require-repositories",
 			},
 			Category: category,
 			Usage: "Adds (or re-adds) repo requirements to the pallet, tracking specified versions " +

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -1023,3 +1023,40 @@ func rmPltAction(versions Versions) cli.ActionFunc {
 		return nil
 	}
 }
+
+// ls-plt-file
+
+func lsPltFileAction(c *cli.Context) error {
+	plt, caches, err := processFullBaseArgs(c.String("workspace"), processingOptions{})
+	if err != nil {
+		return err
+	}
+
+	plt, err = fcli.GetRequiredPallet(plt, caches.p, c.Args().First())
+	if err != nil {
+		return nil
+	}
+	paths, err := fcli.ListPalletFiles(plt, c.Args().Get(1))
+	if err != nil {
+		return err
+	}
+	for _, p := range paths {
+		fmt.Println(p)
+	}
+	return nil
+}
+
+// show-plt-file
+
+func showPltFileAction(c *cli.Context) error {
+	plt, caches, err := processFullBaseArgs(c.String("workspace"), processingOptions{})
+	if err != nil {
+		return err
+	}
+
+	plt, err = fcli.GetRequiredPallet(plt, caches.p, c.Args().First())
+	if err != nil {
+		return nil
+	}
+	return fcli.PrintFile(plt, c.Args().Get(1))
+}

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -1046,6 +1046,26 @@ func lsPltFileAction(c *cli.Context) error {
 	return nil
 }
 
+// locate-plt-file
+
+func locatePltFileAction(c *cli.Context) error {
+	plt, caches, err := processFullBaseArgs(c.String("workspace"), processingOptions{})
+	if err != nil {
+		return err
+	}
+
+	plt, err = fcli.GetRequiredPallet(plt, caches.p, c.Args().First())
+	if err != nil {
+		return nil
+	}
+	location, err := fcli.GetFileLocation(plt, c.Args().Get(1))
+	if err != nil {
+		return err
+	}
+	fmt.Println(location)
+	return nil
+}
+
 // show-plt-file
 
 func showPltFileAction(c *cli.Context) error {

--- a/internal/app/forklift/cli/imports-printing.go
+++ b/internal/app/forklift/cli/imports-printing.go
@@ -34,6 +34,12 @@ func PrintImportInfo(
 	if err != nil {
 		return errors.Wrapf(err, "couldn't resolve import group %s", imp.Name)
 	}
+	resolved.Pallet, err = forklift.MergeFSPallet(resolved.Pallet, cache, nil)
+	if err != nil {
+		return errors.Wrapf(
+			err, "couldn't print merge pallet referenced by resolved import group %s", imp.Name,
+		)
+	}
 	if err = PrintResolvedImport(indent, resolved); err != nil {
 		return errors.Wrapf(err, "couldn't print resolved import group %s", imp.Name)
 	}

--- a/internal/app/forklift/pallets-imports.go
+++ b/internal/app/forklift/pallets-imports.go
@@ -15,8 +15,25 @@ import (
 
 // ResolvedImport
 
-// ResolveImport loads the package from the [FSPkgLoader] instance based on the requirements in the
-// provided deployment and the package requirement loader.
+// ResolveImports loads the packages from the [FSPkgLoader] instance based on the requirements in the
+// provided deployments and the package requirement loader.
+func ResolveImports(
+	pallet *FSPallet, palletLoader FSPalletLoader, imps []Import,
+) (resolved []*ResolvedImport, err error) {
+	resolvedImports := make([]*ResolvedImport, 0, len(imps))
+	for _, imp := range imps {
+		resolved, err := ResolveImport(pallet, palletLoader, imp)
+		if err != nil {
+			return nil, errors.Wrapf(err, "couldn't resolve import group %s", imp.Name)
+		}
+		resolvedImports = append(resolvedImports, resolved)
+	}
+
+	return resolvedImports, nil
+}
+
+// ResolveImport loads the pallet from the [FSPalletLoader] instance based on the requirements in
+// the provided file import group and the pallet.
 func ResolveImport(
 	pallet *FSPallet, palletLoader FSPalletLoader, imp Import,
 ) (resolved *ResolvedImport, err error) {
@@ -42,23 +59,6 @@ func ResolveImport(
 		)
 	}
 	return resolved, nil
-}
-
-// ResolveImports loads the packages from the [FSPkgLoader] instance based on the requirements in the
-// provided deployments and the package requirement loader.
-func ResolveImports(
-	pallet *FSPallet, palletLoader FSPalletLoader, imps []Import,
-) (resolved []*ResolvedImport, err error) {
-	resolvedImports := make([]*ResolvedImport, 0, len(imps))
-	for _, imp := range imps {
-		resolved, err := ResolveImport(pallet, palletLoader, imp)
-		if err != nil {
-			return nil, errors.Wrapf(err, "couldn't resolve import group %s", imp.Name)
-		}
-		resolvedImports = append(resolvedImports, resolved)
-	}
-
-	return resolvedImports, nil
 }
 
 // Evaluate returns a list of target file paths and a mapping between target file paths and source

--- a/internal/app/forklift/pallets-merging.go
+++ b/internal/app/forklift/pallets-merging.go
@@ -201,9 +201,10 @@ func mergePalletImports(
 			}
 
 			// TODO: check for file contents+metadata conflicts among file mappings of different
-			// required pallets; when multiple pallets map the same source file to the same target file,
+			// required pallets; when multiple pallets map the same source file (without any contents or
+			// metadata conflicts between their versions of the source file) to the same target file,
 			// choose the alphabetically first pallet for resolving that target file. For now we just
-			// reject all such situations as invalid, because that's simpler.
+			// reject all such situations as invalid, because that's simpler to implement.
 			if prevRef.fs.Path() != ref.fs.Path() || prevRef.path != ref.path {
 				return nil, errors.Errorf(
 					"couldn't add a mapping from %s to target %s, when a mapping was previously added "+

--- a/internal/app/forklift/pallets-models.go
+++ b/internal/app/forklift/pallets-models.go
@@ -167,7 +167,7 @@ const (
 	ImportDefFileExt = ".imports.yml"
 )
 
-// A ResolvedImport is a deployment with a loaded pallet.
+// A ResolvedImport is a file import group with a loaded pallet.
 type ResolvedImport struct {
 	// Import is the declared file import group.
 	Import


### PR DESCRIPTION
This PR fixes a bug left by #286 for transitive pallet layering. Specifically, this PR enables a pallet to import a file from a pallet when that file is actually imported from another pallet. This is associated with the "linear transitive imports" test case mentioned in https://github.com/PlanktoScope/forklift/issues/253#issuecomment-2210355452 , and with https://github.com/forklift-run/pallet-example-transitive .