### PR TITLE
Add subcommands to print the version string of the required pallet/repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.8.0-alpha.3 - 2024-12-06
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- (cli) Added `[dev] plt show-plt-version` and `[dev] plt show-repo-version` commands to print the version/pseudoversion string for the required version of the specified pallet/repo.
 - (cli) Added a `stage show-next-index` command to print the index of the next staged pallet bundle (if it exists).
 - (cli) Added a `--platform` flag (and `FORKLIFT_PLATFORM` env var) to override the auto-detected platform (e.g. `linux/amd64` or `linux/arm64`) used for downloading container images for file exports and for pre-downloading container images needed for the next `forklift stage apply`.
 

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -148,7 +148,8 @@ func makeQuerySubcmds() []*cli.Command {
 				Action:   showAction,
 			},
 		},
-		makeQueryReqSubcmds(category),
+		makeQueryPltReqSubcmds(category),
+		makeQueryRepoReqSubcmds(category),
 		makeQueryImportSubcmds(category),
 		makeQueryFileSubcmds(category),
 		makeQueryPkgSubcmds(category),
@@ -185,54 +186,74 @@ func makeQuerySubcmds() []*cli.Command {
 	)
 }
 
-func makeQueryReqSubcmds(category string) []*cli.Command {
+func makeQueryPltReqSubcmds(category string) []*cli.Command {
 	return slices.Concat(
 		[]*cli.Command{
 			{
 				Name:     "ls-plt",
 				Aliases:  []string{"list-pallets"},
 				Category: category,
-				Usage:    "Lists pallets which the development pallet may import files from",
+				Usage:    "Lists available pallets which the development pallet may import files from",
 				Action:   lsPltAction,
 			},
 			{
-				Name:      "show-plt",
-				Aliases:   []string{"show-pallet"},
-				Category:  category,
-				Usage:     "Describes a pallet which the development pallet may import files from",
+				Name:     "show-plt",
+				Aliases:  []string{"show-pallet"},
+				Category: category,
+				Usage: "Describes an available pallet which the development pallet may import files " +
+					"from",
 				ArgsUsage: "plt_path",
 				Action:    showPltAction,
+			},
+			{
+				Name:      "show-plt-version",
+				Aliases:   []string{"show-pallet-version"},
+				Category:  category,
+				Usage:     "Prints the required version of the available pallet",
+				ArgsUsage: "plt_path",
+				Action:    showPltVersionAction,
 			},
 		},
 		makeQueryPltFileSubcmds(category),
 		makeQueryPltFeatSubcmds(category),
-		[]*cli.Command{
-			{
-				Name:     "ls-repo",
-				Aliases:  []string{"list-repositories"},
-				Category: category,
-				Usage:    "Lists repos specified by the development pallet",
-				Action:   lsRepoAction,
-			},
-			{
-				Name:     "locate-repo",
-				Aliases:  []string{"locate-repository"},
-				Category: category,
-				Usage: "Prints the absolute filesystem path of a repo available in the development " +
-					"pallet",
-				ArgsUsage: "repo_path",
-				Action:    locateRepoAction,
-			},
-			{
-				Name:      "show-repo",
-				Aliases:   []string{"show-repository"},
-				Category:  category,
-				Usage:     "Describes a repo available in the development pallet",
-				ArgsUsage: "repo_path",
-				Action:    showRepoAction,
-			},
-		},
 	)
+}
+
+func makeQueryRepoReqSubcmds(category string) []*cli.Command {
+	return []*cli.Command{
+		{
+			Name:     "ls-repo",
+			Aliases:  []string{"list-repositories"},
+			Category: category,
+			Usage:    "Lists repos specified by the development pallet",
+			Action:   lsRepoAction,
+		},
+		{
+			Name:     "locate-repo",
+			Aliases:  []string{"locate-repository"},
+			Category: category,
+			Usage: "Prints the absolute filesystem path of a repo available in the development " +
+				"pallet",
+			ArgsUsage: "repo_path",
+			Action:    locateRepoAction,
+		},
+		{
+			Name:      "show-repo",
+			Aliases:   []string{"show-repository"},
+			Category:  category,
+			Usage:     "Describes a repo available in the development pallet",
+			ArgsUsage: "repo_path",
+			Action:    showRepoAction,
+		},
+		{
+			Name:      "show-repo-version",
+			Aliases:   []string{"show-repository-version"},
+			Category:  category,
+			Usage:     "Prints the required version of the available repo",
+			ArgsUsage: "repo_path",
+			// Action:    showRepoVersionAction,
+		},
+	}
 }
 
 func makeQueryPltFileSubcmds(category string) []*cli.Command {

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -251,7 +251,7 @@ func makeQueryRepoReqSubcmds(category string) []*cli.Command {
 			Category:  category,
 			Usage:     "Prints the required version of the available repo",
 			ArgsUsage: "repo_path",
-			// Action:    showRepoVersionAction,
+			Action:    showRepoVersionAction,
 		},
 	}
 }

