### PR TITLE
Allow merging identical source files from different pallets to the same target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (cli) Added a `[dev] plt locate-plt-file` command to print the actual filesystem path of the specified file in the specified pallet required by the local/development pallet.
 - (cli) Added a `[dev] plt show-plt-file` command to print the contents of the specified file in the specified pallet required by the local/development pallet.
 - (cli) Added a `cache rm-dl` command to delete the cache of downloaded files for export.
-- (cli) The bundle manifest's `includes` section now reports when required pallets were overridden.
-- (cli) The bundle manifest's `includes` section now shows the results (as target file path -> source file path mappings) of evaluating each file import group attached to required pallets.
+- (cli) The bundle manifest's `includes` section's description of required pallets now reports when required pallets were overridden.
+- (cli) The bundle manifest's `includes` section's description of required pallets now recursively shows information about transitively-required pallets (but does not show information about file import groups in those transitively-required pallets).
+- (cli) The bundle manifest's `includes` section's description of required pallets now shows the results (as target file path -> source file path mappings) of evaluating each file import group attached to their respective required pallets.
 - (cli) The bundle manifest now has an `imports` section which describes the provenance of each imported file, as a list of how the file has been transitively imported across pallets (with pallets farther down the list being depeer in the transitive import chain).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.8.0-alpha.2 - 2024-09-21
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.8.0-alpha.2 - 2024-09-22
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (cli) Added a `[dev] plt locate-plt-file` command to print the actual filesystem path of the specified file in the specified pallet required by the local/development pallet.
 - (cli) Added a `[dev] plt show-plt-file` command to print the contents of the specified file in the specified pallet required by the local/development pallet.
 - (cli) Added a `cache rm-dl` command to delete the cache of downloaded files for export.
+- (cli) The bundle manifest's `includes` section now reports when required pallets were overridden.
+- (cli) The bundle manifest's `includes` section now shows the results (as target file path -> source file path mappings) of evaluating each file import group attached to required pallets.
+- (cli) The bundle manifest now has an `imports` section which describes the provenance of each imported file, as a list of how the file has been transitively imported across pallets (with pallets farther down the list being depeer in the transitive import chain).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.8.0-alpha.2 - 2024-09-21
+## Unreleased
 
 ### Added
 

--- a/cmd/forklift/dev/plt/pallets.go
+++ b/cmd/forklift/dev/plt/pallets.go
@@ -133,6 +133,12 @@ func loadReplacementPallets(fsPaths []string) (replacements []*forklift.FSPallet
 		if len(externalPallets) == 0 {
 			return nil, errors.Errorf("no replacement pallets found in path %s", replacementPath)
 		}
+		for _, pallet := range externalPallets {
+			version, clean := fcli.CheckGitRepoVersion(pallet.FS.Path())
+			if clean {
+				pallet.Version = version
+			}
+		}
 		replacements = append(replacements, externalPallets...)
 	}
 	return replacements, nil
@@ -202,6 +208,12 @@ func loadReplacementRepos(
 		}
 		if len(externalRepos) == 0 {
 			return nil, errors.Errorf("no replacement repos found in path %s", replacementPath)
+		}
+		for _, repo := range externalRepos {
+			version, clean := fcli.CheckGitRepoVersion(repo.FS.Path())
+			if clean {
+				repo.Version = version
+			}
 		}
 		replacements = append(replacements, externalRepos...)
 	}

--- a/cmd/forklift/main.go
+++ b/cmd/forklift/main.go
@@ -101,7 +101,7 @@ const (
 	bundleMinVersion = "v0.7.0"
 	// newBundleVersion is the Forklift version reported in new staged pallet bundles made by Forklift.
 	// Older versions of the Forklift tool cannot use such bundles.
-	newBundleVersion = "v0.7.0"
+	newBundleVersion = "v0.8.0-alpha.2"
 	// newStageStoreVersion is the Forklift version reported in a stage store initialized by Forklift.
 	// Older versions of the Forklift tool cannot use the state store.
 	newStageStoreVersion = "v0.7.0"

--- a/internal/app/forklift/bundles-models.go
+++ b/internal/app/forklift/bundles-models.go
@@ -95,6 +95,8 @@ type BundlePalletInclusion struct {
 	// Override describes the pallet used to override the required pallet, if an override was
 	// specified for the pallet when building the bundled pallet.
 	Override BundleInclusionOverride `yaml:"override,omitempty"`
+	// Includes describes pallets used to define the pallet, omitting information about file imports.
+	Includes map[string]BundlePalletInclusion `yaml:"includes,omitempty"`
 	// Imports lists the files imported from the pallet, organized by import group. Keys are the names
 	// of the import groups, and values are the results of evaluating the respective import groups -
 	// i.e. maps whose keys are target file paths (where the files are imported to) and whose values

--- a/internal/app/forklift/bundles-models.go
+++ b/internal/app/forklift/bundles-models.go
@@ -51,11 +51,16 @@ type BundleManifest struct {
 	Pallet BundlePallet `yaml:"pallet"`
 	// Includes describes repos and pallets used to define the bundle's package deployments.
 	Includes BundleInclusions `yaml:"includes,omitempty"`
-	// Deploys describes deployments provided by the bundle. Keys are names of deployments.
-	Deploys map[string]DeplDef `yaml:"deploys,omitempty"`
+	// Imports lists the files imported from required pallets and the fully-qualified paths of those
+	// source files (relative to their respective source pallets). Keys are the target paths of the
+	// files, while values are lists showing the chain of provenance of the respective files (with
+	// the deepest ancestor at the end of each list).
+	Imports map[string][]string `yaml:"imports,omitempty"`
 	// Downloads lists the URLs of files and OCI images downloaded for export by the bundle's
 	// deployments. Keys are names of the bundle's deployments which export downloaded files.
 	Downloads map[string][]string `yaml:"downloads,omitempty"`
+	// Deploys describes deployments provided by the bundle. Keys are names of deployments.
+	Deploys map[string]DeplDef `yaml:"deploys,omitempty"`
 	// Exports lists the target paths of file exports provided by the bundle's deployments. Keys are
 	// names of the bundle's deployments which provide file exports.
 	Exports map[string][]string `yaml:"exports,omitempty"`
@@ -90,6 +95,11 @@ type BundlePalletInclusion struct {
 	// Override describes the pallet used to override the required pallet, if an override was
 	// specified for the pallet when building the bundled pallet.
 	Override BundleInclusionOverride `yaml:"override,omitempty"`
+	// Imports lists the files imported from the pallet, organized by import group. Keys are the names
+	// of the import groups, and values are the results of evaluating the respective import groups -
+	// i.e. maps whose keys are target file paths (where the files are imported to) and whose values
+	// are source file paths (where the files are imported from).
+	Imports map[string]map[string]string `yaml:"imports,omitempty"`
 }
 
 // BundleRepoInclusion describes a package repository used to build the bundled pallet.


### PR DESCRIPTION
This PR resolves #253 by implementing a feature left out of #286, namely allowing identical source files (identical permissions & file contents) from different pallets to be merged to the same target file path.

This PR also writes information about file imports & provenance through pallet layering to Forklift bundle manifests.