### PR TITLE
fix(cli): better warning for failed background-update of local mirror

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -94,7 +94,7 @@ changelog:
 release:
   prerelease: auto
   footer: |
-    **Full human-written changelog**: [`CHANGELOG.md`]({{ .GitURL }}/blob/main/CHANGELOG.md)
+    **Full hand-crafted changelog**: [`CHANGELOG.md`]({{ .GitURL }}/blob/main/CHANGELOG.md)
 
     {{ if and .Tag .PreviousTag }}
       **Commit History**: [{{ .Tag }}...{{ .PreviousTag }}]({{ .GitURL }}/compare/{{ .Tag }}...{{ .PreviousTag }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.8.0-beta.1 - 2025-03-19
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - (cli) Improved warning messages printed when an optional background update of a local mirror of a Git repo fails (e.g. due to lack of internet access) to better reassure the user that it might not be a problem.
+- (cli) If `plt switch` is run without internet access, now instead of quitting immediately with an error (due to being unable to fetch changes from remotes) the subcommand will print a warning and continue until either the operation fails (because it couldn't determine that the current commit of the current pallet is in the cache's local mirror of the remote origin) or succeeds (because the commit is in the local mirror, or because `--force` was set).
 
 ## 0.8.0-beta.0 - 2025-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- (cli) Improved warning messages printed when an optional background update of a local mirror of a Git repo fails (e.g. due to lack of internet access) to better reassure the user that it might not be a problem.
+
 ## 0.8.0-beta.0 - 2025-03-19
 
 ### Added

--- a/cmd/forklift/plt/pallets.go
+++ b/cmd/forklift/plt/pallets.go
@@ -296,7 +296,12 @@ func checkPalletDirtiness(workspace *forklift.FSWorkspace, force bool) error {
 
 	fmt.Fprintln(os.Stderr, "Fetching changes from the remote...")
 	if err = gitRepo.FetchAll(1, os.Stdout); err != nil {
-		return errors.Wrap(err, "couldn't fetch changes from the remote Git repo")
+		fcli.IndentedFprintf(
+			1, os.Stderr,
+			"Warning: couldn't fetch changes (maybe you don't have internet, or maybe the repo doesn't "+
+				"exist?): %s\n", err,
+		)
+		fcli.IndentedFprintln(1, os.Stderr, "We may be able to continue anyways, so we'll keep going!")
 	}
 
 	fmt.Fprintf(

--- a/internal/app/forklift/cli/git-repositories.go
+++ b/internal/app/forklift/cli/git-repositories.go
@@ -246,17 +246,17 @@ func performOptionalLocalMirrorsUpdate(indent int, queries []string, mirrorsPath
 		indent, os.Stderr,
 		"Updating local mirrors of remote Git repos (even though it's not required)...",
 	)
+	indent++
 	if err := updateQueriedLocalGitRepoMirrors(indent+1, queries, mirrorsPath); err != nil {
-		IndentedFprintf(
-			indent+1, os.Stderr,
-			"Warning: couldn't update local mirrors (do you have internet access? does the "+
-				"remote repo actually exist?): %s\n", err,
+		IndentedFprintln(
+			indent, os.Stderr,
+			"Warning: couldn't update local mirrors (do you have internet access? does the remote repo "+
+				"actually exist?):",
 		)
-		IndentedFprintf(
-			indent+1, os.Stderr,
-			"We might not even need updates, so we'll continue anyways! It's safe for you to ignore the "+
-				"above warning message, unless you were expecting the result of the version query to have "+
-				"changed after an update.",
+		IndentedFprintln(indent+1, os.Stderr, err)
+		IndentedFprintln(
+			indent, os.Stderr,
+			"We might not even need updates of our local mirrors, so we'll continue anyways!",
 		)
 	}
 }
@@ -341,16 +341,7 @@ func DownloadLockedGitRepoUsingLocalMirror(
 	if !downloaded {
 		IndentedFprintf(indent, os.Stderr, "%s@%s was already downloaded!\n", gitRepoPath, lock.Version)
 	}
-	IndentedFprintln(
-		indent, os.Stderr, "Optionally updating local mirror from remote Git origin...",
-	)
-	indent++
-	if err = updateLocalGitRepoMirror(indent, gitRepoPath, mirrorPath); err != nil {
-		IndentedFprintf(
-			indent, os.Stderr,
-			"Couldn't update local mirror (do you have internet access?): %s\n", err.Error(),
-		)
-	}
+	performOptionalLocalMirrorsUpdate(indent, []string{gitRepoPath + "@" + lock.Version}, mirrorsPath)
 	return downloaded, nil
 }
 

--- a/internal/app/forklift/cli/git-repositories.go
+++ b/internal/app/forklift/cli/git-repositories.go
@@ -17,178 +17,7 @@ import (
 	"github.com/PlanktoScope/forklift/internal/clients/git"
 )
 
-// Downloading to cache
-
-func DownloadQueriedGitReposUsingLocalMirrors(
-	indent int, mirrorsPath, cachePath string, queries []string,
-) (resolved map[string]forklift.GitRepoReq, changed map[forklift.GitRepoReq]bool, err error) {
-	if err = validateGitRepoQueries(queries); err != nil {
-		return nil, nil, errors.Wrap(err, "one or more arguments is invalid")
-	}
-	if resolved, err = ResolveQueriesUsingLocalMirrors(
-		indent, mirrorsPath, queries, true,
-	); err != nil {
-		return nil, nil, err
-	}
-
-	changed = make(map[forklift.GitRepoReq]bool)
-	for _, req := range resolved {
-		downloaded, err := cloneLockedGitRepoFromLocalMirror(
-			indent, cachePath, mirrorsPath, req.Path(), req.VersionLock,
-		)
-		if err != nil {
-			return resolved, nil, errors.Wrapf(
-				err, "couldn't download %s@%s as commit %s",
-				req.Path(), req.VersionLock.Version, req.VersionLock.Def.ShortCommit(),
-			)
-		}
-		if !downloaded {
-			IndentedFprintf(
-				indent, os.Stderr,
-				"Didn't download %s@%s because it already exists\n", req.Path(), req.VersionLock.Version,
-			)
-		}
-		changed[req] = true
-	}
-	return resolved, changed, nil
-}
-
-func validateGitRepoQueries(queries []string) error {
-	if len(queries) == 0 {
-		return errors.Errorf("at least one query must be specified")
-	}
-	for _, query := range queries {
-		if _, _, ok := strings.Cut(query, "@"); !ok {
-			return errors.Errorf("couldn't parse query '%s' as path@version", query)
-		}
-	}
-	return nil
-}
-
-func ResolveQueriesUsingLocalMirrors(
-	indent int, mirrorsPath string, queries []string, updateLocalMirror bool,
-) (resolved map[string]forklift.GitRepoReq, err error) {
-	IndentedFprintln(
-		indent, os.Stderr, "Resolving version queries using local mirrors of remote Git repos...",
-	)
-	indent++
-	resolved, err = resolveGitRepoQueriesUsingLocalMirrors(indent, queries, mirrorsPath)
-	if err != nil {
-		if !updateLocalMirror {
-			return resolved, errors.Wrap(
-				err, "couldn't resolve one or more version queries, and we're not updating local mirrors",
-			)
-		}
-		IndentedFprintln(
-			indent, os.Stderr,
-			"Couldn't resolve one or more version queries, so we'll update local mirrors of remote Git "+
-				"repos and try again",
-		)
-
-		IndentedFprintln(indent, os.Stderr, "Updating local mirrors of remote Git repos...")
-		if err = updateQueriedLocalGitRepoMirrors(indent+1, queries, mirrorsPath); err != nil {
-			return nil, errors.Wrap(err, "couldn't update local Git repo mirrors")
-		}
-		IndentedFprintln(indent, os.Stderr, "Resolving version queries from updated local mirrors...")
-		if resolved, err = resolveGitRepoQueriesUsingLocalMirrors(
-			indent+1, queries, mirrorsPath,
-		); err != nil {
-			return nil, errors.Wrap(err, "couldn't resolve version queries for repos")
-		}
-		return resolved, err
-	}
-
-	if !updateLocalMirror {
-		return resolved, nil
-	}
-
-	IndentedFprintln(
-		indent, os.Stderr,
-		"Updating local mirrors of remote Git repos (even though it's not required)...",
-	)
-	if err = updateQueriedLocalGitRepoMirrors(indent+1, queries, mirrorsPath); err != nil {
-		IndentedFprintf(
-			indent+1, os.Stderr,
-			"Couldn't update local mirrors (do you have internet access? does the "+
-				"remote repo actually exist?): %s\n", err,
-		)
-		return resolved, nil
-	}
-	IndentedFprintln(indent, os.Stderr, "Resolving version queries from updated local mirrors...")
-	newResolved, err := resolveGitRepoQueriesUsingLocalMirrors(
-		indent, queries, mirrorsPath,
-	)
-	if err != nil {
-		IndentedFprintln(
-			indent, os.Stderr,
-			"Couldn't resolve version query with updated local mirror, falling back to previous value",
-		)
-	}
-	return newResolved, nil
-}
-
-func updateQueriedLocalGitRepoMirrors(indent int, queries []string, mirrorsPath string) error {
-	allUpdated := make(map[string]struct{})
-	for _, query := range queries {
-		p, _, ok := strings.Cut(query, "@")
-		if !ok {
-			return errors.Errorf("couldn't parse query '%s' as path@version", query)
-		}
-		if _, updated := allUpdated[p]; updated {
-			continue
-		}
-
-		if err := updateLocalGitRepoMirror(indent, p, path.Join(mirrorsPath, p)); err != nil {
-			return errors.Wrapf(err, "couldn't update local mirror of %s", p)
-		}
-		allUpdated[p] = struct{}{}
-	}
-	return nil
-}
-
-func updateLocalGitRepoMirror(indent int, remote, mirrorPath string) error {
-	remote = filepath.FromSlash(remote)
-	mirrorPath = filepath.FromSlash(mirrorPath)
-	if _, err := os.Stat(mirrorPath); errors.Is(err, fs.ErrNotExist) {
-		IndentedFprintf(indent, os.Stderr, "Cloning %s to local mirror...\n", remote)
-		_, err := git.CloneMirrored(indent+1, remote, mirrorPath, os.Stderr)
-		return err
-	}
-	gitRepo, err := git.Open(mirrorPath)
-	if err != nil {
-		return errors.Errorf("couldn't open local mirror of %s at %s", remote, mirrorPath)
-	}
-	return gitRepo.FetchAll(indent+1, os.Stdout)
-}
-
-func resolveGitRepoQueriesUsingLocalMirrors(
-	indent int, queries []string, mirrorsPath string,
-) (resolved map[string]forklift.GitRepoReq, err error) {
-	resolved = make(map[string]forklift.GitRepoReq)
-	for _, query := range queries {
-		if _, ok := resolved[query]; ok {
-			continue
-		}
-		gitRepoPath, versionQuery, ok := strings.Cut(query, "@")
-		if !ok {
-			return nil, errors.Errorf("couldn't parse '%s' as git_repo_path@version", query)
-		}
-		req := forklift.GitRepoReq{
-			RequiredPath: gitRepoPath,
-		}
-		if req.VersionLock, err = ResolveVersionQueryUsingRepo(
-			filepath.FromSlash(path.Join(mirrorsPath, gitRepoPath)), versionQuery,
-		); err != nil {
-			return nil, errors.Wrapf(
-				err, "couldn't resolve version query %s for git repo %s", versionQuery, gitRepoPath,
-			)
-		}
-
-		IndentedFprintf(indent, os.Stderr, "Resolved %s as %+v\n", query, req.VersionLock.Version)
-		resolved[query] = req
-	}
-	return resolved, nil
-}
+// Resolving version query
 
 func ResolveVersionQueryUsingRepo(
 	localPath, versionQuery string,
@@ -295,6 +124,189 @@ func filterTags[T nameGetter](tags []T) []T {
 		filtered = append(filtered, tag)
 	}
 	return filtered
+}
+
+// Resolving multiple version queries
+
+func ResolveQueriesUsingLocalMirrors(
+	indent int, mirrorsPath string, queries []string, updateLocalMirror bool,
+) (resolved map[string]forklift.GitRepoReq, err error) {
+	IndentedFprintln(
+		indent, os.Stderr, "Resolving version queries using local mirrors of remote Git repos...",
+	)
+	indent++
+	resolved, err = resolveGitRepoQueriesUsingLocalMirrors(indent, queries, mirrorsPath)
+	if err != nil {
+		if !updateLocalMirror {
+			return resolved, errors.Wrap(
+				err, "couldn't resolve one or more version queries, and we're not updating local mirrors",
+			)
+		}
+		IndentedFprintln(
+			indent, os.Stderr,
+			"Warning: couldn't resolve one or more version queries, so we'll update local mirrors of "+
+				"remote Git repos and try again",
+		)
+
+		IndentedFprintln(indent, os.Stderr, "Updating local mirrors of remote Git repos...")
+		if err = updateQueriedLocalGitRepoMirrors(indent+1, queries, mirrorsPath); err != nil {
+			return nil, errors.Wrap(err, "couldn't update local Git repo mirrors")
+		}
+		IndentedFprintln(indent, os.Stderr, "Resolving version queries from updated local mirrors...")
+		if resolved, err = resolveGitRepoQueriesUsingLocalMirrors(
+			indent+1, queries, mirrorsPath,
+		); err != nil {
+			return nil, errors.Wrap(err, "couldn't resolve version queries for repos")
+		}
+		return resolved, err
+	}
+
+	if !updateLocalMirror {
+		return resolved, nil
+	}
+
+	performOptionalLocalMirrorsUpdate(indent, queries, mirrorsPath)
+	IndentedFprintln(indent, os.Stderr, "Resolving version queries from updated local mirrors...")
+	newResolved, err := resolveGitRepoQueriesUsingLocalMirrors(indent, queries, mirrorsPath)
+	if err != nil {
+		IndentedFprintln(
+			indent, os.Stderr,
+			"Warning: couldn't resolve version query with updated local mirror, falling back to "+
+				"previous value",
+		)
+	}
+	return newResolved, nil
+}
+
+func updateQueriedLocalGitRepoMirrors(indent int, queries []string, mirrorsPath string) error {
+	allUpdated := make(map[string]struct{})
+	for _, query := range queries {
+		p, _, ok := strings.Cut(query, "@")
+		if !ok {
+			return errors.Errorf("couldn't parse query '%s' as path@version", query)
+		}
+		if _, updated := allUpdated[p]; updated {
+			continue
+		}
+
+		if err := updateLocalGitRepoMirror(indent, p, path.Join(mirrorsPath, p)); err != nil {
+			return errors.Wrapf(err, "couldn't update local mirror of %s", p)
+		}
+		allUpdated[p] = struct{}{}
+	}
+	return nil
+}
+
+func updateLocalGitRepoMirror(indent int, remote, mirrorPath string) error {
+	remote = filepath.FromSlash(remote)
+	mirrorPath = filepath.FromSlash(mirrorPath)
+	if _, err := os.Stat(mirrorPath); errors.Is(err, fs.ErrNotExist) {
+		IndentedFprintf(indent, os.Stderr, "Cloning %s to local mirror...\n", remote)
+		_, err := git.CloneMirrored(indent+1, remote, mirrorPath, os.Stderr)
+		return err
+	}
+	gitRepo, err := git.Open(mirrorPath)
+	if err != nil {
+		return errors.Errorf("couldn't open local mirror of %s at %s", remote, mirrorPath)
+	}
+	return gitRepo.FetchAll(indent+1, os.Stdout)
+}
+
+func resolveGitRepoQueriesUsingLocalMirrors(
+	indent int, queries []string, mirrorsPath string,
+) (resolved map[string]forklift.GitRepoReq, err error) {
+	resolved = make(map[string]forklift.GitRepoReq)
+	for _, query := range queries {
+		if _, ok := resolved[query]; ok {
+			continue
+		}
+		gitRepoPath, versionQuery, ok := strings.Cut(query, "@")
+		if !ok {
+			return nil, errors.Errorf("couldn't parse '%s' as git_repo_path@version", query)
+		}
+		req := forklift.GitRepoReq{
+			RequiredPath: gitRepoPath,
+		}
+		if req.VersionLock, err = ResolveVersionQueryUsingRepo(
+			filepath.FromSlash(path.Join(mirrorsPath, gitRepoPath)), versionQuery,
+		); err != nil {
+			return nil, errors.Wrapf(
+				err, "couldn't resolve version query %s for git repo %s", versionQuery, gitRepoPath,
+			)
+		}
+
+		IndentedFprintf(indent, os.Stderr, "Resolved %s as %+v\n", query, req.VersionLock.Version)
+		resolved[query] = req
+	}
+	return resolved, nil
+}
+
+func performOptionalLocalMirrorsUpdate(indent int, queries []string, mirrorsPath string) {
+	IndentedFprintln(
+		indent, os.Stderr,
+		"Updating local mirrors of remote Git repos (even though it's not required)...",
+	)
+	if err := updateQueriedLocalGitRepoMirrors(indent+1, queries, mirrorsPath); err != nil {
+		IndentedFprintf(
+			indent+1, os.Stderr,
+			"Warning: couldn't update local mirrors (do you have internet access? does the "+
+				"remote repo actually exist?): %s\n", err,
+		)
+		IndentedFprintf(
+			indent+1, os.Stderr,
+			"We might not even need updates, so we'll continue anyways! It's safe for you to ignore the "+
+				"above warning message, unless you were expecting the result of the version query to have "+
+				"changed after an update.",
+		)
+	}
+}
+
+// Downloading to cache
+
+func DownloadQueriedGitReposUsingLocalMirrors(
+	indent int, mirrorsPath, cachePath string, queries []string,
+) (resolved map[string]forklift.GitRepoReq, changed map[forklift.GitRepoReq]bool, err error) {
+	if err = validateGitRepoQueries(queries); err != nil {
+		return nil, nil, errors.Wrap(err, "one or more arguments is invalid")
+	}
+	if resolved, err = ResolveQueriesUsingLocalMirrors(
+		indent, mirrorsPath, queries, true,
+	); err != nil {
+		return nil, nil, err
+	}
+
+	changed = make(map[forklift.GitRepoReq]bool)
+	for _, req := range resolved {
+		downloaded, err := cloneLockedGitRepoFromLocalMirror(
+			indent, cachePath, mirrorsPath, req.Path(), req.VersionLock,
+		)
+		if err != nil {
+			return resolved, nil, errors.Wrapf(
+				err, "couldn't download %s@%s as commit %s",
+				req.Path(), req.VersionLock.Version, req.VersionLock.Def.ShortCommit(),
+			)
+		}
+		if !downloaded {
+			IndentedFprintf(
+				indent, os.Stderr,
+				"Didn't download %s@%s because it already exists\n", req.Path(), req.VersionLock.Version,
+			)
+		}
+		changed[req] = true
+	}
+	return resolved, changed, nil
+}
+
+func validateGitRepoQueries(queries []string) error {
+	if len(queries) == 0 {
+		return errors.Errorf("at least one query must be specified")
+	}
+	for _, query := range queries {
+		if _, _, ok := strings.Cut(query, "@"); !ok {
+			return errors.Errorf("couldn't parse query '%s' as path@version", query)
+		}
+	}
+	return nil
 }
 
 func DownloadLockedGitRepoUsingLocalMirror(


### PR DESCRIPTION
This PR improves the warning message printed when `forklift` attempts to update a local Git repo mirror in the absence of internet access, to reassure the user that this may not be a problem.