### PR TITLE
Enable support for using package repos constructed by pallet layering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- (cli) Now repos with packages constructed through pallet layering (for repos which are also layered pallets) can actually be used by other pallets as sources of packages. This is done by merging the pallet as part of the work of downloading it into the cache as a repo.
 - (cli) Transitive imports of files across pallets (e.g. importing a file from a pallet which actually imports that file from another pallet) is no longer completely broken (it should work, but there may still be undiscovered bugs because the code paths have not been thoroughly tested).
 - (cli) `[dev] plt cache-plt`, `[dev] plt cache-all`, and other related commands now recursively cache all transitively-required pallets of the local/development pallet, instead of only caching directly-required pallets.
 

--- a/cmd/forklift/dev/plt/pallets.go
+++ b/cmd/forklift/dev/plt/pallets.go
@@ -414,7 +414,7 @@ func cachePltAction(versions Versions) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		downloaded, err := fcli.DownloadRequiredPallets(0, plt, cache, nil)
+		downloaded, err := fcli.DownloadAllRequiredPallets(0, plt, cache, nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/forklift/dev/plt/repositories.go
+++ b/cmd/forklift/dev/plt/repositories.go
@@ -23,7 +23,7 @@ func cacheRepoAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		changed, err := fcli.DownloadRequiredRepos(0, plt, caches.r.Underlay.Path())
+		changed, err := fcli.DownloadAllRequiredRepos(0, plt, caches.r.Underlay, caches.p, nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -927,7 +927,7 @@ func cachePltAction(versions Versions) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		downloaded, err := fcli.DownloadRequiredPallets(0, plt, cache, nil)
+		downloaded, err := fcli.DownloadAllRequiredPallets(0, plt, cache, nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/forklift/plt/repositories.go
+++ b/cmd/forklift/plt/repositories.go
@@ -22,7 +22,7 @@ func cacheRepoAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		changed, err := fcli.DownloadRequiredRepos(0, plt, caches.r.Path())
+		changed, err := fcli.DownloadAllRequiredRepos(0, plt, caches.r, caches.p, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/app/forklift/cli/caching.go
+++ b/internal/app/forklift/cli/caching.go
@@ -33,7 +33,8 @@ func CacheStagingReqs(
 	IndentedPrintln(indent, "Caching everything needed to stage the pallet...")
 	indent++
 
-	if _, err = DownloadRequiredPallets(indent, pallet, palletCache, nil); err != nil {
+	downloadedPallets, err := DownloadAllRequiredPallets(indent, pallet, palletCache, nil)
+	if err != nil {
 		return nil, nil, err
 	}
 
@@ -52,7 +53,9 @@ func CacheStagingReqs(
 		return merged, nil, err
 	}
 
-	if _, err = DownloadRequiredRepos(indent, merged, repoCache.Path()); err != nil {
+	if _, err = DownloadAllRequiredRepos(
+		indent, merged, repoCache, palletCache, downloadedPallets,
+	); err != nil {
 		return merged, repoCacheWithMerged, err
 	}
 

--- a/internal/app/forklift/cli/staging.go
+++ b/internal/app/forklift/cli/staging.go
@@ -65,8 +65,8 @@ type StagingVersions struct {
 }
 
 type StagingCaches struct {
-	Repos     forklift.PathedRepoCache
 	Pallets   forklift.PathedPalletCache
+	Repos     forklift.PathedRepoCache
 	Downloads *forklift.FSDownloadCache
 }
 

--- a/internal/app/forklift/repositories.go
+++ b/internal/app/forklift/repositories.go
@@ -1,0 +1,54 @@
+package forklift
+
+import (
+	"slices"
+
+	"github.com/pkg/errors"
+
+	"github.com/PlanktoScope/forklift/pkg/core"
+)
+
+// LoadFSRepos loads all FSRepos from the provided base filesystem matching the specified search
+// pattern, appropriately handling repos defined (implicitly or explicitly) as potentially-layered
+// pallets. The search pattern should be a [doublestar] pattern, such as `**`, matching repo
+// directories to search for.
+// In the embedded [Repo] of each loaded FSRepo, the version is *not* initialized.
+func LoadFSRepos(
+	fsys core.PathedFS, searchPattern string, palletLoader FSPalletLoader,
+) ([]*core.FSRepo, error) {
+	allRepos := make(map[string]*core.FSRepo) // repo FS path -> repo
+	pallets, err := LoadFSPallets(fsys, searchPattern)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't load pallets (which are also repos)")
+	}
+	for _, pallet := range pallets {
+		merged, err := MergeFSPallet(pallet, palletLoader, nil)
+		if err != nil {
+			return nil, errors.Wrapf(
+				err, "couldn't merge pallet %s with any pallets required by it, to use it as a repo",
+				pallet.FS.Path(),
+			)
+		}
+		allRepos[pallet.FS.Path()] = merged.Repo
+	}
+
+	repos, err := core.LoadFSRepos(fsys, searchPattern)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't load repos")
+	}
+	for _, repo := range repos {
+		if _, ok := allRepos[repo.FS.Path()]; ok { // the repo might've already been added as a pallet
+			continue
+		}
+		allRepos[repo.FS.Path()] = repo
+	}
+
+	repos = make([]*core.FSRepo, 0, len(allRepos))
+	for _, repo := range allRepos {
+		repos = append(repos, repo)
+	}
+	slices.SortFunc(repos, func(a, b *core.FSRepo) int {
+		return core.CompareRepos(a.Repo, b.Repo)
+	})
+	return repos, nil
+}

--- a/pkg/core/repositories.go
+++ b/pkg/core/repositories.go
@@ -3,6 +3,7 @@ package core
 import (
 	"fmt"
 	"io/fs"
+	"os"
 	"path"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -188,6 +189,19 @@ func LoadRepoDef(fsys PathedFS, filePath string) (RepoDef, error) {
 // Check looks for errors in the construction of the repo declaration.
 func (d RepoDef) Check() (errs []error) {
 	return ErrsWrap(d.Repo.Check(), "invalid repo spec")
+}
+
+// WriteRepoDef creates a repo definition file at the specified path.
+func WriteRepoDef(repoDef RepoDef, outputPath string) error {
+	marshaled, err := yaml.Marshal(repoDef)
+	if err != nil {
+		return errors.Wrapf(err, "couldn't marshal bundled repo declaration")
+	}
+	const perm = 0o644 // owner rw, group r, public r
+	if err := os.WriteFile(outputPath, marshaled, perm); err != nil {
+		return errors.Wrapf(err, "couldn't save repo declaration to %s", outputPath)
+	}
+	return nil
 }
 
 // RepoSpec


### PR DESCRIPTION
This PR implements some functionality left out of #286 as part of #253, namely making it possible to use package repositories which are constructed as layered pallets (i.e. packages consisting of files imported from other pallets).