### PR TITLE
Add `inspector resolve-git-repo` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- (cli) Added `inspector resolve-git-repo` command to resolve version queries on git repositories.
+
 ### Fixed
 
 - (cli) `[dev] plt show-plt-version` and `[dev] plt show-repo-version` no longer require the required pallets/repos to be cached before the commands work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.8.0-alpha.4 - 2024-12-07
 
 ### Added
 
-- (cli) Added `inspector resolve-git-repo` command to resolve version queries on git repositories.
+- (cli) Added a `inspector resolve-git-repo` command to resolve version queries on git repositories.
 
 ### Fixed
 
-- (cli) `[dev] plt show-plt-version` and `[dev] plt show-repo-version` no longer require the required pallets/repos to be cached before the commands work.
+- (cli) The `[dev] plt show-plt-version` and `[dev] plt show-repo-version` commands no longer require the required pallets/repos to be cached before the respective commands work.
 
 ## 0.8.0-alpha.3 - 2024-12-06
 

--- a/cmd/forklift/cache/cli.go
+++ b/cmd/forklift/cache/cli.go
@@ -105,7 +105,7 @@ var Cmd = &cli.Command{
 			Name:     "rm-mir",
 			Aliases:  []string{"remove-mirrors", "del-mir", "delete-mirrors"},
 			Category: "Modify the cache",
-			Usage:    "Removes locally-cached pallets",
+			Usage:    "Removes local mirrors of git repositories",
 			// TODO: allow only removing mirrors matching a glob pattern
 			Action: rmGitRepoAction("mirror", getMirrorCache),
 		},

--- a/cmd/forklift/inspector/cli.go
+++ b/cmd/forklift/inspector/cli.go
@@ -1,0 +1,21 @@
+// Package inspector provides subcommands for inspecting the state of various things
+package inspector
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+var Cmd = &cli.Command{
+	Name:  "inspector",
+	Usage: "Inspects the state of various things",
+	Subcommands: []*cli.Command{
+		{
+			Name:    "resolve-git-repo",
+			Aliases: []string{"resolve-git-repository"},
+			Usage: "Prints the version/pseudoversion string for the version query on the specified git " +
+				"repo",
+			ArgsUsage: "git_repo_path@version_query",
+			Action:    resolveGitRepoAction,
+		},
+	},
+}

--- a/cmd/forklift/inspector/inspector.go
+++ b/cmd/forklift/inspector/inspector.go
@@ -1,0 +1,47 @@
+package inspector
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
+
+	"github.com/PlanktoScope/forklift/internal/app/forklift"
+	fcli "github.com/PlanktoScope/forklift/internal/app/forklift/cli"
+)
+
+// resolve-git-repo
+
+func resolveGitRepoAction(c *cli.Context) error {
+	workspace, err := ensureWorkspace(c.String("workspace"))
+	if err != nil {
+		return err
+	}
+
+	query := c.Args().First()
+	resolved, err := fcli.ResolveQueriesUsingLocalMirrors(
+		0, workspace.GetMirrorCachePath(), []string{query}, true,
+	)
+	if err != nil {
+		return errors.Wrapf(err, "couldn't resolve query %s", query)
+	}
+	fmt.Println(resolved[query].VersionLock.Version)
+	return nil
+}
+
+func ensureWorkspace(wpath string) (*forklift.FSWorkspace, error) {
+	if !forklift.DirExists(wpath) {
+		fmt.Printf("Making a new workspace at %s...", wpath)
+	}
+	if err := forklift.EnsureExists(wpath); err != nil {
+		return nil, errors.Wrapf(err, "couldn't make new workspace at %s", wpath)
+	}
+	workspace, err := forklift.LoadWorkspace(wpath)
+	if err != nil {
+		return nil, err
+	}
+	if err = forklift.EnsureExists(workspace.GetDataPath()); err != nil {
+		return nil, errors.Wrapf(err, "couldn't ensure the existence of %s", workspace.GetDataPath())
+	}
+	return workspace, nil
+}

--- a/cmd/forklift/main.go
+++ b/cmd/forklift/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/PlanktoScope/forklift/cmd/forklift/cache"
 	"github.com/PlanktoScope/forklift/cmd/forklift/dev"
 	"github.com/PlanktoScope/forklift/cmd/forklift/host"
+	"github.com/PlanktoScope/forklift/cmd/forklift/inspector"
 	"github.com/PlanktoScope/forklift/cmd/forklift/plt"
 	"github.com/PlanktoScope/forklift/cmd/forklift/stage"
 	fcli "github.com/PlanktoScope/forklift/internal/app/forklift/cli"
@@ -54,6 +55,7 @@ var app = &cli.App{
 		}),
 		cache.Cmd,
 		host.Cmd,
+		inspector.Cmd,
 		dev.MakeCmd(dev.Versions{
 			Staging:       fcliVersions,
 			NewStageStore: newStageStoreVersion,


### PR DESCRIPTION
This PR adds a `inspector resolve-git-repo` subcommand which takes a `git_repo_path@version_query` argument, downloads a copy of the specified git repository to the Forklift cache's collection of local mirrors of git repositories, and attempts to resolve the specified version query into a version/pseudoversion string. This change is in support of https://github.com/forklift-run/pallet-example-layered/pull/2 .