### PR TITLE
Make `[dev] plt cache-plt` recursively cache transitively-required pallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (cli) Added a `[dev] plt ls-plt-file` command to list files in the specified pallet required by the local/development pallet, including files imported by that required pallet from its own required pallets.
 - (cli) Added a `[dev] plt locate-plt-file` command to print the actual filesystem path of the specified file in the specified pallet required by the local/development pallet.
 - (cli) Added a `[dev] plt show-plt-file` command to print the contents of the specified file in the specified pallet required by the local/development pallet.
+- (cli) Added a `cache rm-dl` command to delete the cache of downloaded files for export.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- (cli) Removed some aliases for `[dev] plt add-plt` and `[dev] plt add-repo` which should not have been added, because they were constructed as a combination of an abbrebiation and an unabbreviated word.
+- (Breaking change; cli) Removed some aliases for `[dev] plt add-plt` and `[dev] plt add-repo` which should not have been added, because they were constructed as a combination of an abbrebiation and an unabbreviated word.
+- (cli) Suppressed some noisy Git cloning output in `[dev] plt cache-plt`, `[dev] plt cache-all`, and other related commands.
 
 ### Fixed
 
 - (cli) Transitive imports of files across pallets (e.g. importing a file from a pallet which actually imports that file from another pallet) is no longer completely broken (it should work, but there may still be undiscovered bugs because the code paths have not been thoroughly tested).
-- (cli) `[dev] plt cache-plt` and `[dev] plt cache-all` now recursively cache all transitively-required pallets of the local/development pallet, instead of only caching directly-required pallets.
+- (cli) `[dev] plt cache-plt`, `[dev] plt cache-all`, and other related commands now recursively cache all transitively-required pallets of the local/development pallet, instead of only caching directly-required pallets.
 
 ## 0.8.0-alpha.1 - 2024-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - (cli) Transitive imports of files across pallets (e.g. importing a file from a pallet which actually imports that file from another pallet) is no longer completely broken (it should work, but there may still be undiscovered bugs because the code paths have not been thoroughly tested).
+- (cli) `[dev] plt cache-plt` and `[dev] plt cache-all` now recursively cache all transitively-required pallets of the local/development pallet, instead of only caching directly-required pallets.
 
 ## 0.8.0-alpha.1 - 2024-08-30
 

--- a/cmd/forklift/cache/cli.go
+++ b/cmd/forklift/cache/cli.go
@@ -118,6 +118,13 @@ var Cmd = &cli.Command{
 			Action: rmGitRepoAction("repo", getRepoCache),
 		},
 		{
+			Name:     "rm-dl",
+			Aliases:  []string{"remove-downloads", "del-dl", "delete-downloads"},
+			Category: "Modify the cache",
+			Usage:    "Removes locally-cached file downloads",
+			Action:   rmDlAction,
+		},
+		{
 			Name:     "rm-img",
 			Aliases:  []string{"remove-images", "del-img", "delete-images"},
 			Category: "Modify the cache",

--- a/cmd/forklift/cache/downloads.go
+++ b/cmd/forklift/cache/downloads.go
@@ -42,3 +42,23 @@ func lsDlAction(c *cli.Context) error {
 	}
 	return nil
 }
+
+// rm-dl
+
+func rmDlAction(c *cli.Context) error {
+	workspace, err := forklift.LoadWorkspace(c.String("workspace"))
+	if err != nil {
+		return err
+	}
+
+	cache, err := workspace.GetDownloadCache()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Clearing downloads cache...")
+	if err = cache.Remove(); err != nil {
+		return errors.Wrap(err, "couldn't clear downloads cache")
+	}
+	return nil
+}

