### PR TITLE
Resolve goreleaser deprecations & warnings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     - go mod download
@@ -44,7 +46,8 @@ archives:
     name_template: "forklift_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
     - goos: windows
-      format: zip
+      formats:
+        - zip
 
 release:
   github:


### PR DESCRIPTION
This PR resolves a goreleaser warning about the lack of a top-level `version: 2` key-value pair, and about the deprecation of the `archives.format_overrides.format` key in favor of the `archives.format_overrides.formats` key.