### PR TITLE
Change `--no-cache-img` to `--cache-img=false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unrelease
 
+### Changed
+
+- (Breaking change; cli) The `--no-cache-img` flag has been replaced with `--cache-img=false`; and the `--no-cache-req` flag has been replaced with `--cache-req=false` to avoid causing double-negatives and to make flag naming slightly more logical.
+
 ### Fixed
 
 - (cli) In cases where trying to run `plt upgrade` without the `--force` flag (in order to upgrade from a commit which was only ancestral to the origin repo's references) incorrectly failed, now that operation should work.

--- a/README.md
+++ b/README.md
@@ -191,14 +191,15 @@ staged pallet using a separate `forklift stage apply` command. For example:
 If you aren't running Docker in rootless mode and your user isn't in a `docker` group, we recommend
 a slightly different set of commands:
 
-- If you want to apply the pallet immediately, you can run `forklift pallet switch --no-cache` as a
-regular user, and then run `forklift stage apply` as root; the `--no-cache` flag prevents
-`forklift pallet switch` from attempting to make Docker pre-download all container images required
-by the pallet, as doing so would require root permissions for Forklift to talk to Docker.
+- If you want to apply the pallet immediately, you can run
+`forklift pallet switch --cache-img=false` as a regular user, and then run `forklift stage apply` as
+root; the `--cache-img=false` flag prevents `forklift pallet switch` from attempting to make Docker
+pre-download all container images required by the pallet, as doing so would require root permissions
+for Forklift to talk to Docker.
 For example:
 
   ```
-  forklift pallet switch --no-cache-img github.com/forklift-run/pallet-example-minimal@main
+  forklift pallet switch --cache-img=false github.com/forklift-run/pallet-example-minimal@main
   sudo -E forklift stage apply
   ```
 
@@ -209,7 +210,7 @@ For example:
 
   ```
   # Run now:
-  forklift pallet switch --no-cache-img github.com/forklift-run/pallet-example-minimal@main
+  forklift pallet switch --cache-img=false github.com/forklift-run/pallet-example-minimal@main
   sudo -E forklift stage cache-img
   # Run when you want to apply the pallet:
   sudo -E forklift stage apply
@@ -259,17 +260,18 @@ repositories for use in your development pallet, and/or to change the versions o
 repositories already required by your development pallet.
 
 You can also run commands like `forklift dev plt cache-all` and
-`forklift dev plt stage --no-cache-img` (with appropriate values in the `--cwd` flag if necessary)
-to download the Forklift repositories specified by your development pallet into your local cache and
-stage your development pallet to be applied with `sudo -E forklift stage apply`. This is useful if,
-for example, you want to make some experimental changes to your development pallet and test them on
-your local machine before committing and pushing those changes onto GitHub.
+`forklift dev plt stage --cache-img=false` (with appropriate values in the `--cwd` flag if
+necessary) to download the Forklift repositories specified by your development pallet into your
+local cache and stage your development pallet to be applied with `sudo -E forklift stage apply`.
+This is useful if, for example, you want to make some experimental changes to your development
+pallet and test them on your local machine before committing and pushing those changes onto GitHub.
 
 Finally, you can run the `forklift dev plt check` command to check the pallet for any problems, such
 as violations of resource constraints between package deployments.
 
 You can also override cached repos with repos from your filesystem by specifying one or more