--- a/cmd/forklift/dev/plt/pallets.go
+++ b/cmd/forklift/dev/plt/pallets.go
@@ -485,6 +485,20 @@ func showPltAction(c *cli.Context) error {
 	return fcli.PrintRequiredPalletInfo(0, plt, caches.p, c.Args().First())
 }
 
+// show-plt-version
+
+func showPltVersionAction(c *cli.Context) error {
+	plt, caches, err := processFullBaseArgs(c, processingOptions{
+		requirePalletCache: true,
+		enableOverrides:    true,
+	})
+	if err != nil {
+		return err
+	}
+
+	return fcli.PrintRequiredPalletVersion(0, plt, caches.p, c.Args().First())
+}
+
 // add-plt
 
 func addPltAction(versions Versions) cli.ActionFunc {

--- a/cmd/forklift/dev/plt/repositories.go
+++ b/cmd/forklift/dev/plt/repositories.go
@@ -85,6 +85,21 @@ func showRepoAction(c *cli.Context) error {
 	return fcli.PrintRequiredRepoInfo(0, plt, caches.r, c.Args().First())
 }
 
+// show-repo-version
+
+func showRepoVersionAction(c *cli.Context) error {
+	plt, caches, err := processFullBaseArgs(c, processingOptions{
+		requireRepoCache: true,
+		enableOverrides:  true,
+		merge:            true,
+	})
+	if err != nil {
+		return err
+	}
+
+	return fcli.PrintRequiredRepoVersion(0, plt, caches.r, c.Args().First())
+}
+
 // add-repo
 
 func addRepoAction(versions Versions) cli.ActionFunc {

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -215,7 +215,8 @@ func makeQuerySubcmds() []*cli.Command {
 				Action:   showAction,
 			},
 		},
-		makeQueryReqSubcmds(category),
+		makeQueryPltReqSubcmds(category),
+		makeQueryRepoReqSubcmds(category),
 		makeQueryImportSubcmds(category),
 		makeQueryFileSubcmds(category),
 		makeQueryPkgSubcmds(category),
@@ -252,53 +253,72 @@ func makeQuerySubcmds() []*cli.Command {
 	)
 }
 
-func makeQueryReqSubcmds(category string) []*cli.Command {
+func makeQueryPltReqSubcmds(category string) []*cli.Command {
 	return slices.Concat(
 		[]*cli.Command{
 			{
 				Name:     "ls-plt",
 				Aliases:  []string{"list-pallets"},
 				Category: category,
-				Usage:    "Lists pallets which the local pallet may import files from",
+				Usage:    "Lists available pallets which the local pallet may import files from",
 				Action:   lsPltAction,
 			},
 			{
 				Name:      "show-plt",
 				Aliases:   []string{"show-pallet"},
 				Category:  category,
-				Usage:     "Describes a pallet which the local pallet may import files from",
+				Usage:     "Describes an available pallet which the local pallet may import files from",
 				ArgsUsage: "plt_path",
 				Action:    showPltAction,
+			},
+			{
+				Name:      "show-plt-version",
+				Aliases:   []string{"show-pallet-version"},
+				Category:  category,
+				Usage:     "Prints the required version of the available pallet",
+				ArgsUsage: "plt_path",
+				Action:    showPltVersionAction,
 			},
 		},
 		makeQueryPltFileSubcmds(category),
 		makeQueryPltFeatSubcmds(category),
-		[]*cli.Command{
-			{
-				Name:     "ls-repo",
-				Aliases:  []string{"list-repositories"},
-				Category: category,
-				Usage:    "Lists repos available in the local pallet",
-				Action:   lsRepoAction,
-			},
-			{
-				Name:      "locate-repo",
-				Aliases:   []string{"locate-repository"},
-				Category:  category,
-				Usage:     "Prints the absolute filesystem path of a repo available in the local pallet",
-				ArgsUsage: "repo_path",
-				Action:    locateRepoAction,
-			},
-			{
-				Name:      "show-repo",
-				Aliases:   []string{"show-repository"},
-				Category:  category,
-				Usage:     "Describes a repo available in the local pallet",
-				ArgsUsage: "repo_path",
-				Action:    showRepoAction,
-			},
-		},
 	)
+}
+
+func makeQueryRepoReqSubcmds(category string) []*cli.Command {
+	return []*cli.Command{
+		{
+			Name:     "ls-repo",
+			Aliases:  []string{"list-repositories"},
+			Category: category,
+			Usage:    "Lists repos available in the local pallet",
+			Action:   lsRepoAction,
+		},
+		{
+			Name:      "locate-repo",
+			Aliases:   []string{"locate-repository"},
+			Category:  category,
+			Usage:     "Prints the absolute filesystem path of a repo available in the local pallet",
+			ArgsUsage: "repo_path",
+			Action:    locateRepoAction,
+		},
+		{
+			Name:      "show-repo",
+			Aliases:   []string{"show-repository"},
+			Category:  category,
+			Usage:     "Describes a repo available in the local pallet",
+			ArgsUsage: "repo_path",
+			Action:    showRepoAction,
+		},
+		{
+			Name:      "show-repo-version",
+			Aliases:   []string{"show-repository-version"},
+			Category:  category,
+			Usage:     "Prints the required version of the available repo",
+			ArgsUsage: "repo_path",
+			// Action:    showRepoVersionAction,
+		},
+	}
 }
 
 func makeQueryPltFileSubcmds(category string) []*cli.Command {

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -316,7 +316,7 @@ func makeQueryRepoReqSubcmds(category string) []*cli.Command {
 			Category:  category,
 			Usage:     "Prints the required version of the available repo",
 			ArgsUsage: "repo_path",
-			// Action:    showRepoVersionAction,
+			Action:    showRepoVersionAction,
 		},
 	}
 }

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -989,6 +989,19 @@ func showPltAction(c *cli.Context) error {
 	return fcli.PrintRequiredPalletInfo(0, plt, caches.p, c.Args().First())
 }
 
