### PR TITLE
Allow overriding container image platform for crane-based operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - (cli) Added a `stage show-next-index` command to print the index of the next staged pallet bundle (if it exists).
-- (cli) Added a `--platform` flag (and `FORKLIFT_PLATFORM` env var) to override the auto-detected platform (e.g. `linux/amd64` or `linux/arm64`) used for downloading container images for file exports. This flag is not yet considered for downloading container images for Compose apps.
+- (cli) Added a `--platform` flag (and `FORKLIFT_PLATFORM` env var) to override the auto-detected platform (e.g. `linux/amd64` or `linux/arm64`) used for downloading container images for file exports and for pre-downloading container images needed for the next `forklift stage apply`.
 
 ## 0.8.0-alpha.2 - 2024-09-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - (cli) Added a `stage show-next-index` command to print the index of the next staged pallet bundle (if it exists).
+- (cli) Added a `--platform` flag (and `FORKLIFT_PLATFORM` env var) to override the auto-detected platform (e.g. `linux/amd64` or `linux/arm64`) used for downloading container images for file exports. This flag is not yet considered for downloading container images for Compose apps.
 
 ## 0.8.0-alpha.2 - 2024-09-22
 

--- a/cmd/forklift/dev/plt/downloads.go
+++ b/cmd/forklift/dev/plt/downloads.go
@@ -53,7 +53,7 @@ func cacheDlAction(versions Versions) cli.ActionFunc {
 		}
 
 		if err := fcli.DownloadExportFiles(
-			0, plt, caches.r, caches.d, false, c.Bool("parallel"),
+			0, plt, caches.r, caches.d, c.String("platform"), false, c.Bool("parallel"),
 		); err != nil {
 			return err
 		}