--- a/cmd/forklift/dev/plt/downloads.go
+++ b/cmd/forklift/dev/plt/downloads.go
@@ -52,7 +52,6 @@ func cacheDlAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		fmt.Println("Downloading files for export by the development pallet...")
 		if err := fcli.DownloadExportFiles(
 			0, plt, caches.r, caches.d, false, c.Bool("parallel"),
 		); err != nil {

--- a/cmd/forklift/dev/plt/pallets.go
+++ b/cmd/forklift/dev/plt/pallets.go
@@ -410,7 +410,6 @@ func cachePltAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		fmt.Printf("Downloading pallets specified by the development pallet...\n")
 		cache, err := workspace.GetPalletCache()
 		if err != nil {
 			return err

--- a/cmd/forklift/dev/plt/pallets.go
+++ b/cmd/forklift/dev/plt/pallets.go
@@ -414,11 +414,11 @@ func cachePltAction(versions Versions) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		changed, err := fcli.DownloadRequiredPallets(0, plt, cache)
+		downloaded, err := fcli.DownloadRequiredPallets(0, plt, cache, nil)
 		if err != nil {
 			return err
 		}
-		if !changed {
+		if len(downloaded) == 0 {
 			fmt.Println("Done! No further actions are needed at this time.")
 			return nil
 		}

--- a/cmd/forklift/dev/plt/pallets.go
+++ b/cmd/forklift/dev/plt/pallets.go
@@ -411,7 +411,11 @@ func cachePltAction(versions Versions) cli.ActionFunc {
 		}
 
 		fmt.Printf("Downloading pallets specified by the development pallet...\n")
-		changed, err := fcli.DownloadRequiredPallets(0, plt, workspace.GetPalletCachePath())
+		cache, err := workspace.GetPalletCache()
+		if err != nil {
+			return err
+		}
+		changed, err := fcli.DownloadRequiredPallets(0, plt, cache)
 		if err != nil {
 			return err
 		}

--- a/cmd/forklift/dev/plt/repositories.go
+++ b/cmd/forklift/dev/plt/repositories.go
@@ -23,7 +23,6 @@ func cacheRepoAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		fmt.Printf("Downloading repos specified by the development pallet...\n")
 		changed, err := fcli.DownloadRequiredRepos(0, plt, caches.r.Underlay.Path())
 		if err != nil {
 			return err

--- a/cmd/forklift/plt/downloads.go
+++ b/cmd/forklift/plt/downloads.go
@@ -50,7 +50,6 @@ func cacheDlAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		fmt.Println("Downloading files for export by the local pallet...")
 		if err := fcli.DownloadExportFiles(
 			0, plt, caches.r, caches.d, false, c.Bool("parallel"),
 		); err != nil {

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -927,11 +927,11 @@ func cachePltAction(versions Versions) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		changed, err := fcli.DownloadRequiredPallets(0, plt, cache)
+		downloaded, err := fcli.DownloadRequiredPallets(0, plt, cache, nil)
 		if err != nil {
 			return err
 		}
-		if !changed {
+		if len(downloaded) == 0 {
 			fmt.Println("Done! No further actions are needed at this time.")
 			return nil
 		}

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -924,7 +924,11 @@ func cachePltAction(versions Versions) cli.ActionFunc {
 		}
 
 		fmt.Println("Downloading pallets specified by the local pallet...")
-		changed, err := fcli.DownloadRequiredPallets(0, plt, workspace.GetPalletCachePath())
+		cache, err := workspace.GetPalletCache()
+		if err != nil {
+			return err
+		}
+		changed, err := fcli.DownloadRequiredPallets(0, plt, cache)
 		if err != nil {
 			return err
 		}

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -686,7 +686,7 @@ func fetchAction(c *cli.Context) error {
 	pltPath := workspace.GetCurrentPalletPath()
 
 	fmt.Println("Fetching updates...")
-	updated, err := git.Fetch(0, pltPath)
+	updated, err := git.Fetch(0, pltPath, os.Stdout)
 	if err != nil {
 		return errors.Wrap(err, "couldn't fetch changes from the remote release")
 	}
@@ -711,7 +711,7 @@ func pullAction(versions Versions) cli.ActionFunc {
 		// FIXME: update the local mirror
 
 		fmt.Println("Attempting to fast-forward the local pallet...")
-		updated, err := git.Pull(1, pltPath)
+		updated, err := git.Pull(1, pltPath, os.Stdout)
 		if err != nil {
 			return errors.Wrap(err, "couldn't fast-forward the local pallet")
 		}
@@ -923,7 +923,6 @@ func cachePltAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		fmt.Println("Downloading pallets specified by the local pallet...")
 		cache, err := workspace.GetPalletCache()
 		if err != nil {
 			return err

--- a/cmd/forklift/plt/repositories.go
+++ b/cmd/forklift/plt/repositories.go
@@ -22,7 +22,6 @@ func cacheRepoAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		fmt.Println("Downloading repos specified by the local pallet...")
 		changed, err := fcli.DownloadRequiredRepos(0, plt, caches.r.Path())
 		if err != nil {
 			return err

--- a/internal/app/forklift/cli/caching-exports.go
+++ b/internal/app/forklift/cli/caching-exports.go
@@ -50,6 +50,8 @@ func DownloadExportFiles(
 		return nil
 	}
 
+	IndentedPrintln(indent, "Downloading files for export...")
+	indent++
 	newHTTP := make([]string, 0, len(httpDownloads))
 	for _, url := range httpDownloads {
 		ok, err := dlCache.HasFile(url)
@@ -59,7 +61,7 @@ func DownloadExportFiles(
 			)
 		}
 		if ok {
-			IndentedPrintf(indent, "Skipping already-cached file download: %s\n", url)
+			IndentedPrintf(indent, "Skipped already-cached file download: %s\n", url)
 			continue
 		}
 		newHTTP = append(newHTTP, url)
@@ -74,7 +76,7 @@ func DownloadExportFiles(
 			)
 		}
 		if ok {
-			IndentedPrintf(indent, "Skipping already-cached OCI image download: %s\n", url)
+			IndentedPrintf(indent, "Skipped already-cached OCI image download: %s\n", url)
 			continue
 		}
 		newOCI = append(newOCI, url)

--- a/internal/app/forklift/cli/caching.go
+++ b/internal/app/forklift/cli/caching.go
@@ -34,7 +34,7 @@ func CacheStagingReqs(
 	indent++
 
 	IndentedPrintln(indent, "Downloading pallets required by the local pallet...")
-	if _, err = DownloadRequiredPallets(indent+1, pallet, palletCache.Path()); err != nil {
+	if _, err = DownloadRequiredPallets(indent+1, pallet, palletCache); err != nil {
 		return nil, nil, err
 	}
 

--- a/internal/app/forklift/cli/caching.go
+++ b/internal/app/forklift/cli/caching.go
@@ -33,7 +33,7 @@ func CacheStagingReqs(
 	IndentedPrintln(indent, "Caching everything needed to stage the pallet...")
 	indent++
 
-	if _, err = DownloadRequiredPallets(indent, pallet, palletCache); err != nil {
+	if _, err = DownloadRequiredPallets(indent, pallet, palletCache, nil); err != nil {
 		return nil, nil, err
 	}
 

--- a/internal/app/forklift/cli/caching.go
+++ b/internal/app/forklift/cli/caching.go
@@ -33,8 +33,7 @@ func CacheStagingReqs(
 	IndentedPrintln(indent, "Caching everything needed to stage the pallet...")
 	indent++
 
-	IndentedPrintln(indent, "Downloading pallets required by the local pallet...")
-	if _, err = DownloadRequiredPallets(indent+1, pallet, palletCache); err != nil {
+	if _, err = DownloadRequiredPallets(indent, pallet, palletCache); err != nil {
 		return nil, nil, err
 	}
 
@@ -53,14 +52,12 @@ func CacheStagingReqs(
 		return merged, nil, err
 	}
 
-	IndentedPrintln(indent, "Downloading repos required by the local pallet...")
-	if _, err = DownloadRequiredRepos(indent+1, merged, repoCache.Path()); err != nil {
+	if _, err = DownloadRequiredRepos(indent, merged, repoCache.Path()); err != nil {
 		return merged, repoCacheWithMerged, err
 	}
 
-	IndentedPrintln(indent, "Downloading files for export by the local pallet...")
 	if err = DownloadExportFiles(
-		indent+1, merged, repoCacheWithMerged, dlCache, includeDisabled, parallel,
+		indent, merged, repoCacheWithMerged, dlCache, includeDisabled, parallel,
 	); err != nil {
 		return merged, repoCacheWithMerged, err
 	}

--- a/internal/app/forklift/cli/git-repositories.go
+++ b/internal/app/forklift/cli/git-repositories.go
@@ -294,7 +294,9 @@ func DownloadLockedGitRepoUsingLocalMirror(
 	indent int, cachePath string, gitRepoPath string, lock forklift.VersionLock,
 ) (downloaded bool, err error) {
 	mirrorPath := filepath.Join(filepath.FromSlash(cachePath), gitRepoPath)
-	downloaded, err = cloneLockedGitRepoFromLocalMirror(indent, cachePath, gitRepoPath, lock)
+	downloaded, err = cloneLockedGitRepoFromLocalMirror(
+		indent, cachePath, gitRepoPath, lock,
+	)
 	if err != nil {
 		indent++
 		IndentedPrintln(
@@ -327,7 +329,6 @@ func DownloadLockedGitRepoUsingLocalMirror(
 		IndentedPrintf(
 			indent, "Couldn't update local mirror (do you have internet access?): %s\n", err,
 		)
-		return downloaded, nil
 	}
 	return downloaded, nil
 }
@@ -341,9 +342,9 @@ func cloneLockedGitRepoFromLocalMirror(
 		)
 	}
 	version := lock.Version
-	gitRepoCachePath := filepath.Join(
-		filepath.FromSlash(cachePath), fmt.Sprintf("%s@%s", filepath.FromSlash(gitRepoPath), version),
-	)
+	gitRepoCachePath := filepath.FromSlash(path.Join(
+		cachePath, fmt.Sprintf("%s@%s", gitRepoPath, version),
+	))
 	if forklift.DirExists(gitRepoCachePath) {
 		// TODO: perform a disk checksum
 		return false, nil

--- a/internal/app/forklift/cli/requirements-pallets.go
+++ b/internal/app/forklift/cli/requirements-pallets.go
@@ -238,7 +238,12 @@ func DownloadRequiredPallets(
 	if err != nil {
 		return false, errors.Wrapf(err, "couldn't identify pallets")
 	}
-	changed = false
+	if len(loadedPalletReqs) == 0 {
+		return false, nil
+	}
+
+	IndentedPrintln(indent, "Downloading required pallets...")
+	indent++
 	for _, req := range loadedPalletReqs {
 		downloaded, err := DownloadLockedGitRepoUsingLocalMirror(
 			indent, cache.Path(), req.Path(), req.VersionLock,

--- a/internal/app/forklift/cli/requirements-pallets.go
+++ b/internal/app/forklift/cli/requirements-pallets.go
@@ -2,8 +2,8 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"maps"
+	"os"
 	"path"
 	"path/filepath"
 	"slices"

--- a/internal/app/forklift/cli/requirements-repositories.go
+++ b/internal/app/forklift/cli/requirements-repositories.go
@@ -294,7 +294,14 @@ func DownloadRequiredRepos(
 	if err != nil {
 		return false, errors.Wrapf(err, "couldn't identify repos")
 	}
-	changed = false
+	if len(loadedRepoReqs) == 0 {
+		return false, nil
+	}
+
+	IndentedPrintln(indent, "Downloading required repos...")
+	indent++
+	// FIXME: for repositories which are also layered pallets, we must download its required pallets,
+	// so that we can layer in any imported files for packages exported by the repository.
 	for _, req := range loadedRepoReqs {
 		downloaded, err := DownloadLockedGitRepoUsingLocalMirror(
 			indent, cachePath, req.Path(), req.VersionLock,

--- a/pkg/structures/set.go
+++ b/pkg/structures/set.go
@@ -8,6 +8,7 @@ func (s Set[Node]) Add(n Node) {
 	s[n] = struct{}{}
 }
 
+// Has checks whether the node is already in the set.
 func (s Set[Node]) Has(n Node) bool {
 	_, ok := s[n]
 	return ok


### PR DESCRIPTION
This PR implements a feature left out of #286 as part of #253, namely automatic downloading of transitively-required pallets when a pallet's required pallets are cached.