-directories containing one or more repos; then the repos in those directories will be used instead of the respective repos from the cache, regardless of repo version. For example:
+directories containing one or more repos; then the repos in those directories will be used instead
+of the respective repos from the cache, regardless of repo version. For example:
 
 ```
 cd /home/pi/

--- a/cmd/forklift/dev/plt/cli.go
+++ b/cmd/forklift/dev/plt/cli.go
@@ -70,8 +70,9 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 			Action:   stageAction(versions),
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
-					Name:  "no-cache-img",
-					Usage: "Don't download container images",
+					Name:  "cache-img",
+					Usage: "Download container images",
+					Value: true,
 				},
 			},
 		},
@@ -498,9 +499,10 @@ func makeModifyPltSubcmds(versions Versions) []*cli.Command {
 			ArgsUsage: "[plt_path@version_query]...",
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
-					Name: "no-cache-req",
-					Usage: "Don't download repositories and pallets required by this pallet after adding " +
+					Name: "cache-req",
+					Usage: "Download repositories and pallets required by this pallet after adding the " +
 						"the pallet",
+					Value: true,
 				},
 			},
 			Action: addPltAction(versions),
@@ -546,9 +548,10 @@ func makeModifyRepoSubcmds(versions Versions) []*cli.Command {
 			ArgsUsage: "[repo_path@version_query]...",
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
-					Name: "no-cache-req",
-					Usage: "Don't download repositories and pallets required by this pallet after adding " +
-						"the repo",
+					Name: "cache-req",
+					Usage: "Download repositories and pallets required by this pallet after adding the " +
+						"repo",
+					Value: true,
 				},
 			},
 			Action: addRepoAction(versions),
@@ -590,8 +593,9 @@ func makeModifyDeplSubcmds( //nolint:funlen // this is already decomposed; it's 
 				"if --apply is set)",
 		},
 		&cli.BoolFlag{
-			Name:  "no-cache-img",
-			Usage: "Don't download container images (this flag is only used if --stage is set)",
+			Name:  "cache-img",
+			Usage: "Download container images (this flag is only used if --stage is set)",
+			Value: true,
 		},
 		&cli.BoolFlag{
 			Name:  "apply",

--- a/cmd/forklift/dev/plt/pallets.go
+++ b/cmd/forklift/dev/plt/pallets.go
@@ -361,7 +361,7 @@ func stageAction(versions Versions) cli.ActionFunc {
 		}
 		if _, err = fcli.StagePallet(
 			0, plt, stageStore, caches.staging(), c.String("exports"),
-			versions.Staging, c.Bool("no-cache-img"), c.String("platform"), c.Bool("parallel"),
+			versions.Staging, !c.Bool("cache-img"), c.String("platform"), c.Bool("parallel"),
 			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
@@ -521,7 +521,7 @@ func addPltAction(versions Versions) cli.ActionFunc {
 		); err != nil {
 			return err
 		}
-		if !c.Bool("no-cache-req") {
+		if c.Bool("cache-req") {
 			plt, caches, err := processFullBaseArgs(c, processingOptions{
 				enableOverrides: true,
 			})

--- a/cmd/forklift/dev/plt/repositories.go
+++ b/cmd/forklift/dev/plt/repositories.go
@@ -118,7 +118,7 @@ func addRepoAction(versions Versions) cli.ActionFunc {
 		if err = fcli.AddRepoReqs(0, plt, caches.m.Path(), c.Args().Slice()); err != nil {
 			return err
 		}
-		if !c.Bool("no-cache-req") {
+		if c.Bool("cache-req") {
 			if _, _, err = fcli.CacheStagingReqs(
 				0, plt, caches.m, caches.p, caches.r, caches.d,
 				c.String("platform"), false, c.Bool("parallel"),

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -38,8 +38,9 @@ func MakeCmd(versions Versions) *cli.Command {
 								"changes, replace it",
 						},
 						&cli.BoolFlag{
-							Name:  "no-cache-img",
-							Usage: "Don't download container images (this flag is ignored if --apply is set)",
+							Name:  "cache-img",
+							Usage: "Download container images (this flag is ignored if --apply is set)",
+							Value: true,
 						},
 						&cli.BoolFlag{
 							Name:  "apply",
@@ -77,8 +78,9 @@ func makeUpgradeSubcmds(versions Versions) []*cli.Command {
 						"upgraded version",
 				},
 				&cli.BoolFlag{
-					Name:  "no-cache-img",
-					Usage: "Don't download container images (this flag is ignored if --apply is set)",
+					Name:  "cache-img",
+					Usage: "Download container images (this flag is ignored if --apply is set)",
+					Value: true,
 				},
 				&cli.BoolFlag{
 					Name:  "apply",
@@ -142,8 +144,9 @@ func makeUseSubcmds(versions Versions) []*cli.Command {
 			Action:   stageAction(versions),
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
-					Name:  "no-cache-img",
-					Usage: "Don't download container images",
+					Name:  "cache-img",
+					Usage: "Download container images",
+					Value: true,
 				},
 			},
 		},
@@ -548,8 +551,9 @@ func makeModifyGitSubcmds(versions Versions) []*cli.Command {
 							"pallet",
 					},
 					&cli.BoolFlag{
-						Name:  "no-cache-req",
-						Usage: "Don't download repositories and pallets required by this pallet after cloning",
+						Name:  "cache-req",
+						Usage: "Download repositories and pallets required by this pallet after cloning",
+						Value: true,
 					},
 				},
 				modifyBaseFlags,
@@ -571,8 +575,9 @@ func makeModifyGitSubcmds(versions Versions) []*cli.Command {
 			Flags: slices.Concat(
 				[]cli.Flag{
 					&cli.BoolFlag{
-						Name:  "no-cache-req",
-						Usage: "Don't download repositories and pallets required by this pallet after pulling",
+						Name:  "cache-req",
+						Usage: "Download repositories and pallets required by this pallet after pulling",
+						Value: true,
 					},
 					// TODO: add an option to fall back to a rebase if a fast-forward is not possible
 				},
@@ -592,8 +597,9 @@ var modifyBaseFlags []cli.Flag = []cli.Flag{
 			"is set)",
 	},
 	&cli.BoolFlag{
-		Name:  "no-cache-img",
-		Usage: "Don't download container images (this flag is only used if --stage is set)",
+		Name:  "cache-img",
+		Usage: "Download container images (this flag is only used if --stage is set)",
+		Value: true,
 	},
 	&cli.BoolFlag{
 		Name:  "apply",
@@ -659,9 +665,10 @@ func makeModifyPltSubcmds(versions Versions) []*cli.Command {
 			ArgsUsage: "[plt_path@version_query]...",
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
-					Name: "no-cache-req",
-					Usage: "Don't download repositories and pallets required by this pallet after adding " +
-						"the pallet",
+					Name: "cache-req",
+					Usage: "Download repositories and pallets required by this pallet after adding the " +
+						"pallet",
+					Value: true,
 				},
 			},
 			Action: addPltAction(versions),
@@ -706,9 +713,10 @@ func makeModifyRepoSubcmds(versions Versions) []*cli.Command {
 			ArgsUsage: "[repo_path@version_query]...",
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
-					Name: "no-cache-req",
-					Usage: "Don't download repositories and pallets required by this pallet after adding " +
-						"the repo",
+					Name: "cache-req",
+					Usage: "Download repositories and pallets required by this pallet after adding the " +
+						"repo",
+					Value: true,
 				},
 			},
 			Action: addRepoAction(versions),
@@ -862,8 +870,9 @@ var modifyDeplBaseFlags []cli.Flag = []cli.Flag{
 			"if --apply is set)",
 	},
 	&cli.BoolFlag{
-		Name:  "no-cache-img",
-		Usage: "Don't download container images (this flag is only used if --stage is set)",
+		Name:  "cache-img",
+		Usage: "Download container images (this flag is only used if --stage is set)",
+		Value: true,
 	},
 	&cli.BoolFlag{
 		Name:  "apply",

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -692,7 +692,7 @@ func cloneAction(versions Versions) cli.ActionFunc {
 		}
 
 		if err = preparePallet(
-			workspace, query, true, !c.Bool("no-cache-req"), c.String("platform"), c.Bool("parallel"),
+			workspace, query, true, c.Bool("cache-req"), c.String("platform"), c.Bool("parallel"),
 			c.Bool("ignore-tool-version"), versions,
 		); err != nil {
 			return err
@@ -765,7 +765,7 @@ func pullAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		if !c.Bool("no-cache-req") {
+		if c.Bool("cache-req") {
 			if _, _, err = fcli.CacheStagingReqs(
 				0, plt, caches.m, caches.p, caches.r, caches.d,
 				c.String("platform"), false, c.Bool("parallel"),
@@ -889,7 +889,7 @@ func stageAction(versions Versions) cli.ActionFunc {
 		}
 		if _, err = fcli.StagePallet(
 			0, plt, stageStore, caches.staging(), c.String("exports"),
-			versions.Staging, c.Bool("no-cache-img"), c.String("platform"), c.Bool("parallel"),
+			versions.Staging, !c.Bool("cache-img"), c.String("platform"), c.Bool("parallel"),
 			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err
@@ -1045,7 +1045,7 @@ func addPltAction(versions Versions) cli.ActionFunc {
 		); err != nil {
 			return err
 		}
-		if !c.Bool("no-cache-req") {
+		if c.Bool("cache-req") {
 			plt, caches, err := processFullBaseArgs(c.String("workspace"), processingOptions{})
 			if err != nil {
 				return err

--- a/cmd/forklift/plt/repositories.go
+++ b/cmd/forklift/plt/repositories.go
@@ -110,7 +110,7 @@ func addRepoAction(versions Versions) cli.ActionFunc {
 		if err = fcli.AddRepoReqs(0, plt, caches.m.Path(), c.Args().Slice()); err != nil {
 			return err
 		}
-		if !c.Bool("no-cache-req") {
+		if c.Bool("cache-req") {
 			if _, _, err = fcli.CacheStagingReqs(
 				0, plt, caches.m, caches.p, caches.r, caches.d,
 				c.String("platform"), false, c.Bool("parallel"),

--- a/cmd/forklift/stage/cli.go
+++ b/cmd/forklift/stage/cli.go
@@ -151,8 +151,9 @@ func makeModifySubcmds(versions Versions) []*cli.Command {
 			Action:    setNextAction(versions),
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
-					Name:  "no-cache-img",
-					Usage: "Don't download container images",
+					Name:  "cache-img",
+					Usage: "Download container images",
+					Value: true,
 				},
 			},
 		},

--- a/cmd/forklift/stage/store.go
+++ b/cmd/forklift/stage/store.go
@@ -302,7 +302,7 @@ func setNextAction(versions Versions) cli.ActionFunc {
 
 		if err = fcli.SetNextStagedBundle(
 			0, store, newNext, c.String("exports"), versions.Tool, versions.MinSupportedBundle,
-			c.Bool("no-cache-img"), c.String("platform"), c.Bool("parallel"),
+			!c.Bool("cache-img"), c.String("platform"), c.Bool("parallel"),
 			c.Bool("ignore-tool-version"),
 		); err != nil {
 			return err


### PR DESCRIPTION
This PR replaces the `--no-cache-img` and `--no-cache-req` CLI flags with `--cache-img=false` and `--cache-req=false`, to simplify CLI flag naming and avoid double-negatives.