### PR TITLE
Enable explicitly setting target file permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.8.0-alpha.6 - 2024-01-27
 
 ### Added
 
+- (spec) Added an optional `permissions` field to file exports in the packaging spec. If specified, this field enables overriding the source file's Unix permissions with an explicitly-provided permissions value for creating a regular file at the target path. The permissions should be specified as an octal value (e.g. `0644`).
 - (spec) Now the bundle manifest file's `exports` section lists information about the Docker Compose apps created by the bundle's package deployments.
 - (spec) Now the bundle manifest file's `downloads` section lists OCI images to be cached for Docker Compose apps; this is enabled by a breaking change in the layout of that section, described below.
 - (cli) Now `stage show-bun` prints information about required pallets in the "Includes" section.

--- a/docs/specs/00-package.md
+++ b/docs/specs/00-package.md
@@ -1360,6 +1360,16 @@ url: ghcr.io/planktoscope/machine-name:0.1.3
   target: overlays/etc/dnsmasq.d/dhcp-and-dns.conf
   ```
 
+`permissions` is the octal Unix permission bits which should be attached to the exported file.
+
+- This field is optional: it defaults to the permissions of the source file. For `local`-type source files, this is likely to be `0644` (corresponding to `rw-r--r--`) due to how Git handles file permissions.
+
+- Example:
+  
+  ```yaml
+  permissions: 0777
+  ```
+
 `tags` is an array of strings which describe the file export. These tags are ignored in determining whether file exports conflict with each other, since they are not part of the file export's location(s).
 
 - This field is optional.

--- a/pkg/core/packages-models.go
+++ b/pkg/core/packages-models.go
@@ -1,5 +1,7 @@
 package core
 
+import "io/fs"
+
 // A FSPkg is a Forklift package stored at the root of a [fs.FS] filesystem.
 type FSPkg struct {
 	// Pkg is the Forklift package at the root of the filesystem.
@@ -197,6 +199,8 @@ type FileExportRes struct {
 	Source string `yaml:"source,omitempty"`
 	// URL is the URL of the file to be downloaded for export, for a `http` source.
 	URL string `yaml:"url,omitempty"`
+	// Permissions is the Unix permission bits to attach to the exported file.
+	Permissions fs.FileMode `yaml:"permissions,omitempty"`
 	// Target is the path where the file will be exported to, relative to an export directory.
 	Target string `yaml:"target"`
 }


### PR DESCRIPTION
This PR enables explicitly specifying the file permissions to be used for exporting a file.

This PR is needed to help implement https://github.com/PlanktoScope/pallet-standard/pull/47 , because that PR needs to create some NetworkManager connection files (which are rejected by NetworkManager if they are readable by anyone other than the file owner), and because non-owner permission bits aren't tracked by Git (so those file permissions have to be stored out-of-band, i.e. in Forklift package declarations).