### PR TITLE
Fix bug in searching for commit among ancestors of git refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unrelease
+
+### Fixed
+
+- (cli) In certain cases where trying to run `plt upgrade` without the `--force` flag to upgrade from a commit which was only ancestral to the origin repo's references failed, now that operation should work.
+
 ## 0.8.0-alpha.7 - 2024-03-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- (cli) In certain cases where trying to run `plt upgrade` without the `--force` flag to upgrade from a commit which was only ancestral to the origin repo's references failed, now that operation should work.
+- (cli) In cases where trying to run `plt upgrade` without the `--force` flag (in order to upgrade from a commit which was only ancestral to the origin repo's references) incorrectly failed, now that operation should work.
 
 ## 0.8.0-alpha.7 - 2024-03-05
 

--- a/internal/clients/git/git.go
+++ b/internal/clients/git/git.go
@@ -390,7 +390,7 @@ func (r *Repo) RefsHaveAncestor(refs []*plumbing.Reference, commit string) (bool
 
 		visited.Add(next.commit.Hash)
 		for _, hash := range next.commit.ParentHashes {
-			if visited.Has(next.commit.Hash) {
+			if visited.Has(hash) {
 				continue
 			}
 


### PR DESCRIPTION
This PR fixes a bug in which the `plt upgrade` subcommand had to be run with `--force` even when the current commit of the current pallet was in the ancestry of at least one of the `origin` remote's refs. Specifically, the bug some incorrect logic for traversing the ancestry tree of refs (the ancestors of commits were not actually being added to the breadth-first tree search).