+// show-plt-version
+
+func showPltVersionAction(c *cli.Context) error {
+	plt, caches, err := processFullBaseArgs(c.String("workspace"), processingOptions{
+		requirePalletCache: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	return fcli.PrintRequiredPalletVersion(0, plt, caches.p, c.Args().First())
+}
+
 // add-plt
 
 func addPltAction(versions Versions) cli.ActionFunc {

--- a/cmd/forklift/plt/repositories.go
+++ b/cmd/forklift/plt/repositories.go
@@ -79,6 +79,20 @@ func showRepoAction(c *cli.Context) error {
 	return fcli.PrintRequiredRepoInfo(0, plt, caches.r, c.Args().First())
 }
 
+// show-repo-version
+
+func showRepoVersionAction(c *cli.Context) error {
+	plt, caches, err := processFullBaseArgs(c.String("workspace"), processingOptions{
+		requireRepoCache: true,
+		merge:            true,
+	})
+	if err != nil {
+		return err
+	}
+
+	return fcli.PrintRequiredRepoVersion(0, plt, caches.r, c.Args().First())
+}
+
 // add-repo
 
 func addRepoAction(versions Versions) cli.ActionFunc {

--- a/internal/app/forklift/cli/requirements-pallets.go
+++ b/internal/app/forklift/cli/requirements-pallets.go
@@ -115,6 +115,21 @@ func printPalletReq(indent int, req forklift.PalletReq) {
 	IndentedPrintf(indent, "Locked pallet version: %s\n", req.VersionLock.Version)
 }
 
+func PrintRequiredPalletVersion(
+	indent int, pallet *forklift.FSPallet, cache forklift.PathedPalletCache,
+	requiredPalletPath string,
+) error {
+	req, err := pallet.LoadFSPalletReq(requiredPalletPath)
+	if err != nil {
+		return errors.Wrapf(
+			err, "couldn't load pallet version lock definition %s from pallet %s",
+			requiredPalletPath, pallet.FS.Path(),
+		)
+	}
+	IndentedPrintln(indent, req.VersionLock.Version)
+	return nil
+}
+
 // Add
 
 func AddPalletReqs(

--- a/internal/app/forklift/cli/requirements-repositories.go
+++ b/internal/app/forklift/cli/requirements-repositories.go
@@ -149,6 +149,20 @@ func printRepoReq(indent int, req forklift.RepoReq) {
 	IndentedPrintf(indent, "Locked repo version: %s\n", req.VersionLock.Version)
 }
 
+func PrintRequiredRepoVersion(
+	indent int, pallet *forklift.FSPallet, cache forklift.PathedRepoCache, requiredRepoPath string,
+) error {
+	req, err := pallet.LoadFSRepoReq(requiredRepoPath)
+	if err != nil {
+		return errors.Wrapf(
+			err, "couldn't load repo version lock definition %s from pallet %s",
+			requiredRepoPath, pallet.FS.Path(),
+		)
+	}
+	IndentedPrintln(indent, req.VersionLock.Version)
+	return nil
+}
+
 // Add
 
 func AddRepoReqs(


### PR DESCRIPTION
This PR adds `[dev] plt show-plt-version` and `[dev] plt show-repo-version` subcommands which print the version/pseudoversion string of the required pallet/repo, in support of https://github.com/forklift-run/pallet-example-layered/pull/2 (since [updatecli's shell target](https://www.updatecli.io/docs/plugins/resource/shell/#_shell_target) treats the stdout from its command as a version string).