### PR TITLE
Speed up free-disk-space action step in CI release/release-test runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Free up disk space
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
+          large-packages: false
           docker-images: false
           swap-storage: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Free up disk space
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
+          large-packages: false
           docker-images: false
           swap-storage: false
 


### PR DESCRIPTION
This PR attempts to make the `release` and `release-test` CI jobs faster by skipping some relatively-slower work in freeing up disk space on the GitHub Actions runner VM.