### PR TITLE
Reuse the same cached Git repo mirrors between pallets and package repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - (Breaking change; cli) Removed some aliases for `[dev] plt add-plt` and `[dev] plt add-repo` which should not have been added, because they were constructed as a combination of an abbrebiation and an unabbreviated word.
 - (Breaking change; cli) Now, by default `[dev] plt ls-file` and `[dev] plt ls-plt-file` don't list files in hidden directories (i.e. directories whose names start with `.`) at the root of the pallet. To list all files including those in hidden directories, you should now specify `**` as the file path glob (e.g. by running `[dev] plt ls-file '**'` or `[dev] plt ls-plt-file required_pallet_path '**'`).
+- (cli) Git repository mirrors of pallets and package repos in the cache are now stored in a single `mirrors` subdirectory of the Forklift workspace, rather than being split/duplicated across the `pallets` and `repositories` subdirectories.
 - (cli) Suppressed some noisy Git cloning output in `[dev] plt cache-plt`, `[dev] plt cache-all`, and other related commands.
 - (cli) `[dev] plt show-imp` now shows any deprecated notices of deprecated features referenced directly or indirectly by the specified import group.
 

--- a/cmd/forklift/cache/cli.go
+++ b/cmd/forklift/cache/cli.go
@@ -102,11 +102,19 @@ var Cmd = &cli.Command{
 			Action:   rmAllAction,
 		},
 		{
+			Name:     "rm-mir",
+			Aliases:  []string{"remove-mirrors", "del-mir", "delete-mirrors"},
+			Category: "Modify the cache",
+			Usage:    "Removes locally-cached pallets",
+			// TODO: allow only removing mirrors matching a glob pattern
+			Action: rmGitRepoAction("mirror", getMirrorCache),
+		},
+		{
 			Name:     "rm-plt",
 			Aliases:  []string{"remove-pallets", "del-plt", "delete-pallets"},
 			Category: "Modify the cache",
 			Usage:    "Removes locally-cached pallets",
-			// TODO: allow only removing repos matching a glob pattern
+			// TODO: allow only removing pallets matching a glob pattern
 			Action: rmGitRepoAction("pallet", getPalletCache),
 		},
 		{

--- a/cmd/forklift/cache/git-repositories.go
+++ b/cmd/forklift/cache/git-repositories.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 
+	"github.com/PlanktoScope/forklift/internal/app/forklift"
 	fcli "github.com/PlanktoScope/forklift/internal/app/forklift/cli"
 	"github.com/PlanktoScope/forklift/pkg/core"
 )