--- a/cmd/forklift/dev/plt/images.go
+++ b/cmd/forklift/dev/plt/images.go
@@ -51,7 +51,7 @@ func cacheImgAction(versions Versions) cli.ActionFunc {
 
 		fmt.Println("Downloading Docker container images specified by the development pallet...")
 		if err := fcli.DownloadImages(
-			0, plt, caches.r, c.Bool("include-disabled"), c.Bool("parallel"),
+			0, plt, caches.r, c.String("platform"), c.Bool("include-disabled"), c.Bool("parallel"),
 		); err != nil {
 			return err
 		}

--- a/cmd/forklift/dev/plt/pallets.go
+++ b/cmd/forklift/dev/plt/pallets.go
@@ -261,7 +261,7 @@ func cacheAllAction(versions Versions) cli.ActionFunc {
 
 		if err = fcli.CacheAllReqs(
 			0, plt, caches.m, caches.p, caches.r, caches.d,
-			c.Bool("include-disabled"), c.Bool("parallel"),
+			c.String("platform"), c.Bool("include-disabled"), c.Bool("parallel"),
 		); err != nil {
 			return err
 		}
@@ -360,7 +360,8 @@ func stageAction(versions Versions) cli.ActionFunc {
 		}
 		if _, err = fcli.StagePallet(
 			0, plt, stageStore, caches.staging(), c.String("exports"),
-			versions.Staging, c.Bool("no-cache-img"), c.Bool("parallel"), c.Bool("ignore-tool-version"),
+			versions.Staging, c.Bool("no-cache-img"), c.String("platform"), c.Bool("parallel"),
+			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}
@@ -400,7 +401,8 @@ func applyAction(versions Versions) cli.ActionFunc {
 		}
 		index, err := fcli.StagePallet(
 			0, plt, stageStore, caches.staging(), c.String("exports"),
-			versions.Staging, false, c.Bool("parallel"), c.Bool("ignore-tool-version"),
+			versions.Staging, false, c.String("platform"), c.Bool("parallel"),
+			c.Bool("ignore-tool-version"),
 		)
 		if err != nil {
 			return errors.Wrap(err, "couldn't stage pallet to be applied immediately")
@@ -513,7 +515,8 @@ func addPltAction(versions Versions) cli.ActionFunc {
 				return err
 			}
 			if _, _, err = fcli.CacheStagingReqs(
-				0, plt, caches.m, caches.p, caches.r, caches.d, false, c.Bool("parallel"),
+				0, plt, caches.m, caches.p, caches.r, caches.d,
+				c.String("platform"), false, c.Bool("parallel"),
 			); err != nil {
 				return err
 			}

--- a/cmd/forklift/dev/plt/repositories.go
+++ b/cmd/forklift/dev/plt/repositories.go
@@ -105,7 +105,8 @@ func addRepoAction(versions Versions) cli.ActionFunc {
 		}
 		if !c.Bool("no-cache-req") {
 			if _, _, err = fcli.CacheStagingReqs(
-				0, plt, caches.m, caches.p, caches.r, caches.d, false, c.Bool("parallel"),
+				0, plt, caches.m, caches.p, caches.r, caches.d,
+				c.String("platform"), false, c.Bool("parallel"),
 			); err != nil {
 				return err
 			}

--- a/cmd/forklift/main.go
+++ b/cmd/forklift/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/PlanktoScope/forklift/cmd/forklift/plt"
 	"github.com/PlanktoScope/forklift/cmd/forklift/stage"
 	fcli "github.com/PlanktoScope/forklift/internal/app/forklift/cli"
+	"github.com/PlanktoScope/forklift/internal/clients/crane"
 )
 
 func main() {
@@ -22,7 +23,10 @@ func main() {
 	}
 }
 
-var defaultWorkspaceBase, _ = os.UserHomeDir()
+var (
+	defaultWorkspaceBase, _ = os.UserHomeDir()
+	defaultPlatform         = crane.DetectPlatform().String()
+)
 
 var fcliVersions fcli.StagingVersions = fcli.StagingVersions{
 	Core: fcli.Versions{
@@ -82,6 +86,12 @@ var app = &cli.App{
 			Usage: "Allow parallel execution of I/O-bound tasks, such as downloading container images " +
 				"or starting containers",
 			EnvVars: []string{"FORKLIFT_PARALLEL"},
+		},
+		&cli.StringFlag{
+			Name:    "platform",
+			Value:   defaultPlatform,
+			Usage:   "Select the os/arch or os/arch/variant platform for downloading container images",
+			EnvVars: []string{"FORKLIFT_PLATFORM"},
 		},
 	},
 	Suggest: true,

--- a/cmd/forklift/plt/downloads.go
+++ b/cmd/forklift/plt/downloads.go
@@ -51,7 +51,7 @@ func cacheDlAction(versions Versions) cli.ActionFunc {
 		}
 
 		if err := fcli.DownloadExportFiles(
-			0, plt, caches.r, caches.d, false, c.Bool("parallel"),
+			0, plt, caches.r, caches.d, c.String("platform"), false, c.Bool("parallel"),
 		); err != nil {
 			return err
 		}

--- a/cmd/forklift/plt/images.go
+++ b/cmd/forklift/plt/images.go
@@ -49,7 +49,7 @@ func cacheImgAction(versions Versions) cli.ActionFunc {
 
 		fmt.Println("Downloading Docker container images specified by the local pallet...")
 		if err := fcli.DownloadImages(
-			0, plt, caches.r, c.Bool("include-disabled"), c.Bool("parallel"),
+			0, plt, caches.r, c.String("platform"), c.Bool("include-disabled"), c.Bool("parallel"),
 		); err != nil {
 			return err
 		}

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -99,7 +99,7 @@ func cacheAllAction(versions Versions) cli.ActionFunc {
 
 		if err = fcli.CacheAllReqs(
 			0, plt, caches.m, caches.p, caches.r, caches.d,
-			c.Bool("include-disabled"), c.Bool("parallel"),
+			c.String("platform"), c.Bool("include-disabled"), c.Bool("parallel"),
 		); err != nil {
 			return err
 		}
@@ -136,7 +136,8 @@ func switchAction(versions Versions) cli.ActionFunc {
 		if err = preparePallet(
 			// Note: we don't cache staging requirements because that will be handled by the apply/stage
 			// step anyways:
-			workspace, query, true, false, c.Bool("parallel"), c.Bool("ignore-tool-version"), versions,
+			workspace, query, true, false, c.String("platform"), c.Bool("parallel"),
+			c.Bool("ignore-tool-version"), versions,
 		); err != nil {
 			return err
 		}
@@ -370,7 +371,8 @@ func isHeadInRemotes(indent int, gitRepo *git.Repo) (bool, error) {
 
 func preparePallet(
 	workspace *forklift.FSWorkspace, gitRepoQuery forklift.GitRepoQuery,
-	updateLocalMirror, cacheStagingReqs, parallel, ignoreToolVersion bool, versions Versions,
+	updateLocalMirror, cacheStagingReqs bool, platform string, parallel, ignoreToolVersion bool,
+	versions Versions,
 ) error {
 	// clone pallet
 	if err := fcli.CloneQueriedGitRepoUsingLocalMirror(
@@ -394,7 +396,7 @@ func preparePallet(
 	if cacheStagingReqs {
 		fmt.Println()
 		if _, _, err = fcli.CacheStagingReqs(
-			0, plt, caches.m, caches.p, caches.r, caches.d, false, parallel,
+			0, plt, caches.m, caches.p, caches.r, caches.d, platform, false, parallel,
 		); err != nil {
 			return err
 		}
@@ -431,7 +433,8 @@ func upgradeAction(versions Versions) cli.ActionFunc {
 		if err = preparePallet(
 			// Note: we don't cache staging requirements because that will be handled by the apply/stage
 			// step anyways:
-			workspace, query, false, false, c.Bool("parallel"), c.Bool("ignore-tool-version"), versions,
+			workspace, query, false, false, c.String("platform"), c.Bool("parallel"),
+			c.Bool("ignore-tool-version"), versions,
 		); err != nil {
 			return err
 		}
@@ -669,7 +672,7 @@ func cloneAction(versions Versions) cli.ActionFunc {
 		}
 
 		if err = preparePallet(
-			workspace, query, true, !c.Bool("no-cache-req"), c.Bool("parallel"),
+			workspace, query, true, !c.Bool("no-cache-req"), c.String("platform"), c.Bool("parallel"),
 			c.Bool("ignore-tool-version"), versions,
 		); err != nil {
 			return err
@@ -744,7 +747,8 @@ func pullAction(versions Versions) cli.ActionFunc {
 
 		if !c.Bool("no-cache-req") {
 			if _, _, err = fcli.CacheStagingReqs(
-				0, plt, caches.m, caches.p, caches.r, caches.d, false, c.Bool("parallel"),
+				0, plt, caches.m, caches.p, caches.r, caches.d,
+				c.String("platform"), false, c.Bool("parallel"),
 			); err != nil {
 				return err
 			}
@@ -865,7 +869,8 @@ func stageAction(versions Versions) cli.ActionFunc {
 		}
 		if _, err = fcli.StagePallet(
 			0, plt, stageStore, caches.staging(), c.String("exports"),
-			versions.Staging, c.Bool("no-cache-img"), c.Bool("parallel"), c.Bool("ignore-tool-version"),
+			versions.Staging, c.Bool("no-cache-img"), c.String("platform"), c.Bool("parallel"),
+			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}
@@ -900,7 +905,8 @@ func applyAction(versions Versions) cli.ActionFunc {
 		}
 		index, err := fcli.StagePallet(
 			0, plt, stageStore, caches.staging(), c.String("exports"),
-			versions.Staging, false, c.Bool("parallel"), c.Bool("ignore-tool-version"),
+			versions.Staging, false, c.String("platform"), c.Bool("parallel"),
+			c.Bool("ignore-tool-version"),
 		)
 		if err != nil {
 			return errors.Wrap(err, "couldn't stage pallet to be applied immediately")
@@ -1011,7 +1017,8 @@ func addPltAction(versions Versions) cli.ActionFunc {
 				return err
 			}
 			if _, _, err = fcli.CacheStagingReqs(
-				0, plt, caches.m, caches.p, caches.r, caches.d, false, c.Bool("parallel"),
+				0, plt, caches.m, caches.p, caches.r, caches.d,
+				c.String("platform"), false, c.Bool("parallel"),
 			); err != nil {
 				return err
 			}

--- a/cmd/forklift/plt/repositories.go
+++ b/cmd/forklift/plt/repositories.go
@@ -98,7 +98,8 @@ func addRepoAction(versions Versions) cli.ActionFunc {
 		}
 		if !c.Bool("no-cache-req") {
 			if _, _, err = fcli.CacheStagingReqs(
-				0, plt, caches.m, caches.p, caches.r, caches.d, false, c.Bool("parallel"),
+				0, plt, caches.m, caches.p, caches.r, caches.d,
+				c.String("platform"), false, c.Bool("parallel"),
 			); err != nil {
 				return err
 			}

--- a/cmd/forklift/stage/images.go
+++ b/cmd/forklift/stage/images.go
@@ -22,7 +22,7 @@ func cacheImgAction(versions Versions) cli.ActionFunc {
 
 		if err = fcli.DownloadImagesForStoreApply(
 			0, store, versions.Tool, versions.MinSupportedBundle,
-			c.Bool("parallel"), c.Bool("ignore-tool-version"),
+			c.String("platform"), c.Bool("parallel"), c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}

--- a/cmd/forklift/stage/store.go
+++ b/cmd/forklift/stage/store.go
@@ -298,7 +298,8 @@ func setNextAction(versions Versions) cli.ActionFunc {
 
 		if err = fcli.SetNextStagedBundle(
 			0, store, newNext, c.String("exports"), versions.Tool, versions.MinSupportedBundle,
-			c.Bool("no-cache-img"), c.Bool("parallel"), c.Bool("ignore-tool-version"),
+			c.Bool("no-cache-img"), c.String("platform"), c.Bool("parallel"),
+			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
 		}

--- a/internal/app/forklift/cli/caching.go
+++ b/internal/app/forklift/cli/caching.go
@@ -25,7 +25,9 @@ func CacheAllReqs(
 		indent,
 		"Downloading Docker container images to be deployed by the local pallet...",
 	)
-	if err := DownloadImages(1, pallet, repoCacheWithMerged, includeDisabled, parallel); err != nil {
+	if err := DownloadImages(
+		1, pallet, repoCacheWithMerged, platform, includeDisabled, parallel,
+	); err != nil {
 		return err
 	}
 	return nil

--- a/internal/app/forklift/cli/caching.go
+++ b/internal/app/forklift/cli/caching.go
@@ -11,16 +11,20 @@ func CacheAllReqs(
 	indent int, pallet *forklift.FSPallet, mirrorsCache core.Pather,
 	palletCache forklift.PathedPalletCache, repoCache forklift.PathedRepoCache,
 	dlCache *forklift.FSDownloadCache,
-	includeDisabled, parallel bool,
+	platform string, includeDisabled, parallel bool,
 ) error {
 	pallet, repoCacheWithMerged, err := CacheStagingReqs(
-		indent, pallet, mirrorsCache, palletCache, repoCache, dlCache, includeDisabled, parallel,
+		indent, pallet, mirrorsCache, palletCache, repoCache, dlCache,
+		platform, includeDisabled, parallel,
 	)
 	if err != nil {
 		return err
 	}
 
-	IndentedPrintln(indent, "Downloading Docker container images to be deployed by the local pallet...")
+	IndentedPrintln(
+		indent,
+		"Downloading Docker container images to be deployed by the local pallet...",
+	)
 	if err := DownloadImages(1, pallet, repoCacheWithMerged, includeDisabled, parallel); err != nil {
 		return err
 	}
@@ -31,7 +35,7 @@ func CacheStagingReqs(
 	indent int, pallet *forklift.FSPallet, mirrorsCache core.Pather,
 	palletCache forklift.PathedPalletCache, repoCache forklift.PathedRepoCache,
 	dlCache *forklift.FSDownloadCache,
-	includeDisabled, parallel bool,
+	platform string, includeDisabled, parallel bool,
 ) (merged *forklift.FSPallet, repoCacheWithMerged *forklift.LayeredRepoCache, err error) {
 	IndentedPrintln(indent, "Caching everything needed to stage the pallet...")
 	indent++
@@ -65,7 +69,7 @@ func CacheStagingReqs(
 	}
 
 	if err = DownloadExportFiles(
-		indent, merged, repoCacheWithMerged, dlCache, includeDisabled, parallel,
+		indent, merged, repoCacheWithMerged, dlCache, platform, includeDisabled, parallel,
 	); err != nil {
 		return merged, repoCacheWithMerged, err
 	}

--- a/internal/app/forklift/cli/staging.go
+++ b/internal/app/forklift/cli/staging.go
@@ -76,14 +76,15 @@ type StagingCaches struct {
 func StagePallet(
 	indent int, merged *forklift.FSPallet, stageStore *forklift.FSStageStore, caches StagingCaches,
 	exportPath string, versions StagingVersions,
-	skipImageCaching, parallel, ignoreToolVersion bool,
+	skipImageCaching bool, platform string, parallel, ignoreToolVersion bool,
 ) (index int, err error) {
 	if _, isMerged := merged.FS.(*forklift.MergeFS); isMerged {
 		return 0, errors.Errorf("the pallet provided for staging should not be a merged pallet!")
 	}
 
 	merged, repoCacheWithMerged, err := CacheStagingReqs(
-		0, merged, caches.Mirrors, caches.Pallets, caches.Repos, caches.Downloads, false, parallel,
+		0, merged, caches.Mirrors, caches.Pallets, caches.Repos, caches.Downloads,
+		platform, false, parallel,
 	)
 	if err != nil {
 		return 0, errors.Wrap(err, "couldn't cache requirements for staging the pallet")
@@ -178,7 +179,9 @@ func newBundleManifest(
 	desc.Pallet.Version, desc.Pallet.Clean = CheckGitRepoVersion(merged.FS.Path())
 	palletReqs, err := merged.LoadFSPalletReqs("**")
 	if err != nil {
-		return desc, errors.Wrapf(err, "couldn't determine pallets required by pallet %s", merged.Path())
+		return desc, errors.Wrapf(
+			err, "couldn't determine pallets required by pallet %s", merged.Path(),
+		)
 	}
 	for _, req := range palletReqs {
 		if desc.Includes.Pallets[req.RequiredPath], err = newBundlePalletInclusion(

--- a/internal/app/forklift/cli/staging.go
+++ b/internal/app/forklift/cli/staging.go
@@ -36,7 +36,8 @@ func GetStageStore(
 
 func SetNextStagedBundle(
 	indent int, store *forklift.FSStageStore, index int, exportPath,
-	toolVersion, bundleMinVersion string, skipImageCaching, parallel, ignoreToolVersion bool,
+	toolVersion, bundleMinVersion string, skipImageCaching bool, platform string, parallel,
+	ignoreToolVersion bool,
 ) error {
 	store.SetNext(index)
 	fmt.Printf(
@@ -51,7 +52,7 @@ func SetNextStagedBundle(
 	}
 
 	if err := DownloadImagesForStoreApply(
-		indent, store, toolVersion, bundleMinVersion, parallel, ignoreToolVersion,
+		indent, store, platform, toolVersion, bundleMinVersion, parallel, ignoreToolVersion,
 	); err != nil {
 		return errors.Wrap(err, "couldn't cache Docker container images required by staged pallet")
 	}
@@ -111,7 +112,7 @@ func StagePallet(
 	}
 	if err = SetNextStagedBundle(
 		indent, stageStore, index, exportPath, versions.Core.Tool, versions.MinSupportedBundle,
-		skipImageCaching, parallel, ignoreToolVersion,
+		skipImageCaching, platform, parallel, ignoreToolVersion,
 	); err != nil {
 		return index, errors.Wrapf(
 			err, "couldn't prepare staged pallet bundle %d to be applied next", index,

--- a/internal/clients/docker/images.go
+++ b/internal/clients/docker/images.go
@@ -134,7 +134,7 @@ func CompareDeletedImages(i, j dti.DeleteResponse) int {
 }
 
 func (c *Client) PullImage(
-	ctx context.Context, taggedName string, outStream *streams.Out,
+	ctx context.Context, taggedName, platform string, outStream *streams.Out,
 ) (trust.ImageRefAndAuth, error) {
 	// This function is adapted from the github.com/docker/cli/cli/command/image
 	// package's RunPull function, which is licensed under Apache-2.0. This function was changed to
@@ -157,7 +157,7 @@ func (c *Client) PullImage(
 		)
 	}
 
-	if err = c.pullImage(ctx, imgRefAndAuth, outStream); err != nil {
+	if err = c.pullImage(ctx, imgRefAndAuth, platform, outStream); err != nil {
 		return trust.ImageRefAndAuth{}, err
 	}
 
@@ -173,7 +173,7 @@ func authResolver(ctx context.Context, index *dtr.IndexInfo) dtr.AuthConfig {
 }
 
 func (c *Client) pullImage(
-	ctx context.Context, imgRefAndAuth trust.ImageRefAndAuth, out *streams.Out,
+	ctx context.Context, imgRefAndAuth trust.ImageRefAndAuth, platform string, out *streams.Out,
 ) (err error) {
 	// This function is adapted from the github.com/docker/cli/cli/command/image
 	// package's imagePullPrivileged function, which is licensed under Apache-2.0. This function was
@@ -186,6 +186,7 @@ func (c *Client) pullImage(
 	responseBody, err := c.Client.ImagePull(
 		ctx, reference.FamiliarString(imgRefAndAuth.Reference()), dti.PullOptions{
 			RegistryAuth: encodedAuth,
+			Platform:     platform,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
This PR closes #256 by adding a `--platform` flag (and `FORKLIFT_PLATFORM` env var) which is used for when container images are explicitly pulled (e.g. as part of a `forklift plt stage`, but not if the image is only pulled during `forklift stage apply`).