### PR TITLE
Add a `stage show-next-index` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- (cli) Added a `stage show-next-index` command to print the index of the next staged pallet bundle (if it exists).
+
 ## 0.8.0-alpha.2 - 2024-09-22
 
 ### Added

--- a/cmd/forklift/stage/cli.go
+++ b/cmd/forklift/stage/cli.go
@@ -74,6 +74,12 @@ func makeQuerySubcmds(versions Versions) []*cli.Command {
 				Usage:    "Shows the history of successfully-applied staged pallet bundles",
 				Action:   showHistAction(versions),
 			},
+			{
+				Name:     "show-next-index",
+				Category: category,
+				Usage:    "Prints the index of next staged pallet bundle to be applied",
+				Action:   showNextIndexAction(versions),
+			},
 		},
 		makeQueryBunSubcmds(versions)...,
 	)

--- a/cmd/forklift/stage/store.go
+++ b/cmd/forklift/stage/store.go
@@ -237,6 +237,27 @@ func showHistAction(versions Versions) cli.ActionFunc {
 	}
 }
 
+// show-next-index
+
+func showNextIndexAction(versions Versions) cli.ActionFunc {
+	return func(c *cli.Context) error {
+		store, err := getStageStore(c.String("workspace"), c.String("stage-store"), versions)
+		if err != nil {
+			return err
+		}
+		if !store.Exists() {
+			return errMissingStore
+		}
+
+		next, ok := store.GetNext()
+		if !ok {
+			return errors.New("there is currently no staged pallet bundle to be applied next!")
+		}
+		fmt.Println(next)
+		return nil
+	}
+}
+
 // set-next
 
 func setNextAction(versions Versions) cli.ActionFunc {
@@ -251,7 +272,10 @@ func setNextAction(versions Versions) cli.ActionFunc {
 
 		if c.Args().First() == "0" {
 			store.SetNext(0)
-			fmt.Println("Committing update to the stage store so that no stage will be applied next...")
+			fmt.Println(
+				"Committing update to the stage store so that no staged pallet bundle will be applied " +
+					"next...",
+			)
 			if err := store.CommitState(); err != nil {
 				return errors.Wrap(err, "couldn't commit updated stage store state")
 			}


### PR DESCRIPTION
This PR closes #227 by adding a command which provides the requested functionality, though under a different command name (`stage show-next-index` instead of `stage get-next`).