### PR TITLE
Add `--set-upgrade-query` flag to `plt clone/switch/upgrade`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.8.0-beta.0 - 2025-03-19
 
 ### Added
 
@@ -19,13 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - (cli) In cases where trying to run `plt upgrade` without the `--force` flag (in order to upgrade from a commit which was only ancestral to the origin repo's references) incorrectly failed, now that operation should work.
 
-## 0.8.0-alpha.7 - 2024-03-05
+## 0.8.0-alpha.7 - 2025-03-05
 
 ### Fixed
 
 - (cli) Symlinks to nonexistent targets no longer fail to be merged in as part of file imports from pallets.
 
-## 0.8.0-alpha.6 - 2024-01-27
+## 0.8.0-alpha.6 - 2025-01-27
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unrelease
+## Unreleased
+
+### Added
+
+- (cli) Added a default-true `--set-upgrade-query` boolean flag to the `plt clone`, `plt switch`, and `plt upgrade` subcommands which can be set to false to prevent the `[pallet_path]@[version_query]` query from being saved into the file which tracks the last-used query.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ your hardware-specific embedded Linux operating systems.
 Note: this is still an experimental prototype in the sense that Forklift's architectural design and
 command-line interface may undergo significant backwards-incompatible simplifications. While
 Forklift is already used in production as a lower-level implementation detail of the
-[PlanktoScope OS](https://docs-edge.planktoscope.community/reference/software/architecture/os/)
+[PlanktoScope OS](https://docs.planktoscope.community/reference/software/architecture/os/)
 and is exposed to advanced users with a command-line interface for customization of PlanktoScope OS,
 any other use of Forklift is not yet officially documented or supported.
 
@@ -45,7 +45,7 @@ specified, composed, deployed, and reversibly upgraded/downgraded as version-con
 software modules. The [PlanktoScope](https://www.planktoscope.org/), an open-source microscope for
 quantitative imaging of plankton, uses Forklift as low-level infrastructure for software
 releases, deployment, and extensibility in the
-[PlanktoScope OS](https://docs-edge.planktoscope.community/reference/software/architecture/os/), a
+[PlanktoScope OS](https://docs.planktoscope.community/reference/software/architecture/os/), a
 hardware-specific operating system based on the Raspberry Pi OS; and Forklift was designed
 specifically to solve the OS/software maintenance, customization, and operations challenges
 experienced in the PlanktoScope project.

--- a/cmd/forklift/plt/cli.go
+++ b/cmd/forklift/plt/cli.go
@@ -33,6 +33,12 @@ func MakeCmd(versions Versions) *cli.Command {
 					Action:    switchAction(versions),
 					Flags: []cli.Flag{
 						&cli.BoolFlag{
+							Name: "set-upgrade-query",
+							Usage: "Remember the pallet path and version query used in this operation for " +
+								"future clone/switch/upgrade operations",
+							Value: true,
+						},
+						&cli.BoolFlag{
 							Name: "force",
 							Usage: "Even if the local pallet already exists and has uncommitted/unpushed " +
 								"changes, replace it",
@@ -67,26 +73,7 @@ func makeUpgradeSubcmds(versions Versions) []*cli.Command {
 				"stages the pallet",
 			ArgsUsage: "[[pallet_path]@[version_query]]",
 			Action:    upgradeAction(versions),
-			Flags: []cli.Flag{
-				&cli.BoolFlag{
-					Name:  "allow-downgrade",
-					Usage: "Allow upgrading to an older version (i.e. performing a downgrade)",
-				},
-				&cli.BoolFlag{
-					Name: "force",
-					Usage: "Even if the local pallet has uncommitted/unpushed changes, replace it with the " +
-						"upgraded version",
-				},
-				&cli.BoolFlag{
-					Name:  "cache-img",
-					Usage: "Download container images (this flag is ignored if --apply is set)",
-					Value: true,
-				},
-				&cli.BoolFlag{
-					Name:  "apply",
-					Usage: "Immediately apply the upgraded pallet after staging it",
-				},
-			},
+			Flags:     upgradeFlags,
 		},
 		{
 			Name:     "check-upgrade",
@@ -118,6 +105,33 @@ func makeUpgradeSubcmds(versions Versions) []*cli.Command {
 			Action:    setUpgradeQueryAction,
 		},
 	}
+}
+
+var upgradeFlags = []cli.Flag{
+	&cli.BoolFlag{
+		Name:  "allow-downgrade",
+		Usage: "Allow upgrading to an older version (i.e. performing a downgrade)",
+	},
+	&cli.BoolFlag{
+		Name: "set-upgrade-query",
+		Usage: "Remember the pallet path and version query used in this operation for future " +
+			"clone/switch/upgrade operations",
+		Value: true,
+	},
+	&cli.BoolFlag{
+		Name: "force",
+		Usage: "Even if the local pallet has uncommitted/unpushed changes, replace it with the " +
+			"upgraded version",
+	},
+	&cli.BoolFlag{
+		Name:  "cache-img",
+		Usage: "Download container images (this flag is ignored if --apply is set)",
+		Value: true,
+	},
+	&cli.BoolFlag{
+		Name:  "apply",
+		Usage: "Immediately apply the upgraded pallet after staging it",
+	},
 }
 
 func makeUseSubcmds(versions Versions) []*cli.Command {
@@ -545,6 +559,12 @@ func makeModifyGitSubcmds(versions Versions) []*cli.Command {
 			ArgsUsage: "[[pallet_path]@[version_query]]",
 			Flags: slices.Concat(
 				[]cli.Flag{
+					&cli.BoolFlag{
+						Name: "set-upgrade-query",
+						Usage: "Remember the pallet path and version query used in this operation for " +
+							"future clone/switch/upgrade operations",
+						Value: true,
+					},
 					&cli.BoolFlag{
 						Name: "force",
 						Usage: "If a local pallet already exists, delete it to replace it with the specified" +

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -117,7 +117,7 @@ func switchAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		query, err := handlePalletQuery(workspace, c.Args().First())
+		query, err := handlePalletQuery(workspace, c.Args().First(), c.Bool("set-upgrade-query"))
 		if err != nil {
 			return errors.Wrapf(err, "couldn't handle provided version query %s", c.Args().First())
 		}
@@ -168,7 +168,7 @@ func ensureWorkspace(wpath string) (*forklift.FSWorkspace, error) {
 }
 
 func handlePalletQuery(
-	workspace *forklift.FSWorkspace, providedQuery string,
+	workspace *forklift.FSWorkspace, providedQuery string, commitPalletQuery bool,
 ) (forklift.GitRepoQuery, error) {
 	query, loaded, provided, err := completePalletQuery(workspace, providedQuery)
 	if err != nil {
@@ -181,7 +181,8 @@ func handlePalletQuery(
 	if !provided.Complete() {
 		fmt.Fprintf(
 			os.Stderr,
-			"Provided query %s was completed with stored query %s as %s!\n", provided, loaded, query,
+			"Provided query %s was completed (based on stored query %s) as %s!\n",
+			provided, loaded, query,
 		)
 		printed = true
 	}
@@ -189,6 +190,14 @@ func handlePalletQuery(
 		if printed {
 			fmt.Fprintln(os.Stderr)
 		}
+		return query, nil
+	}
+
+	if !commitPalletQuery {
+		fmt.Fprintf(
+			os.Stderr,
+			"Using (but not saving) the path & version query: %s\n", query,
+		)
 		return query, nil
 	}
 
@@ -427,7 +436,7 @@ func upgradeAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		query, err := handlePalletQuery(workspace, c.Args().First())
+		query, err := handlePalletQuery(workspace, c.Args().First(), c.Bool("set-upgrade-query"))
 		if err != nil {
 			return errors.Wrapf(err, "couldn't handle provided version query %s", c.Args().First())
 		}
@@ -656,7 +665,7 @@ func setUpgradeQueryAction(c *cli.Context) error {
 		return err
 	}
 
-	_, err = handlePalletQuery(workspace, c.Args().First())
+	_, err = handlePalletQuery(workspace, c.Args().First(), true)
 	if err != nil {
 		return errors.Wrapf(err, "couldn't handle provided version query %s", c.Args().First())
 	}
@@ -673,7 +682,7 @@ func cloneAction(versions Versions) cli.ActionFunc {
 			return err
 		}
 
-		query, err := handlePalletQuery(workspace, c.Args().First())
+		query, err := handlePalletQuery(workspace, c.Args().First(), c.Bool("set-upgrade-query"))
 		if err != nil {
 			return errors.Wrapf(err, "couldn't handle provided version query %s", c.Args().First())
 		}

--- a/internal/app/forklift/workspace.go
+++ b/internal/app/forklift/workspace.go
@@ -224,7 +224,7 @@ func (w *FSWorkspace) GetCurrentPalletUpgrades() (GitRepoQuery, error) {
 	return loadGitRepoQuery(fsys, configCurrentPalletUpgradesFile)
 }
 
-// CommitCurrentPalletUpgrades atomoically updates the current pallet upgrades file.
+// CommitCurrentPalletUpgrades atomically updates the current pallet upgrades file.
 // Warning: on non-Unix platforms, the update is not entirely atomic!
 func (w *FSWorkspace) CommitCurrentPalletUpgrades(query GitRepoQuery) error {
 	// TODO: we might want to be less sloppy about read locks vs. write locks in the future. After


### PR DESCRIPTION
This PR makes it possible to run `plt clone`/`plt switch`/`plt upgrade` without changing the tracked pallet path & version query used for completing partial query strings.