@@ -67,10 +68,14 @@ func addGitRepoAction[Cache core.Pather](
 		if err != nil {
 			return err
 		}
+		workspace, err := forklift.LoadWorkspace(c.String("workspace"))
+		if err != nil {
+			return err
+		}
 
 		queries := c.Args().Slice()
 		if _, _, err = fcli.DownloadQueriedGitReposUsingLocalMirrors(
-			0, cache.Path(), queries,
+			0, workspace.GetMirrorCachePath(), cache.Path(), queries,
 		); err != nil {
 			return err
 		}

--- a/cmd/forklift/dev/plt/repositories.go
+++ b/cmd/forklift/dev/plt/repositories.go
@@ -23,7 +23,9 @@ func cacheRepoAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		changed, err := fcli.DownloadAllRequiredRepos(0, plt, caches.r.Underlay, caches.p, nil)
+		changed, err := fcli.DownloadAllRequiredRepos(
+			0, plt, caches.m, caches.p, caches.r.Underlay, nil,
+		)
 		if err != nil {
 			return err
 		}
@@ -98,12 +100,12 @@ func addRepoAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		if err = fcli.AddRepoReqs(0, plt, caches.r.Underlay.Path(), c.Args().Slice()); err != nil {
+		if err = fcli.AddRepoReqs(0, plt, caches.m.Path(), c.Args().Slice()); err != nil {
 			return err
 		}
 		if !c.Bool("no-cache-req") {
 			if _, _, err = fcli.CacheStagingReqs(
-				0, plt, caches.p, caches.r, caches.d, false, c.Bool("parallel"),
+				0, plt, caches.m, caches.p, caches.r, caches.d, false, c.Bool("parallel"),
 			); err != nil {
 				return err
 			}

--- a/cmd/forklift/plt/repositories.go
+++ b/cmd/forklift/plt/repositories.go
@@ -22,7 +22,7 @@ func cacheRepoAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		changed, err := fcli.DownloadAllRequiredRepos(0, plt, caches.r, caches.p, nil)
+		changed, err := fcli.DownloadAllRequiredRepos(0, plt, caches.m, caches.p, caches.r, nil)
 		if err != nil {
 			return err
 		}
@@ -93,12 +93,12 @@ func addRepoAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		if err = fcli.AddRepoReqs(0, plt, caches.r.Path(), c.Args().Slice()); err != nil {
+		if err = fcli.AddRepoReqs(0, plt, caches.m.Path(), c.Args().Slice()); err != nil {
 			return err
 		}
 		if !c.Bool("no-cache-req") {
 			if _, _, err = fcli.CacheStagingReqs(
-				0, plt, caches.p, caches.r, caches.d, false, c.Bool("parallel"),
+				0, plt, caches.m, caches.p, caches.r, caches.d, false, c.Bool("parallel"),
 			); err != nil {
 				return err
 			}

--- a/internal/app/forklift/caching-mirrors.go
+++ b/internal/app/forklift/caching-mirrors.go
@@ -1,0 +1,23 @@
+package forklift
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// FSMirrorCache
+
+// Exists checks whether the cache actually exists on the OS's filesystem.
+func (c *FSMirrorCache) Exists() bool {
+	return DirExists(filepath.FromSlash(c.FS.Path()))
+}
+
+// Remove deletes the cache from the OS's filesystem, if it exists.
+func (c *FSMirrorCache) Remove() error {
+	return os.RemoveAll(filepath.FromSlash(c.FS.Path()))
+}
+
+// Path returns the path of the cache's filesystem.
+func (c *FSMirrorCache) Path() string {
+	return c.FS.Path()
+}

--- a/internal/app/forklift/caching-models.go
+++ b/internal/app/forklift/caching-models.go
@@ -5,6 +5,15 @@ import (
 	"github.com/PlanktoScope/forklift/pkg/structures"
 )
 
+// Mirror
+
+// FSMirrorCache is a [PathedPalletCache] implementation with git repository mirrors
+// stored in a [core.PathedFS] filesystem.
+type FSMirrorCache struct {
+	// FS is the filesystem which corresponds to the cache of pallets.
+	FS core.PathedFS
+}
+
 // Pallet
 
 // FSPalletLoader is a source of [FSPallet]s indexed by path and version.

--- a/internal/app/forklift/cli/caching.go
+++ b/internal/app/forklift/cli/caching.go
@@ -4,15 +4,17 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/PlanktoScope/forklift/internal/app/forklift"
+	"github.com/PlanktoScope/forklift/pkg/core"
 )
 
 func CacheAllReqs(
-	indent int, pallet *forklift.FSPallet, palletCache forklift.PathedPalletCache,
-	repoCache forklift.PathedRepoCache, dlCache *forklift.FSDownloadCache,
+	indent int, pallet *forklift.FSPallet, mirrorsCache core.Pather,
+	palletCache forklift.PathedPalletCache, repoCache forklift.PathedRepoCache,
+	dlCache *forklift.FSDownloadCache,
 	includeDisabled, parallel bool,
 ) error {
 	pallet, repoCacheWithMerged, err := CacheStagingReqs(
-		indent, pallet, palletCache, repoCache, dlCache, includeDisabled, parallel,
+		indent, pallet, mirrorsCache, palletCache, repoCache, dlCache, includeDisabled, parallel,
 	)
 	if err != nil {
 		return err
@@ -26,14 +28,17 @@ func CacheAllReqs(
 }
 
 func CacheStagingReqs(
-	indent int, pallet *forklift.FSPallet, palletCache forklift.PathedPalletCache,
-	repoCache forklift.PathedRepoCache, dlCache *forklift.FSDownloadCache,
+	indent int, pallet *forklift.FSPallet, mirrorsCache core.Pather,
+	palletCache forklift.PathedPalletCache, repoCache forklift.PathedRepoCache,
+	dlCache *forklift.FSDownloadCache,
 	includeDisabled, parallel bool,
 ) (merged *forklift.FSPallet, repoCacheWithMerged *forklift.LayeredRepoCache, err error) {
 	IndentedPrintln(indent, "Caching everything needed to stage the pallet...")
 	indent++
 
-	downloadedPallets, err := DownloadAllRequiredPallets(indent, pallet, palletCache, nil)
+	downloadedPallets, err := DownloadAllRequiredPallets(
+		indent, pallet, mirrorsCache, palletCache, nil,
+	)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -54,7 +59,7 @@ func CacheStagingReqs(
 	}
 
 	if _, err = DownloadAllRequiredRepos(
-		indent, merged, repoCache, palletCache, downloadedPallets,
+		indent, merged, mirrorsCache, palletCache, repoCache, downloadedPallets,
 	); err != nil {
 		return merged, repoCacheWithMerged, err
 	}

--- a/internal/app/forklift/cli/staging.go
+++ b/internal/app/forklift/cli/staging.go
@@ -15,6 +15,7 @@ import (
 	"github.com/PlanktoScope/forklift/internal/clients/cli"
 	"github.com/PlanktoScope/forklift/internal/clients/docker"
 	"github.com/PlanktoScope/forklift/internal/clients/git"
+	"github.com/PlanktoScope/forklift/pkg/core"
 	"github.com/PlanktoScope/forklift/pkg/structures"
 )
 
@@ -65,6 +66,7 @@ type StagingVersions struct {
 }
 
 type StagingCaches struct {
+	Mirrors   core.Pather
 	Pallets   forklift.PathedPalletCache
 	Repos     forklift.PathedRepoCache
 	Downloads *forklift.FSDownloadCache
@@ -80,7 +82,7 @@ func StagePallet(
 	}
 
 	pallet, repoCacheWithMerged, err := CacheStagingReqs(
-		0, pallet, caches.Pallets, caches.Repos, caches.Downloads, false, parallel,
+		0, pallet, caches.Mirrors, caches.Pallets, caches.Repos, caches.Downloads, false, parallel,
 	)
 	if err != nil {
 		return 0, errors.Wrap(err, "couldn't cache requirements for staging the pallet")

--- a/internal/app/forklift/workspace-models.go
+++ b/internal/app/forklift/workspace-models.go
@@ -12,6 +12,7 @@ type FSWorkspace struct {
 
 const (
 	cacheDirPath          = ".cache/forklift"
+	cacheMirrorsDirName   = "mirrors"
 	cacheReposDirName     = "repositories"
 	cachePalletsDirName   = "pallets"
 	cacheDownloadsDirName = "downloads"

--- a/internal/app/forklift/workspace.go
+++ b/internal/app/forklift/workspace.go
@@ -118,6 +118,26 @@ func (w *FSWorkspace) getCacheFS() (core.PathedFS, error) {
 	return fsys, nil
 }
 
+// Cache: Mirrors
+
+func (w *FSWorkspace) GetMirrorCachePath() string {
+	return path.Join(w.getCachePath(), cacheMirrorsDirName)
+}
+
+func (w *FSWorkspace) GetMirrorCache() (*FSMirrorCache, error) {
+	fsys, err := w.getCacheFS()
+	if err != nil {
+		return nil, err
+	}
+	pathedFS, err := fsys.Sub(cacheMirrorsDirName)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't get mirrors cache from workspace")
+	}
+	return &FSMirrorCache{
+		FS: pathedFS,
+	}, nil
+}
+
 // Cache: Repos
 
 func (w *FSWorkspace) GetRepoCachePath() string {


### PR DESCRIPTION
This PR moves the cache's Git repo mirrors to all be stored under a new `mirrors` subdirectory, so that they won't need to be duplicated (and so that updating the mirror for a pallet also causes the mirror to be updated for that pallet as a repository).